### PR TITLE
feat: File transforms

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,10 @@ export type ElectronVersionState = 'downloading' | 'ready' | 'unknown';
 
 export type WindowNames = 'main';
 
+export type Files = Map<string, string>;
+
+export type FileTransform = (files: Files) => Promise<Files>;
+
 export interface GitHubVersion {
   url: string;
   assets_url: string;


### PR DESCRIPTION
This PR adds a `FileTransform` type, allowing us to make it a bit easier to apply all kinds of transforms to a Fiddle - for instance saving as a `electron-forge` or an `electron-builder` project 🎉 