### PR TITLE
refactor: add contributor pre a previous PR

### DIFF
--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -19,7 +19,8 @@ const CONTRIBUTORS_WHITELIST = [
   'zeke',
   'charliehess',
   'marshallofsound',
-  'felixrieseberg'
+  'felixrieseberg',
+  'benicheni'
 ];
 
 async function maybeFetchContributors() {


### PR DESCRIPTION
Per #78 , reviewer is kind enough to invite to add to self to the contributor list. Therefore, this PR simply adds my GitHub handle to the list. It's an honor. Will look out for issues to try to help out. 🙏 