### PR TITLE
fix: Prevent error in isContentUnchanged

### DIFF
--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -45,6 +45,8 @@ export async function getContent(
  * @returns {Promise<boolean>}
  */
 export async function isContentUnchanged(name: ContentNames): Promise<boolean> {
+  if (!window.ElectronFiddle || !window.ElectronFiddle.app) return false;
+
   const values = await window.ElectronFiddle.app.getValues({ include: false });
 
   // Handle main case, which needs to check both possible versions

--- a/tests/renderer/content-spec.ts
+++ b/tests/renderer/content-spec.ts
@@ -20,6 +20,13 @@ describe('content', () => {
   });
 
   describe('isContentUnchanged()', () => {
+    it('returns false if app is not available', async () => {
+      window.ElectronFiddle.app = null;
+
+      const isUnchanged = await isContentUnchanged(ContentNames.MAIN);
+      expect(isUnchanged).toBe(false);
+    });
+
     describe('main', () => {
       it('returns false if it changed', async () => {
         window.ElectronFiddle.app.getValues.mockReturnValueOnce({


### PR DESCRIPTION
Some operations _can_ run before the Monaco editor has fully loaded. This guards against an error in `isContentUnchanged()`.