### PR TITLE
feat: Make quick start flexible

### DIFF
--- a/src/content/main-1-x-x.ts
+++ b/src/content/main-1-x-x.ts
@@ -12,7 +12,11 @@ function createWindow () {
   mainWindow = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
-  mainWindow.loadFile('index.html')
+  mainWindow.loadURL(url.format({
+    protocol: 'file',
+    slashes: true,
+    pathname: path.resolve(app.getAppPath(), 'index.html')
+  }))
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -29,7 +29,7 @@ export class App {
    *
    * @param {EditorValues} values
    */
-  public async setValues(values: EditorValues): Promise<boolean> {
+  public async setValues(values: Partial<EditorValues>): Promise<boolean> {
     const { ElectronFiddle: fiddle } = window;
 
     if (!fiddle) {
@@ -43,9 +43,17 @@ export class App {
 
     const { main, html, renderer } = fiddle.editors;
 
-    if (html && html.setValue) html.setValue(values.html);
-    if (main && main.setValue) main.setValue(values.main);
-    if (renderer && renderer.setValue) renderer.setValue(values.renderer);
+    if (html && html.setValue && values.html) {
+      html.setValue(values.html);
+    }
+
+    if (main && main.setValue && values.main) {
+      main.setValue(values.main);
+    }
+
+    if (renderer && renderer.setValue && values.renderer) {
+      renderer.setValue(values.renderer);
+    }
 
     appState.isUnsaved = false;
     this.setupUnsavedOnChangeListener();
@@ -58,7 +66,7 @@ export class App {
    *
    * @returns {EditorValues}
    */
-  public async getValues(options: PackageJsonOptions): Promise<EditorValues> {
+  public async getValues(options?: PackageJsonOptions): Promise<EditorValues> {
     const { ElectronFiddle: fiddle } = window;
 
     if (!fiddle) {
@@ -72,7 +80,9 @@ export class App {
       renderer: renderer && renderer.getValue() ? renderer.getValue() : '',
     };
 
-    values.package = await getPackageJson(appState, values, options);
+    if (options && options.include !==  false) {
+      values.package = await getPackageJson(appState, values, options);
+    }
 
     return values;
   }

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -60,7 +60,8 @@ export class Editor extends React.Component<EditorProps> {
    * Initialize Monaco.
    */
   public async initMonaco() {
-    const { options, monaco, id } = this.props;
+    const { options, monaco, id, appState } = this.props;
+    const { version } = appState;
     const ref = this.containerRef.current;
 
     if (ref) {
@@ -71,7 +72,7 @@ export class Editor extends React.Component<EditorProps> {
           enabled: false
         },
         contextmenu: false,
-        value: await getContent(id as ContentNames),
+        value: await getContent(id as ContentNames, version),
         ...options
       });
       this.editorDidMount(this.editor);

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -53,11 +53,13 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
       this.executeCommand(cmd);
     });
 
-    ipcRendererManager.on(IpcEvents.FS_NEW_FIDDLE, async (_event, cmd: string) => {
+    ipcRendererManager.on(IpcEvents.FS_NEW_FIDDLE, async (_event) => {
+      const { version } = this.props.appState;
+
       window.ElectronFiddle.app.setValues({
-        html: await getContent(ContentNames.HTML),
-        renderer: await getContent(ContentNames.RENDERER),
-        main: await getContent(ContentNames.MAIN)
+        html: await getContent(ContentNames.HTML, version),
+        renderer: await getContent(ContentNames.RENDERER, version),
+        main: await getContent(ContentNames.MAIN, version)
       });
     });
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -6,6 +6,7 @@ import { arrayToStringMap } from '../utils/array-to-stringmap';
 import { getName } from '../utils/get-title';
 import { normalizeVersion } from '../utils/normalize-version';
 import { BinaryManager } from './binary';
+import { ContentNames, getContent, isContentUnchanged } from './content';
 import { updateEditorTypeDefinitions } from './fetch-types';
 import { ipcRendererManager } from './ipc';
 import { activateTheme } from './themes';
@@ -233,6 +234,12 @@ export class AppState {
     console.log(`State: Switching to Electron ${version}`);
 
     this.version = version;
+
+    // Should we update the editor?
+    if (await isContentUnchanged(ContentNames.MAIN)) {
+      const main = await getContent(ContentNames.MAIN, version);
+      window.ElectronFiddle.app.setValues({ main });
+    }
 
     // Update TypeScript definitions
     updateEditorTypeDefinitions(version);

--- a/src/utils/get-package.ts
+++ b/src/utils/get-package.ts
@@ -4,6 +4,7 @@ import { AppState } from '../renderer/state';
 import { getUsername } from './get-username';
 
 export interface PackageJsonOptions {
+  include?: boolean;
   includeElectron?: boolean;
   includeDependencies?: boolean;
 }

--- a/tests/renderer/content-spec.ts
+++ b/tests/renderer/content-spec.ts
@@ -1,4 +1,4 @@
-import { ContentNames, getContent } from '../../src/renderer/content';
+import { ContentNames, getContent, isContentUnchanged } from '../../src/renderer/content';
 
 describe('content', () => {
   describe('getContent()', () => {
@@ -16,6 +16,57 @@ describe('content', () => {
 
     it('returns an empty string for an unknown request', () => {
       expect(getContent('beep' as any)).toBeTruthy();
+    });
+  });
+
+  describe('isContentUnchanged()', () => {
+    describe('main', () => {
+      it('returns false if it changed', async () => {
+        window.ElectronFiddle.app.getValues.mockReturnValueOnce({
+          main: 'hi'
+        });
+
+        const isUnchanged = await isContentUnchanged(ContentNames.MAIN);
+        expect(isUnchanged).toBe(false);
+      });
+
+      it('returns true if it did not change', async () => {
+        window.ElectronFiddle.app.getValues.mockReturnValueOnce({
+          main: require('../../src/content/main').main
+        });
+
+        const isUnchanged = await isContentUnchanged(ContentNames.MAIN);
+        expect(isUnchanged).toBe(true);
+      });
+
+      it('returns true if it did not change (1.0 version)', async () => {
+        window.ElectronFiddle.app.getValues.mockReturnValueOnce({
+          main: require('../../src/content/main-1-x-x').main
+        });
+
+        const isUnchanged = await isContentUnchanged(ContentNames.MAIN);
+        expect(isUnchanged).toBe(true);
+      });
+    });
+
+    describe('renderer', () => {
+      it('returns false if it changed', async () => {
+        window.ElectronFiddle.app.getValues.mockReturnValueOnce({
+          renderer: 'hi'
+        });
+
+        const isUnchanged = await isContentUnchanged(ContentNames.RENDERER);
+        expect(isUnchanged).toBe(false);
+      });
+
+      it('returns true if it did not change', async () => {
+        window.ElectronFiddle.app.getValues.mockReturnValueOnce({
+          renderer: require('../../src/content/renderer').renderer
+        });
+
+        const isUnchanged = await isContentUnchanged(ContentNames.RENDERER);
+        expect(isUnchanged).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
⚠️ This PR isn't as good as I'd like it to be, but it'll be good enough for now.

This PR enables a more flexible quick start. If you switch to a `v1.x` version, we'll use `loadURL`. If you switch to an Electron version that supports `loadFile`, we'll use `loadFile`. That change doesn't happen if you changed your main script so that we don't touch a user's code.