### PR TITLE
fix: save as dialog titles

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -164,7 +164,7 @@ function getFileMenu(): MenuItemConstructorOptions {
     },
     {
       label: 'Save as',
-      click: showSaveDialog,
+      click: () => showSaveDialog(IpcEvents.FS_SAVE_FIDDLE),
       accelerator: 'CmdOrCtrl+Shift+S'
     },
     {
@@ -176,7 +176,7 @@ function getFileMenu(): MenuItemConstructorOptions {
     },
     {
       label: 'Save as Forge Project',
-      click: () => showSaveDialog(IpcEvents.FS_SAVE_FIDDLE_FORGE, 'Gist')
+      click: () => showSaveDialog(IpcEvents.FS_SAVE_FIDDLE_FORGE, 'Forge Project')
     }
   ];
 


### PR DESCRIPTION
"Save as Forge Project" dialog title was incorrect.

"Save as" dialog title had `[Object BrowserWindow]` appended to it.