### PR TITLE
fix: Adjust .mosaic-window-body styles

### DIFF
--- a/src/less/mosaic.less
+++ b/src/less/mosaic.less
@@ -34,6 +34,9 @@
     flex-wrap: nowrap;
     align-items: stretch;
     align-content: stretch;
+    padding-top: 20px;
+    background-color: #1d2427;
+    font-size: 12px;
   }
 
   .mosaic {


### PR DESCRIPTION
Refs #61 

After analyzing the details & suggestions in #61 & inspecting the `.mosaic-window-body` element's styles, this PR attempts to simply adjust the styles to resolve the observation in #61.
* add padding top allowance to support a visible tooltip on any variable on code line 1
* adjust font-size to 12px; local test seems to look okay.

Happy to update to any suggested styles to make the UI look nice. 🙏 for your review in advance.

<img width="499" alt="electron-fiddler" src="https://user-images.githubusercontent.com/6441326/44376780-050db900-a4c8-11e8-80fd-200d18cc2f90.png">
