### PR TITLE
fix: Path on Linux, too

### DIFF
--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -34,7 +34,7 @@ export async function exec(dir: string, cliArgs: string): Promise<string> {
  * @returns {Promise<void>}
  */
 async function maybeFixPath(): Promise<void> {
-  if (!_fixPathCalled && process.platform === 'darwin') {
+  if (!_fixPathCalled && process.platform !== 'win32') {
     const fixPaths = (await import('fix-path')).default;
     fixPaths();
   }


### PR DESCRIPTION
Previously, we only used `fix-path` on macOS, but we should really use it on Unix in general.

Closes #68 