### PR TITLE
fix: exec `toString` test issue

### DIFF
--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -19,7 +19,7 @@ export async function exec(dir: string, cliArgs: string): Promise<string> {
         reject(error);
       }
 
-      resolve(result.toString());
+      resolve(typeof result === 'string' ? result : `${result}`);
     });
   });
 }


### PR DESCRIPTION
`exec` always returns a string, there's no need to call `toString()`.