### PR TITLE
chore: remove unused requires in main

### DIFF
--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -1,7 +1,5 @@
 export const main = `// Modules to control application life and create native browser window
 const {app, BrowserWindow} = require('electron')
-const path = require('path')
-const url = require('url')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.


### PR DESCRIPTION
`path` and `url` are no longer used here since `index.html` is loaded via `loadFile`. 

This PR thus removes them.

/cc @felixrieseberg