### PR TITLE
fix: Update mosaic less to improve tooltip styles

### DIFF
--- a/src/less/mosaic.less
+++ b/src/less/mosaic.less
@@ -34,9 +34,11 @@
     flex-wrap: nowrap;
     align-items: stretch;
     align-content: stretch;
-    padding-top: 20px;
+    padding-top: 13px;
     background-color: #1d2427;
     font-size: 12px;
+    overflow: visible;
+    z-index: 4;
   }
 
   .mosaic {


### PR DESCRIPTION
Refs #61 

I tested the current build more and found some style nuance.
###### Before PR, style is still not 100% perfect with top line, even with seemingly enough top padding
<img width="398" alt="before" src="https://user-images.githubusercontent.com/6441326/44444466-fa782000-a5aa-11e8-8d40-d4b34b8c9580.png">

I dug a little more to attempt to improve the tooltip styles further. The PR is able to:
* shorter the top padding space to make the draggable toolbar not as consuming as much height
* in viewport with narrow width, tested two use cases of right clicking and hovering to see tooltip.

###### Right click on keyword "application" in top line
<img width="279" alt="right-click-tooltip" src="https://user-images.githubusercontent.com/6441326/44444345-63ab6380-a5aa-11e8-92a6-a1e39dc0863f.png">

###### Hover on `browserWindow` object
<img width="211" alt="hover-tooltip" src="https://user-images.githubusercontent.com/6441326/44444350-67d78100-a5aa-11e8-86ef-1d1fdbcea9b7.png">
