### PR TITLE
test: Add AppVeyor, Readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 > :warning: Still a work in progress, please stay tuned.
 
+<center>
+
+[![Build status](https://ci.appveyor.com/api/projects/status/ngeqlis14337ke3q/branch/master?svg=true)](https://ci.appveyor.com/project/felixrieseberg/fiddle/branch/master)
+[![Build Status](https://travis-ci.org/electron/fiddle.svg?branch=master)](https://travis-ci.org/electron/fiddle)
+
+</center>
+
 Electron Fiddle let's you create and play with small Electron experiments. It
 greets you with a quick-start template after opening – change a few things,
 choose the version of Electron you want to run it with, and play around. Then,

--- a/src/renderer/components/appveyor.yml
+++ b/src/renderer/components/appveyor.yml
@@ -1,0 +1,20 @@
+environment:
+  matrix:
+    - nodejs_version: "8"
+
+init:
+  - git config --global core.symlinks true
+
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  - node --version
+  - npm i
+
+cache:
+  - '%APPDATA%\npm-cache -> appveyor.yml'
+
+test_script:
+  - npm run lint
+  - npm run test
+
+build: off

--- a/src/renderer/components/appveyor.yml
+++ b/src/renderer/components/appveyor.yml
@@ -8,7 +8,7 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - node --version
-  - npm i
+  - npm ci
 
 cache:
   - '%APPDATA%\npm-cache -> appveyor.yml'


### PR DESCRIPTION
This PR enables tests on AppVeyor, ensuring that we cover all three operating systems with our unit tests. It also adds testing badges to the README.