### PR TITLE
Whitelist for credits view, new copy

### DIFF
--- a/src/renderer/components/settings-credits.tsx
+++ b/src/renderer/components/settings-credits.tsx
@@ -56,9 +56,9 @@ export class CreditsSettings extends React.Component<CreditsSettingsProps, {}> {
       <div>
         <h2>Credits</h2>
         <p>
-          Electron Fiddle is, just like Electron, a free open source project brought
-          to you by dedicated engineers of all genders, cultures, and backgrounds. We
-          would like to thank those who contributed to Electron Fiddle:
+          Electron Fiddle is, just like Electron, a free open source project
+          welcoming contributors of all genders, cultures, and backgrounds. We
+          would like to thank those who helped to make Electron Fiddle:
         </p>
         <div className='contributors'>
           {this.renderContributors()}

--- a/tools/fetch-contributors.js
+++ b/tools/fetch-contributors.js
@@ -7,8 +7,19 @@ const logSymbols = require('log-symbols');
 const CONTRIBUTORS_FILE_PATH = path.join(__dirname, '../static/contributors.json');
 const CONTRIBUTORS_URL = 'https://api.github.com/repos/electron/fiddle/contributors'
 
-// Add bots you don't want to get credit here
-const CONTRIBUTORS_BLACKLIST = [];
+// 💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖
+// 💖                                                     💖
+// 💖  If you're a contributor, we'd love to say          💖
+// 💖  "thanks" on the app's credits page! Add            💖
+// 💖  your GitHub username here to have it included.     💖
+// 💖  We'll pull your details automatically from there.  💖
+// 💖                                                     💖
+// 💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖
+const CONTRIBUTORS_WHITELIST = [
+  'zeke',
+  'charliehess',
+  'marshallofsound'
+];
 
 async function maybeFetchContributors() {
   try {
@@ -88,7 +99,7 @@ function fetchContributors() {
     .then(async (data) => {
       if (data && data.forEach) {
         data.forEach(({ html_url, url, login, avatar_url }) => {
-          if (CONTRIBUTORS_BLACKLIST.find((name) => name === login)) {
+          if (CONTRIBUTORS_WHITELIST.find((name) => name !== login)) {
             return;
           }
 


### PR DESCRIPTION
After discussion with the team it was decided that the copy should be changed - and that the credits screen should only display those who want to be publicly recognized.