### PR TITLE
fix: Settings toggle, context menu init, and a typo

### DIFF
--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -14,6 +14,9 @@ export function getRunItems(): Array<MenuItemConstructorOptions> {
       id: 'run',
       label: 'Run Fiddle',
       click: () => ipcMainManager.send(IpcEvents.FIDDLE_RUN)
+    },
+    {
+      type: 'separator'
     }
   ];
 }
@@ -30,12 +33,11 @@ export function getRunItems(): Array<MenuItemConstructorOptions> {
 export function getMonacoItems(
   { pageURL, editFlags }: ContextMenuParams
 ): Array<MenuItemConstructorOptions> {
-  if (!editFlags.canPaste || !/.*index\.html(#?)$/.test(pageURL)) {
+  if (!editFlags.canPaste || !/.*index\.html(#?)$/.test(pageURL || '')) {
     return [];
   }
 
   return [
-    { type: 'separator' },
     {
       id: 'go_to_definition',
       label: 'Go to Definition',

--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -28,9 +28,11 @@ export function getRunItems(): Array<MenuItemConstructorOptions> {
  * @returns {Array<MenuItemConstructorOptions>}
  */
 export function getMonacoItems(
-  { editFlags }: ContextMenuParams
+  { pageURL, editFlags }: ContextMenuParams
 ): Array<MenuItemConstructorOptions> {
-  if (!editFlags.canPaste) return [];
+  if (!editFlags.canPaste || !/.*index\.html(#?)$/.test(pageURL)) {
+    return [];
+  }
 
   return [
     { type: 'separator' },
@@ -83,7 +85,8 @@ export function getMonacoItems(
         const cmd = [ 'editor.action.formatSelection' ];
         ipcMainManager.send(IpcEvents.MONACO_EXECUTE_COMMAND, cmd);
       }
-    }
+    },
+    { type: 'separator' },
   ];
 }
 
@@ -122,13 +125,12 @@ export function getInspectItems(
  * @param {BrowserWindow} browserWindow
  */
 export function createContextMenu(browserWindow: BrowserWindow) {
-  browserWindow.webContents.on('context-menu', (event, props) => {
+  browserWindow.webContents.on('context-menu', (_event, props) => {
     const { editFlags, selectionText, isEditable } = props;
     const hasText = (selectionText || '').toString().trim().length > 0;
     const template: Array<MenuItemConstructorOptions> = [
       ...getRunItems(),
       ...getMonacoItems(props),
-      { type: 'separator' },
       {
         id: 'cut',
         label: 'Cut',

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -90,8 +90,6 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
   }
 
   public render() {
-    console.log(this.state.section);
-
     const { appState } = this.props;
     const { isSettingsShowing } = appState;
 

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -119,7 +119,7 @@ function getWelcomeTour(): Set<TourScriptStep> {
             a Node.js application is started. The main script runs in the "main
             process". To display a user interface, the main process creates renderer
             processes – usually in the form of windows, which Electron calls
-            <code>BrowserWindows</code>.
+            <code>BrowserWindow</code>.
           </p>
           <p>
             To get started, pretend that the main process is just like a Node.js

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -100,26 +100,22 @@ export class AppState {
   }
 
   @action public toggleSettings() {
-    const newSetting = !this.isSettingsShowing;
-
     // We usually don't lose editor focus,
     // so you can still type. Let's force-blur.
-    if (document.activeElement && document.activeElement.blur) {
-      (document as any).activeElement.blur();
+    if ((document.activeElement as HTMLInputElement).blur) {
+      (document.activeElement as HTMLInputElement).blur();
     }
 
-    this.resetView();
-    this.isSettingsShowing = newSetting;
+    this.resetView({ isSettingsShowing: !this.isSettingsShowing });
   }
 
   @action public disableTour() {
-    this.isTourShowing = false;
+    this.resetView({ isTourShowing: false });
     localStorage.setItem('hasShownTour', 'true');
   }
 
   @action public showTour() {
-    this.resetView();
-    this.isTourShowing = true;
+    this.resetView({ isTourShowing: true });
   }
 
  /*
@@ -270,11 +266,44 @@ export class AppState {
     console.warn(error);
   }
 
-  @action private resetView() {
+  /**
+   * Resets the view, optionally with certain view flags enabled.
+   *
+   * @param {Record<string, boolean>} [additionalOptions]
+   * @memberof AppState
+   */
+  @action private resetView(additionalOptions?: Record<string, boolean>) {
     this.isTokenDialogShowing = false;
     this.isSettingsShowing = false;
     this.isTourShowing = false;
     this.isConsoleShowing = false;
+
+    if (additionalOptions) {
+      for (const key in additionalOptions) {
+        if (additionalOptions.hasOwnProperty(key)) {
+          this[key] = additionalOptions[key];
+        }
+      }
+    }
+
+    this.setPageHash();
+  }
+
+  /**
+   * Updates the pages url with a hash element that allows the main
+   * process to quickly determine if there's a view open.
+   *
+   * @private
+   * @memberof AppState
+   */
+  @action private setPageHash() {
+    let hash = '';
+
+    if (this.isSettingsShowing) {
+      hash = 'settings';
+    }
+
+    window.location.hash = hash;
   }
 }
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -100,8 +100,16 @@ export class AppState {
   }
 
   @action public toggleSettings() {
+    const newSetting = !this.isSettingsShowing;
+
+    // We usually don't lose editor focus,
+    // so you can still type. Let's force-blur.
+    if (document.activeElement && document.activeElement.blur) {
+      (document as any).activeElement.blur();
+    }
+
     this.resetView();
-    this.isSettingsShowing = !this.isSettingsShowing;
+    this.isSettingsShowing = newSetting;
   }
 
   @action public disableTour() {

--- a/tests/main/context-menu-spec.ts
+++ b/tests/main/context-menu-spec.ts
@@ -100,12 +100,12 @@ describe('context-menu', () => {
 
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
 
-      expect(template[11].id).toBe('cut');
-      expect(template[11].enabled).toBe(true);
-      expect(template[12].id).toBe('copy');
-      expect(template[12].enabled).toBe(true);
-      expect(template[13].id).toBe('paste');
-      expect(template[13].enabled).toBe(true);
+      expect(template[2].id).toBe('cut');
+      expect(template[2].enabled).toBe(true);
+      expect(template[3].id).toBe('copy');
+      expect(template[3].enabled).toBe(true);
+      expect(template[4].id).toBe('paste');
+      expect(template[4].enabled).toBe(true);
     });
   });
 
@@ -161,14 +161,19 @@ describe('context-menu', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('returns an array if canPaste is true', () => {
-      const result = getMonacoItems({ editFlags: { canPaste: true }} as any);
+    it('returns an array if the page url suggest the editor is up', () => {
+      const result = getMonacoItems({
+        editFlags: { canPaste: true },
+        pageURL: 'index.html'} as any
+      );
       expect(result).toHaveLength(9);
     });
 
     it('executes an IPC send() for each element', () => {
-      const result = getMonacoItems({ editFlags: { canPaste: true }} as any);
-      let i = 0;
+      const result = getMonacoItems({
+        editFlags: { canPaste: true },
+        pageURL: 'index.html'} as any
+      );      let i = 0;
 
       result.forEach((item) => {
         if (item.click) {


### PR DESCRIPTION
Little catch-all PR that fixes three distinct bugs:

- A typo in the welcome tour found by @malept 
- Broken settings toggle, also found by @malept 
- The context menu showing monaco elements when it shouldn't