### PR TITLE
fix: don't pin download link to 0.1 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GitHub, anyone can quickly try your Fiddle out by just entering it in the
 address bar.
 
 <h3 align="center">
-  <a href="https://github.com/electron/fiddle/releases/tag/0.1">
+  <a href="https://github.com/electron/fiddle/releases/">
   Download Electron Fiddle for macOS, Windows, and Linux
   </a>
 </h3>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GitHub, anyone can quickly try your Fiddle out by just entering it in the
 address bar.
 
 <h3 align="center">
-  <a href="https://github.com/electron/fiddle/releases/">
+  <a href="https://github.com/electron/fiddle/releases/latest">
   Download Electron Fiddle for macOS, Windows, and Linux
   </a>
 </h3>


### PR DESCRIPTION
The main page's

**"Download Electron Fiddle for macOS, Windows, and Linux"**

link still points to 0.1.

I was showing Fiddle to an Electron user today and we were both confused for a bit why we couldn't find 0.2 :smiley: 