### PR TITLE
Rough draft: Accept a GitHub Gist token

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -17,6 +17,7 @@ const defaultVersion = normalizeVersion(knownVersions[0].tag_name);
 
 export class AppState {
   @observable public version: string = defaultVersion;
+  @observable public accessToken: string | null = null;
   @observable public binaryManager: BinaryManager = new BinaryManager(defaultVersion);
   @observable public versions: StringMap<ElectronVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -17,14 +17,16 @@ const defaultVersion = normalizeVersion(knownVersions[0].tag_name);
 
 export class AppState {
   @observable public version: string = defaultVersion;
-  @observable public accessToken: string | null = null;
+  @observable public githubToken: string | null = null;
   @observable public binaryManager: BinaryManager = new BinaryManager(defaultVersion);
   @observable public versions: StringMap<ElectronVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
   @observable public isConsoleShowing: boolean = false;
+  @observable public isTokenDialogShowing: boolean = false;
 }
 
 const appState = new AppState();
+appState.githubToken = localStorage.getItem('githubToken');
 
 class App {
   public editors: any = {

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as Icon from '@fortawesome/react-fontawesome';
-import { faTerminal } from '@fortawesome/fontawesome-free-solid';
+import { faTerminal, faUser } from '@fortawesome/fontawesome-free-solid';
 
 import { Runner } from './runner';
 import { VersionChooser } from './version-chooser';
@@ -17,13 +17,24 @@ export class Commands extends React.Component<CommandsProps, {}> {
     super(props);
 
     this.toggleConsole = this.toggleConsole.bind(this);
+    this.showTokenDialog = this.showTokenDialog.bind(this);
   }
 
   public toggleConsole() {
     this.props.appState.isConsoleShowing = !this.props.appState.isConsoleShowing;
   }
 
+  public showTokenDialog() {
+    this.props.appState.accessToken = 'fake-access-token';
+  }
+
   public render() {
+    const authButton = !this.props.appState.accessToken ? (
+      <button className='button' onClick={this.showTokenDialog}>
+        <Icon icon={faUser} />
+      </button>
+    ) : null;
+
     return (
       <div className='commands'>
         <div>
@@ -34,6 +45,7 @@ export class Commands extends React.Component<CommandsProps, {}> {
           <button className='button' onClick={this.toggleConsole}>
             <Icon icon={faTerminal} />
           </button>
+          {authButton}
         </div>
       </div>
     );

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -17,20 +17,20 @@ export class Commands extends React.Component<CommandsProps, {}> {
     super(props);
 
     this.toggleConsole = this.toggleConsole.bind(this);
-    this.showTokenDialog = this.showTokenDialog.bind(this);
+    this.showAuthDialog = this.showAuthDialog.bind(this);
   }
 
   public toggleConsole() {
     this.props.appState.isConsoleShowing = !this.props.appState.isConsoleShowing;
   }
 
-  public showTokenDialog() {
-    this.props.appState.accessToken = 'fake-access-token';
+  public showAuthDialog() {
+    this.props.appState.isTokenDialogShowing = true;
   }
 
   public render() {
-    const authButton = !this.props.appState.accessToken ? (
-      <button className='button' onClick={this.showTokenDialog}>
+    const authButton = !this.props.appState.githubToken ? (
+      <button className='button' onClick={this.showAuthDialog}>
         <Icon icon={faUser} />
       </button>
     ) : null;

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -5,6 +5,7 @@ import { EditorTitle } from './editor-title';
 import { Commands } from './commands';
 import { AppState } from '../app';
 import { Output } from './output';
+import { TokenDialog } from './token-dialog';
 
 export interface HeaderProps {
   appState: AppState;
@@ -12,10 +13,18 @@ export interface HeaderProps {
 @observer
 export class Header extends React.Component<HeaderProps, {}> {
   public render() {
-    return [
+    const { isTokenDialogShowing } = this.props.appState;
+
+    const elements = [
       <Commands key='commands' appState={this.props.appState} />,
       <Output key='output' appState={this.props.appState} />,
       <EditorTitle key='titles' />
     ];
+
+    if (isTokenDialogShowing) elements.push(
+      <TokenDialog key='tokenDialog' appState={this.props.appState} />
+    );
+
+    return elements;
   }
 }

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -21,7 +21,7 @@ export class Output extends React.Component<CommandsProps, {}> {
 
 
     return lines.map((text) => (
-      <p>{timestamp}{text}</p>
+      <p key={ts}>{timestamp}{text}</p>
     ));
   }
 

--- a/src/renderer/components/token-dialog.tsx
+++ b/src/renderer/components/token-dialog.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+
+import { AppState } from '../app';
+
+export interface TokenDialogProps {
+  appState: AppState;
+}
+
+const TOKEN_SCOPES = [ 'gist' ].join();
+const TOKEN_DESCRIPTION = encodeURIComponent('Fiddle Gist Token');
+const GENERATE_TOKEN_URL = `https://github.com/settings/tokens/new?scopes=${TOKEN_SCOPES}&description=${TOKEN_DESCRIPTION}`;
+
+@observer
+export class TokenDialog extends React.Component<TokenDialogProps, {}> {
+  public render() {
+    return (
+      <div className='tokenDialog'>
+        <span>Please generate an access token from <a href={GENERATE_TOKEN_URL}>GitHub</a> and paste it here:</span>
+        <input className='tokenInput' />
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/token-dialog.tsx
+++ b/src/renderer/components/token-dialog.tsx
@@ -1,5 +1,8 @@
+import { clipboard, shell } from 'electron';
 import * as React from 'react';
 import { observer } from 'mobx-react';
+import * as Icon from '@fortawesome/react-fontawesome';
+import { faKey } from '@fortawesome/fontawesome-free-solid';
 
 import { AppState } from '../app';
 
@@ -7,17 +10,68 @@ export interface TokenDialogProps {
   appState: AppState;
 }
 
+export interface TokenDialogState {
+  tokenInput?: string;
+}
+
 const TOKEN_SCOPES = [ 'gist' ].join();
 const TOKEN_DESCRIPTION = encodeURIComponent('Fiddle Gist Token');
 const GENERATE_TOKEN_URL = `https://github.com/settings/tokens/new?scopes=${TOKEN_SCOPES}&description=${TOKEN_DESCRIPTION}`;
 
 @observer
-export class TokenDialog extends React.Component<TokenDialogProps, {}> {
+export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogState> {
+  private tokenInputRef: React.RefObject<HTMLInputElement>;
+
+  constructor(props: TokenDialogProps) {
+    super(props);
+
+    this.state = {};
+    this.tokenInputRef = React.createRef();
+    this.onSubmitToken = this.onSubmitToken.bind(this);
+    this.openGenerateTokenExternal = this.openGenerateTokenExternal.bind(this);
+    this.onTokenInputFocused = this.onTokenInputFocused.bind(this);
+  }
+
+  public onSubmitToken() {
+    // TODO: Do more validation of the token
+    if (!this.state.tokenInput) return;
+
+    localStorage.setItem('githubToken', this.state.tokenInput);
+    this.props.appState.githubToken = this.state.tokenInput;
+    this.props.appState.isTokenDialogShowing = false;
+  }
+
+  public openGenerateTokenExternal() {
+    shell.openExternal(GENERATE_TOKEN_URL);
+  }
+
+  public onTokenInputFocused() {
+    this.setState({
+      tokenInput: clipboard.readText()
+    });
+  }
+
   public render() {
+    const canSubmit = !!this.state.tokenInput;
     return (
       <div className='tokenDialog'>
-        <span>Please generate an access token from <a href={GENERATE_TOKEN_URL}>GitHub</a> and paste it here:</span>
-        <input className='tokenInput' />
+        <span className='generateTokenText'>
+          <Icon icon={faKey} />
+          Generate an access token from <a onClick={this.openGenerateTokenExternal}> GitHub </a> and paste it here:
+        </span>
+        <input
+          readOnly={true}
+          ref={this.tokenInputRef}
+          value={this.state.tokenInput || ''}
+          onFocus={this.onTokenInputFocused}
+        />
+        <button
+          className='button'
+          disabled={!canSubmit}
+          onClick={this.onSubmitToken}
+        >
+          Done
+        </button>
       </div>
     );
   }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -139,3 +139,38 @@ header {
   margin-left: 5px;
   line-height: 15px;
 }
+
+.tokenDialog {
+  position: absolute;
+  top: 100px;
+  width: 300px;
+  height: 170px;
+  left: calc(50% - (300px / 2));
+  padding: 10px 20px;
+  z-index: 1000;
+  background-color: var(--electron-background-2);
+  border: 1px solid var(--electron-dark);
+  color: #f3f3f3;
+}
+
+.generateTokenText svg {
+  margin-right: 4px;
+}
+
+.tokenDialog button {
+  color: #1e2527;
+}
+
+.tokenDialog a {
+  cursor: pointer;
+}
+
+.tokenDialog input {
+  width: 250px;
+  color: rgba(159, 234, 249, 0.5);
+  height: 28px;
+  margin-top: 10px;
+  background-color: var(--electron-background);
+  border: 1px solid var(--electron-dark);
+  outline: 0 solid transparent;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -123,6 +123,10 @@ header {
   margin-left: 80px;
 }
 
+.commands > div:last-of-type > button {
+  margin-left: 5px;
+}
+
 .commands > div:last-of-type {
   margin-right: 10px;
 }


### PR DESCRIPTION
This PR adds an auth button to the right of the terminal, which opens a very ugly dialog with a link to `https://github.com/settings/tokens/new?scopes=gist&description=Fiddle%20Gist%20Token` and an input field. The input field can't be typed into, but when it receives focus we'll automatically paste the token using the `clipboard` module.

![image](https://user-images.githubusercontent.com/1865957/41102736-d6bb109c-6a67-11e8-8ad2-2c834afbacf3.png)

## TODO
- [ ] Make the dialog prettier
- [ ] Transitions on the dialog
- [ ] Token validation
