### PR TITLE
fix: Dialog position on Linux and Windows

### DIFF
--- a/src/utils/position-for-rect.ts
+++ b/src/utils/position-for-rect.ts
@@ -37,7 +37,8 @@ export function positionForRect(
 ): PositionResult {
   const result: PositionResult = { left: 0, top: 0, type: 'top' };
   const middle = target.left + (target.width / 2) - (size.width / 2);
-  const topPlusMargin = target.top - (margin * 1.5);
+  const darwinTop = process.platform === 'darwin' ? margin * 1.5 : 0;
+  const topPlusMargin = target.top - darwinTop;
 
   // Okay, let's try top right
   result.left = target.left + target.width + margin;

--- a/tests/renderer/components/tour-spec.tsx
+++ b/tests/renderer/components/tour-spec.tsx
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { Tour } from '../../../src/renderer/components/tour';
+import { overridePlatform, resetPlatform } from '../../utils';
 
 describe('VersionChooser component', () => {
   const oldQuerySelector = document.querySelector;
@@ -21,6 +22,14 @@ describe('VersionChooser component', () => {
       )
     }
   ]);
+
+  beforeAll(() => {
+    overridePlatform('darwin');
+  });
+
+  afterAll(() => {
+    resetPlatform();
+  });
 
   beforeEach(() => {
     document.querySelector = jest.fn(() => ({

--- a/tests/utils/position-for-rect-spec.ts
+++ b/tests/utils/position-for-rect-spec.ts
@@ -1,4 +1,5 @@
 import { invertPosition, positionForRect } from '../../src/utils/position-for-rect';
+import { overridePlatform } from '../utils';
 
 describe('position-for-rect', () => {
   describe('invertPosition()', () => {
@@ -23,7 +24,7 @@ describe('position-for-rect', () => {
     });
   });
 
-  describe('positionForRect()', () => {
+  describe('positionForRect() (macOS)', () => {
     const { innerWidth, innerHeight } = window;
 
     beforeEach(() => {
@@ -33,22 +34,52 @@ describe('position-for-rect', () => {
       });
     });
 
-    it('returns a position on the top right if doable', () => {
-      const target = { left: 50, top: 100, width: 175, height: 50 };
-      const size = { width: 200, height: 150 };
-      const result = positionForRect(target as any, size);
+    describe('positionForRect() (Windows, Linux)', () => {
+      beforeEach(() => {
+        overridePlatform('win32');
+      });
 
-      expect(result).toEqual({ left: 235, top: 85, type: 'right' });
+      it('returns a position on the top right if doable', () => {
+        const target = { left: 50, top: 100, width: 175, height: 50 };
+        const size = { width: 200, height: 150 };
+        const result = positionForRect(target as any, size);
+
+        expect(result).toEqual({ left: 235, top: 100, type: 'right' });
+      });
+
+      it('returns a position on the top left if doable', () => {
+        Object.defineProperty(window, 'innerWidth', { value: 575 });
+
+        const target = { left: 400, top: 100, width: 175, height: 50 };
+        const size = { width: 200, height: 150 };
+        const result = positionForRect(target as any, size);
+
+        expect(result).toEqual({ left: 190, top: 100, type: 'left' });
+      });
     });
 
-    it('returns a position on the top left if doable', () => {
-      Object.defineProperty(window, 'innerWidth', { value: 575 });
+    describe('positionForRect() (Windows, Linux)', () => {
+      beforeEach(() => {
+        overridePlatform('darwin');
+      });
 
-      const target = { left: 400, top: 100, width: 175, height: 50 };
-      const size = { width: 200, height: 150 };
-      const result = positionForRect(target as any, size);
+      it('returns a position on the top right if doable', () => {
+        const target = { left: 50, top: 100, width: 175, height: 50 };
+        const size = { width: 200, height: 150 };
+        const result = positionForRect(target as any, size);
 
-      expect(result).toEqual({ left: 190, top: 85, type: 'left' });
+        expect(result).toEqual({ left: 235, top: 85, type: 'right' });
+      });
+
+      it('returns a position on the top left if doable', () => {
+        Object.defineProperty(window, 'innerWidth', { value: 575 });
+
+        const target = { left: 400, top: 100, width: 175, height: 50 };
+        const size = { width: 200, height: 150 };
+        const result = positionForRect(target as any, size);
+
+        expect(result).toEqual({ left: 190, top: 85, type: 'left' });
+      });
     });
 
     it('returns a position on the bottom middle if doable', () => {

--- a/tests/utils/position-for-rect-spec.ts
+++ b/tests/utils/position-for-rect-spec.ts
@@ -24,7 +24,7 @@ describe('position-for-rect', () => {
     });
   });
 
-  describe('positionForRect() (macOS)', () => {
+  describe('positionForRect()', () => {
     const { innerWidth, innerHeight } = window;
 
     beforeEach(() => {
@@ -58,7 +58,7 @@ describe('position-for-rect', () => {
       });
     });
 
-    describe('positionForRect() (Windows, Linux)', () => {
+    describe('positionForRect() (macOS)', () => {
       beforeEach(() => {
         overridePlatform('darwin');
       });


### PR DESCRIPTION
The automatic dialog positioning would take the macOS-only header into account, which broke the position on Windows and Linux. This fixes that (and tests the fix).