### PR TITLE
Add basic File menu, improve Windows CSS

### DIFF
--- a/src/less/commands.less
+++ b/src/less/commands.less
@@ -27,7 +27,7 @@
 
     &:first-of-type {
       button {
-        margin-left: 80px;
+        margin-left: 10px;
       }
     }
 

--- a/src/less/system-macos.less
+++ b/src/less/system-macos.less
@@ -1,0 +1,15 @@
+.darwin {
+  .commands {
+    & > div {
+      display: flex;
+
+      // On macOS, we need a bit of space on the left
+      // for the traffic lights
+      &:first-of-type {
+        button {
+          margin-left: 80px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR does two things: 

1) It adds a "File" top-level menu, which allows Windows users to open preferences and quit the app
2) It scopes the margin for the "Run" button to macOS, which is the only environment where we need it