### PR TITLE
Improve login/publish flow

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import * as MonacoType from 'monaco-editor';
 
 import { mainTheme } from './themes';
 import { Header } from './components/header';
+import { Dialogs } from './components/dialogs';
 import { EditorValues } from '../interfaces';
 import { editors } from './components/editors';
 import { updateEditorLayout } from '../utils/editor-layout';
@@ -82,6 +83,7 @@ class App {
     const app = (
       <div>
         <Header appState={appState} />
+        <Dialogs appState={appState} />
         {editors({ monaco: this.monaco!, appState })}å
       </div>
     );

--- a/src/renderer/components/address-bar.tsx
+++ b/src/renderer/components/address-bar.tsx
@@ -51,7 +51,7 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
    * @param {React.ChangeEvent<HTMLInputElement>} event
    * @memberof AddressBar
    */
-  public async handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  public handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({ value: idFromUrl(event.target.value) || event.target.value });
   }
 

--- a/src/renderer/components/address-bar.tsx
+++ b/src/renderer/components/address-bar.tsx
@@ -6,6 +6,7 @@ import * as classNames from 'classnames';
 import { AppState } from '../state';
 import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME } from '../constants';
 import { idFromUrl } from '../../utils/gist';
+import { reaction } from 'mobx';
 
 export interface AddressBarProps {
   appState: AppState;
@@ -43,6 +44,16 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
     if (this.state.value) {
       this.loadFiddle();
     }
+  }
+
+  /**
+   * Once the component mounts, we'll subscribe to gistId changes
+   */
+  public componentDidMount() {
+    reaction(
+      () => this.props.appState.gistId,
+      (gistId: string) => this.setState({ value: gistId })
+    );
   }
 
   /**

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as Icon from '@fortawesome/react-fontawesome';
-import { faTerminal, faUser } from '@fortawesome/fontawesome-free-solid';
+import { faTerminal } from '@fortawesome/fontawesome-free-solid';
 
 import { Runner } from './runner';
 import { VersionChooser } from './version-chooser';
@@ -28,11 +28,6 @@ export class Commands extends React.Component<CommandsProps, {}> {
 
   public render() {
     const { appState } = this.props;
-    const authButton = !appState.githubToken ? (
-      <button className='button' onClick={() => appState.toggleAuthDialog()}>
-        <Icon icon={faUser} />
-      </button>
-    ) : null;
 
     return (
       <div className='commands'>
@@ -42,7 +37,6 @@ export class Commands extends React.Component<CommandsProps, {}> {
         </div>
         <div>
           <AddressBar appState={appState} />
-          {authButton}
           <PublishButton appState={appState} />
           <button className='button' onClick={() => appState.toggleConsole()}>
             <Icon icon={faTerminal} />

--- a/src/renderer/components/dialogs.tsx
+++ b/src/renderer/components/dialogs.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { AppState } from '../state';
+import { TokenDialog } from './token-dialog';
+
+export interface DialogsProps {
+  appState: AppState;
+}
+
+/**
+ * Dialogs (like the GitHub PAT input).
+ *
+ * @class Dialogs
+ * @extends {React.Component<DialogsProps, {}>}
+ */
+export class Dialogs extends React.Component<DialogsProps, {}> {
+  public render() {
+    return (
+      <div key='dialogs' className='dialogs'>
+        <TokenDialog key='dialogs' appState={this.props.appState} />
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -3,14 +3,13 @@ import * as React from 'react';
 import { Commands } from './commands';
 import { AppState } from '../state';
 import { Output } from './output';
-import { TokenDialog } from './token-dialog';
 
 export interface HeaderProps {
   appState: AppState;
 }
 
 /**
- * Everything above the editors, so buttons, address bar, and dialogs.
+ * Everything above the editors, so buttons and the address bar.
  *
  * @class Header
  * @extends {React.Component<HeaderProps, {}>}
@@ -21,7 +20,6 @@ export class Header extends React.Component<HeaderProps, {}> {
       <header id='header'>
         <Commands key='commands' appState={this.props.appState} />
         <Output key='output' appState={this.props.appState} />
-        <TokenDialog key='tokenDialog' appState={this.props.appState} />
       </header>
     );
   }

--- a/src/renderer/components/publish-button.tsx
+++ b/src/renderer/components/publish-button.tsx
@@ -29,7 +29,24 @@ export class PublishButton extends React.Component<PublishButtonProps, PublishBu
     super(props);
 
     this.state = { isPublishing: false };
-    this.publishFiddle = this.publishFiddle.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  /**
+   * When the user clicks the publish button, we either show the
+   * authentication dialog or publish right away.
+   *
+   * @returns {Promise<void>}
+   * @memberof PublishButton
+   */
+  public async handleClick(): Promise<void> {
+    const { githubToken, toggleAuthDialog } = this.props.appState;
+
+    if (!!githubToken) {
+      return this.publishFiddle();
+    } else {
+      return toggleAuthDialog();
+    }
   }
 
   /**
@@ -73,12 +90,12 @@ export class PublishButton extends React.Component<PublishButtonProps, PublishBu
     const icon = isPublishing ? faSpinner : faUpload;
     const text = isPublishing ? 'Publishing...' : 'Publish';
 
-    return this.props.appState.githubToken ? (
-      <button className={className} onClick={this.publishFiddle} disabled={isPublishing}>
+    return (
+      <button className={className} onClick={this.handleClick} disabled={isPublishing}>
         <Icon icon={icon} spin={isPublishing} />
         <span style={{ marginLeft: 8 }} />
         {text}
       </button>
-    ) : null;
+    );
   }
 }

--- a/src/renderer/components/token-dialog.tsx
+++ b/src/renderer/components/token-dialog.tsx
@@ -1,4 +1,4 @@
-import { clipboard, shell, dialog } from 'electron';
+import { clipboard, shell } from 'electron';
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as Icon from '@fortawesome/react-fontawesome';

--- a/src/renderer/components/token-dialog.tsx
+++ b/src/renderer/components/token-dialog.tsx
@@ -1,9 +1,10 @@
-import { clipboard, shell } from 'electron';
+import { clipboard, shell, dialog } from 'electron';
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import * as Icon from '@fortawesome/react-fontawesome';
 import { faKey, faSpinner } from '@fortawesome/fontawesome-free-solid';
 import * as Octokit from '@octokit/rest';
+import * as classNames from 'classnames';
 
 import { AppState } from '../state';
 
@@ -36,7 +37,7 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
     this.onSubmitToken = this.onSubmitToken.bind(this);
     this.openGenerateTokenExternal = this.openGenerateTokenExternal.bind(this);
     this.onTokenInputFocused = this.onTokenInputFocused.bind(this);
-    this.onTokenKeyDown = this.onTokenKeyDown.bind(this);
+    this.handleChange = this.handleChange.bind(this);
     this.close = this.close.bind(this);
   }
 
@@ -91,12 +92,14 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
     });
   }
 
-  public onTokenKeyDown(event: React.KeyboardEvent<any>) {
-    if (event.which !== 27) return;
-
-    this.setState({
-      tokenInput: '',
-    });
+  /**
+   * Handle the change event, which usually just updates the address bar's value
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   * @memberof AddressBar
+   */
+  public handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    this.setState({ tokenInput: event.target.value });
   }
 
   get spinner() {
@@ -110,29 +113,30 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
   }
 
   public render() {
+    const { isTokenDialogShowing } = this.props.appState;
     const canSubmit = !!this.state.tokenInput;
+    const dialogClassNames = classNames({ tokenDialogVisible: isTokenDialogShowing }, 'tokenDialog');
 
     return [
       (
         <div
           key='drop'
-          className={`dialogDrop ${this.props.appState.isTokenDialogShowing ? 'dialogDropVisible' : ''}`}
+          className={`dialogDrop ${isTokenDialogShowing ? 'dialogDropVisible' : ''}`}
           onClick={this.close}
         />
       ),
       (
-        <div key='tokenDialog' className={`tokenDialog ${this.props.appState.isTokenDialogShowing ? 'tokenDialogVisible' : ''}`}>
+        <div key='tokenDialog' className={dialogClassNames}>
           {this.spinner}
           <span className='generateTokenText'>
             <Icon icon={faKey} />
-            Generate an access token from <a onClick={this.openGenerateTokenExternal}> GitHub </a> and paste it here:
+            Generate a <a onClick={this.openGenerateTokenExternal}>GitHub Personal Access Token</a> and paste it here:
           </span>
           <input
-            readOnly={true}
             ref={this.tokenInputRef}
             value={this.state.tokenInput || ''}
             onFocus={this.onTokenInputFocused}
-            onKeyDown={this.onTokenKeyDown}
+            onChange={this.handleChange}
             className={this.state.error ? 'hasError' : ''}
           />
           <button
@@ -142,6 +146,7 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
           >
             Done
           </button>
+          <button className='cancel' onClick={this.close}>Cancel</button>
         </div>
       )
     ];

--- a/src/renderer/components/token-dialog.tsx
+++ b/src/renderer/components/token-dialog.tsx
@@ -54,7 +54,7 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
 
     try {
       const { data } = await octo.users.get({});
-      localStorage.setItem('avatarUrl', data.avatar_url);
+      this.props.appState.avatarUrl = data.avatar_url;
     } catch (err) {
       this.setState({
         verifying: false,
@@ -63,7 +63,6 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
       return;
     }
 
-    localStorage.setItem('githubToken', this.state.tokenInput);
     this.props.appState.githubToken = this.state.tokenInput;
     this.props.appState.isTokenDialogShowing = false;
 
@@ -112,6 +111,7 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
 
   public render() {
     const canSubmit = !!this.state.tokenInput;
+
     return [
       (
         <div

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -1,4 +1,4 @@
-import { observable, action } from 'mobx';
+import { observable, action, autorun } from 'mobx';
 import * as tmp from 'tmp';
 
 import { BinaryManager } from './binary';
@@ -35,6 +35,7 @@ export class AppState {
   @observable public gistId: string = '';
   @observable public version: string = defaultVersion;
   @observable public tmpDir: tmp.SynchrounousResult = tmp.dirSync();
+  @observable public avatarUrl: string | null = null;
   @observable public githubToken: string | null = null;
   @observable public binaryManager: BinaryManager = new BinaryManager(defaultVersion);
   @observable public versions: StringMap<ElectronVersion> = arrayToStringMap(knownVersions);
@@ -43,6 +44,13 @@ export class AppState {
   @observable public isTokenDialogShowing: boolean = false;
   @observable public isUnsaved: boolean = true;
   @observable public isMyGist: boolean = false;
+
+  constructor() {
+    // Bind all actions
+    this.toggleConsole = this.toggleConsole.bind(this);
+    this.toggleAuthDialog = this.toggleAuthDialog.bind(this);
+    this.setVersion = this.setVersion.bind(this);
+  }
 
   @action public toggleConsole() {
     this.isConsoleShowing = !this.isConsoleShowing;
@@ -71,6 +79,9 @@ export class AppState {
       await this.binaryManager.setup(version);
       this.updateDownloadedVersionState();
     }
+
+    autorun(() => localStorage.setItem('githubToken', this.githubToken || ''));
+    autorun(() => localStorage.setItem('avatarUrl', this.avatarUrl || ''));
   }
 
  /*

--- a/static/css/colors.css
+++ b/static/css/colors.css
@@ -1,45 +1,46 @@
 a {
-  color: #9feaf9;
-}
-
-.button[disabled]:focus, .button[disabled]:hover, button[disabled]:focus, button[disabled]:hover {
-  background-color: unset;
+  color: var(--electron-bright);
 }
 
 .button, button, input[type='button'], input[type='reset'], input[type='submit'] {
-  background-color: #9feaf9;
-  border: .1rem solid #9feaf9;
+  background-color: var(--electron-bright);
+  border: .1rem solid var(--electron-bright);
 }
 
 .button.button-outline, button.button-outline, input[type='button'].button-outline, input[type='reset'].button-outline, input[type='submit'].button-outline {
-  color: #9feaf9;
+  color: var(--electron-bright);
 }
 
 .button.button-clear, button.button-clear, input[type='button'].button-clear, input[type='reset'].button-clear, input[type='submit'].button-clear {
-  color: #9feaf9;
+  color: var(--electron-bright);
+}
+
+.button[disabled]:focus, .button[disabled]:hover, button[disabled]:focus, button[disabled]:hover {
+  border-color: var(--electron-tuned);
+  background: unset;
 }
 
 pre.prettyprint .lit {
-  color: #9feaf9;
+  color: var(--electron-bright);
 }
 
 .share-icon {
-  background-color: #9feaf9;
-  color: #ffffff;
+  background-color: var(--electron-bright);
+  color: white;
 }
 
 pre {
   background: #f4f5f6;
-  border-left: .3rem solid #9feaf9;
+  border-left: .3rem solid var(--electron-bright);
 }
 
 pre.prettyprint {
-  border-left: .3rem solid #9feaf9 !important;
+  border-left: .3rem solid var(--electron-bright) !important;
   color: #655d5d;
 }
 
 pre.prettyprint .tag {
-  color: #9feaf9;
+  color: var(--electron-bright);
 }
 
 pre.prettyprint .atn {
@@ -47,14 +48,14 @@ pre.prettyprint .atn {
 }
 
 input[type='email']:focus, input[type='number']:focus, input[type='password']:focus, input[type='search']:focus, input[type='tel']:focus, input[type='text']:focus, input[type='url']:focus, textarea:focus, select:focus {
-  border: .1rem solid #9feaf9;
+  border: .1rem solid var(--electron-bright);
 }
 
 select:focus {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="#9feaf9" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="var(--electron-bright)" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
 }
 
 .github-corner {
   color: #f4f5f6;
-  fill: #9feaf9;
+  fill: var(--electron-bright);
 }

--- a/static/css/commands.css
+++ b/static/css/commands.css
@@ -12,27 +12,6 @@
   -webkit-app-region: no-drag;
 }
 
-.commands button {
-  background-color: #9feaf9;
-  border: none;
-  color: #1e2527;
-  padding: 0px 30px;
-  text-align: center;
-  text-decoration: none;
-  border-radius: 4px;
-  height: 28px;
-  line-height: 4px;
-}
-
-.commands button:hover {
-  box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.4);
-}
-
-.commands button:focus {
-  background-color: #9feaf9;
-  color: initial;
-}
-
 .commands>div {
   display: flex;
 }

--- a/static/css/dialogs.css
+++ b/static/css/dialogs.css
@@ -1,0 +1,92 @@
+.dialogs {
+  z-index: 10;
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+}
+
+.tokenDialog {
+  position: absolute;
+  z-index: 2;
+  top: 60px;
+  width: 300px;
+  padding: 10px;
+  z-index: 1000;
+  background-color: var(--electron-background-2);
+  border: 1px solid var(--electron-dark);
+  color: #f3f3f3;
+  border-radius: 6px;
+  left: -10000px;
+  opacity: 0;
+  transition: top 0.4s ease-in-out, opacity 0.4s ease-in-out;
+}
+
+.tokenDialog.tokenDialogVisible {
+  left: calc(50% - (300px / 2));
+  opacity: 1;
+  top: 100px;
+}
+
+.generateTokenText svg {
+  margin-right: 4px;
+}
+
+.tokenDialog .tokenSpinner {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenDialog button {
+  color: #1e2527;
+  float: right;
+  margin-left: 5px;
+  margin-bottom: 0;
+}
+
+.tokenDialog a {
+  cursor: pointer;
+}
+
+.tokenDialog input {
+  width: 100%;
+  color: rgba(159, 234, 249, 0.5);
+  height: 28px;
+  margin-top: 10px;
+  background-color: var(--electron-background);
+  border: 1px solid var(--electron-dark);
+  outline: 0 solid transparent;
+}
+
+.tokenDialog input:focus {
+  border-color: var(--electron-bright);
+}
+
+.tokenDialog input.hasError {
+  border-color: #df3434;
+}
+
+.dialogDrop {
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: black;
+  transition: opacity 0.4s ease-in-out;
+}
+
+.dialogDrop.dialogDropVisible {
+  pointer-events: all;
+  opacity: 0.5;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -117,91 +117,31 @@ header {
   font-size: 12px;
 }
 
-.dialogDrop {
-  opacity: 0;
-  pointer-events: none;
-  position: fixed;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: #fff;
-  transition: opacity 0.4s ease-in-out;
-}
-
-.dialogDrop.dialogDropVisible {
-  pointer-events: all;
-  opacity: 0.5;
-}
-
-.tokenDialog {
-  position: absolute;
-  z-index: 2;
-  top: 60px;
-  width: 300px;
-  min-height: 170px;
-  padding: 10px 20px;
-  z-index: 1000;
-  background-color: var(--electron-background-2);
-  border: 1px solid var(--electron-dark);
-  color: #f3f3f3;
-  border-radius: 6px;
-  left: -10000px;
-  opacity: 0;
-  transition: top 0.4s ease-in-out, opacity 0.4s ease-in-out;
-}
-
-.tokenDialog.tokenDialogVisible {
-  left: calc(50% - (300px / 2));
-  opacity: 1;
-  top: 100px;
-}
-
-.generateTokenText svg {
-  margin-right: 4px;
-}
-
-.tokenDialog .tokenSpinner {
-  position: absolute;
-  z-index: 3;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.tokenDialog button {
-  color: #1e2527;
-  float: right;
-}
-
-.tokenDialog a {
-  cursor: pointer;
-}
-
-.tokenDialog input {
-  width: 250px;
-  color: rgba(159, 234, 249, 0.5);
-  height: 28px;
-  margin-top: 10px;
-  background-color: var(--electron-background);
-  border: 1px solid var(--electron-dark);
-  outline: 0 solid transparent;
-}
-
-.tokenDialog input:focus {
-  border-color: var(--electron-bright);
-}
-
-.tokenDialog input.hasError {
-  border-color: #df3434;
-}
-
 .mosaic {
   height: 100vh;
+}
+
+.fiddle button {
+  background-color: #9feaf9;
+  border: none;
+  color: #1e2527;
+  padding: 0px 30px;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 4px;
+  height: 28px;
+  line-height: 4px;
+}
+
+.fiddle button:hover {
+  box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.4);
+}
+
+.fiddle button:focus {
+  background-color: #9feaf9;
+  color: initial;
+}
+
+.fiddle .shadow {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }

--- a/static/index.html
+++ b/static/index.html
@@ -11,8 +11,9 @@
   <link rel="stylesheet" href="./css/colors.css">
   <link rel="stylesheet" href="./css/commands.css">
   <link rel="stylesheet" href="./css/mosaic.css">
+  <link rel="stylesheet" href="./css/dialogs.css">
 </head>
-<body>
+<body class="fiddle">
   <div id="app"></div>
   <script>require('../dist/renderer/app')</script>
 </body>


### PR DESCRIPTION
This PR improves and integrates the login/publish flow by always displaying the `Publish` button and only asking for credentials when we actually need them. Saving the token to `localStorage` is now a side effect of mobx, meaning that that logic no longer lives in the component. This change also cleans up a bunch of broken styles.

Also, cool bonus points: When you hit publish, but have yet to login, we'll continue publishing once you *have* logged in.