### PR TITLE
Fix first electron version install

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -19,10 +19,6 @@ const eDownload = promisify(require('electron-download'));
 export class BinaryManager {
   public state: StringMap<'ready' | 'downloading'> = {};
 
-  constructor(version: string) {
-    this.setup(version);
-  }
-
   /**
    * Remove a version from disk. Does not update state. We'll try up to
    * three times before giving up if an error occurs.

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -41,7 +41,7 @@ export class AppState {
   @observable public gitHubName: string | null = null;
   @observable public gitHubLogin: string | null = null;
   @observable public gitHubToken: string | null = null;
-  @observable public binaryManager: BinaryManager = new BinaryManager(defaultVersion);
+  @observable public binaryManager: BinaryManager = new BinaryManager();
   @observable public versions: StringMap<ElectronVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
   @observable public isConsoleShowing: boolean = false;


### PR DESCRIPTION
![screen shot 2018-06-14 at 3 07 13 pm](https://user-images.githubusercontent.com/320654/41413856-a7139760-6fe4-11e8-93ba-657ce468bf06.png)

Currently on first run (or running after deleting `~/Application Support/electron-fiddle`) the first electron version download is never reflected in the app.

At the moment `new BinaryManager` is responsible for downloading the first version of electron, which happens in a way `AppState` isn't aware of. A second call to `downloadVersion`, initiated by `AppState` does happen, but at the moment it resolves early as "already being downloaded". By removing the `new BinaryManager` side-effect, everything works as expected.