### PR TITLE
feat: Support being offline better

### DIFF
--- a/src/renderer/components/runner.tsx
+++ b/src/renderer/components/runner.tsx
@@ -235,7 +235,6 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
    * Actually run the fiddle.
    *
    * @returns {Promise<boolean>}
-   * @memberof Runner
    */
   public async run(): Promise<boolean> {
     const { appState } = this.props;
@@ -255,11 +254,20 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
       await this.installModulesForEditor(values, dir);
     } catch (error) {
       console.error('Runner: Could not install modules', error);
+      fileManager.cleanup(dir);
       return false;
     }
 
     if (!isDownloaded) {
       console.warn(`Runner: Binary ${version} not ready`);
+
+      let message = `Could not start fiddle: `;
+      message += `Electron ${version} not downloaded yet. `;
+      message += `Please wait for it to finish downloading `;
+      message += `before running the fiddle.`;
+
+      appState.pushOutput(message);
+      fileManager.cleanup(dir);
       return false;
     }
 

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -125,6 +125,29 @@ export class FileManager {
 
 
   /**
+   * Attempts to clean a given directory. Used to manually
+   * clean temp directories.
+   *
+   * @param {string} dir
+   */
+  public async cleanup(dir?: string): Promise<boolean> {
+    if (dir) {
+      const fs = await fancyImport<typeof fsType>('fs-extra');
+
+      if (fs.existsSync(dir)) {
+        try {
+          await fs.remove(dir);
+          return true;
+        } catch (error) {
+          console.warn(`cleanup: Failed to clean directory`, error);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Save the current project to a temporary directory. Returns the
    * path to the temp directory.
    *

--- a/tests/mocks/app.ts
+++ b/tests/mocks/app.ts
@@ -1,3 +1,5 @@
+import { FileManager } from './file-manager';
+
 export class AppMock {
   public setValues = jest.fn();
   public getValues = jest.fn(() => ({
@@ -10,9 +12,7 @@ export class AppMock {
     dispose: jest.fn()
   };
 
-  public fileManager = {
-    saveToTemp: jest.fn(() => '/mock/temp/dir')
-  };
+  public fileManager = new FileManager();
 
   public monaco = {
     editor: {

--- a/tests/mocks/file-manager.ts
+++ b/tests/mocks/file-manager.ts
@@ -1,3 +1,4 @@
 export class FileManager {
-
+  public saveToTemp = jest.fn(() => '/mock/temp/dir');
+  public cleanup = jest.fn();
 }

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -126,4 +126,36 @@ describe('FileManager', () => {
       expect(ipcRendererManager.send).toHaveBeenCalledTimes(4);
     });
   });
+
+  describe('cleanup()', () => {
+    it('attempts to remove a directory if it exists', async () => {
+      const fs = require('fs-extra');
+      fs.existsSync.mockReturnValueOnce(true);
+
+      const result = await fm.cleanup('/fake/dir');
+
+      expect(fs.remove).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('does not attempt to remove a directory if it does not exists', async () => {
+      const fs = require('fs-extra');
+      fs.existsSync.mockReturnValueOnce(false);
+
+      const result = await fm.cleanup('/fake/dir');
+
+      expect(fs.remove).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    it('handles an error', async () => {
+      const fs = require('fs-extra');
+      fs.existsSync.mockReturnValueOnce(true);
+      fs.remove.mockReturnValueOnce(Promise.reject('bwapbwap'));
+
+      const result = await fm.cleanup('/fake/dir');
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -127,9 +127,18 @@ async function fetchAndWriteContributorsFile() {
       }
 
       console.log(logSymbols.info, 'Fetching contributors');
+      let data;
 
-      const data = await fetchContributors()
+      try {
+        data = await fetchContributors()
+      } catch (error) {
+        console.warn(`Fetching contributors failed!`, error);
+        console.log(`We'll continue without.`);
+        data = [];
+      }
+
       await fs.outputFile(CONTRIBUTORS_FILE_PATH, JSON.stringify(data));
+
       console.log(logSymbols.success, 'Contributors fetched');
       resolve();
     });


### PR DESCRIPTION
This PR does two things:

• When we can't run a fiddle because the current Electron version hasn't been downloaded yet, we call that out in the console.
• If contributors.json can't be fetched during development, we're cool with that.