### PR TITLE
fix: Install beta.22 of Fiddle

### DIFF
--- a/src/renderer/components/runner.tsx
+++ b/src/renderer/components/runner.tsx
@@ -114,7 +114,7 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
       if (!(await getIsNpmInstalled())) {
         let message = `The ${maybePlural(`module`, modules)} ${modules.join(', ')} need to be installed, `;
         message += `but we could not find npm. Fiddle requires Node.js and npm `;
-        message += `only to support the installation of modules not included in `;
+        message += `to support the installation of modules not included in `;
         message += `Electron. Please visit https://nodejs.org to install Node.js `;
         message += `and npm.`;
 
@@ -226,6 +226,15 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
 
     appState.isConsoleShowing = true;
     pushOutput(`📦 ${strings[0]} current Fiddle...`);
+
+    if (!(await getIsNpmInstalled())) {
+      let message = `Error: Could not find npm. Fiddle requires Node.js and npm `;
+      message += `to compile packages. Please visit https://nodejs.org to install `;
+      message += `Node.js and npm.`;
+
+      appState.pushOutput(message, { isNotPre: true });
+      return false;
+    }
 
     // Save files to temp
     const dir = await this.saveToTemp(options, dotfilesTransform, forgeTransform);

--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -15,11 +15,11 @@ export async function forgeTransform(files: Files): Promise<Files> {
 
       // devDependencies
       parsed.devDependencies = parsed.devDependencies || {};
-      parsed.devDependencies['@electron-forge/cli'] = 'latest';
-      parsed.devDependencies['@electron-forge/maker-deb'] = 'latest';
-      parsed.devDependencies['@electron-forge/maker-rpm'] = 'latest';
-      parsed.devDependencies['@electron-forge/maker-squirrel'] = 'latest';
-      parsed.devDependencies['@electron-forge/maker-zip'] = 'latest';
+      parsed.devDependencies['@electron-forge/cli'] = '6.0.0-beta.22';
+      parsed.devDependencies['@electron-forge/maker-deb'] = '6.0.0-beta.22';
+      parsed.devDependencies['@electron-forge/maker-rpm'] = '6.0.0-beta.22';
+      parsed.devDependencies['@electron-forge/maker-squirrel'] = '6.0.0-beta.22';
+      parsed.devDependencies['@electron-forge/maker-zip'] = '6.0.0-beta.22';
 
       // Scripts
       parsed.scripts = parsed.scripts || {};

--- a/tests/renderer/components/runner-spec.tsx
+++ b/tests/renderer/components/runner-spec.tsx
@@ -190,12 +190,22 @@ describe('Runner component', () => {
     expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
   });
 
+  it('does attempt a forge operation if npm is not installed', async () => {
+    const wrapper = shallow(<Runner appState={this.store} />);
+    const instance: Runner = wrapper.instance() as any;
+
+    (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
+
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
+  });
+
   describe('installModulesForEditor()', () => {
     it('does not attempt installation if npm is not installed', async () => {
       const wrapper = shallow(<Runner appState={this.store} />);
       const instance: Runner = wrapper.instance() as any;
 
       (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
+      (findModulesInEditors as jest.Mock).mockReturnValueOnce([ 'fake-module' ]);
 
       await instance.installModulesForEditor({
         html: '',

--- a/tests/transforms/forge-spec.ts
+++ b/tests/transforms/forge-spec.ts
@@ -12,11 +12,11 @@ describe('forgeTransform()', () => {
     const files = await forgeTransform(filesBefore);
     expect(JSON.parse(files.get('package.json'))).toEqual({
       devDependencies: {
-        '@electron-forge/cli': 'latest',
-        '@electron-forge/maker-deb': 'latest',
-        '@electron-forge/maker-rpm': 'latest',
-        '@electron-forge/maker-squirrel': 'latest',
-        '@electron-forge/maker-zip': 'latest'
+        '@electron-forge/cli': '6.0.0-beta.22',
+        '@electron-forge/maker-deb': '6.0.0-beta.22',
+        '@electron-forge/maker-rpm': '6.0.0-beta.22',
+        '@electron-forge/maker-squirrel': '6.0.0-beta.22',
+        '@electron-forge/maker-zip': '6.0.0-beta.22'
       },
       scripts: {
         start: 'electron-forge start',


### PR DESCRIPTION
Installing `latest` has unwelcome side effects (mostly, that we're installing older versions). Let's go with the `beta` for now, it does enough for us here.