### PR TITLE
fix: friendlier button text for intro tour

### DIFF
--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -219,8 +219,10 @@ export class WelcomeTour extends React.Component<WelcomeTourProps, WelcomeTourSt
           isCentered={true}
           isShowing={true}
           isShowingBackdrop={true}
-          onConfirm={this.startTour}
-          onClose={this.stopTour}
+          buttons={[
+            <button key='cancel' className='btn-close' onClick={this.stopTour}>I'll figure it out</button>,
+            <button key='ok' className='btn-ok' onClick={this.startTour}>Show me around</button>
+          ]}
         >
           <h4>🙋‍ Hey There!</h4>
           <p>

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -2,12 +2,26 @@
 
 exports[`Header component renders 1`] = `
 <Dialog
+  buttons={
+    Array [
+      <button
+        className="btn-close"
+        onClick={[Function]}
+      >
+        I'll figure it out
+      </button>,
+      <button
+        className="btn-ok"
+        onClick={[Function]}
+      >
+        Show me around
+      </button>,
+    ]
+  }
   isCentered={true}
   isShowing={true}
   isShowingBackdrop={true}
   key="welcome-tour-dialog"
-  onClose={[Function]}
-  onConfirm={[Function]}
 >
   <h4>
     🙋‍ Hey There!

--- a/tests/utils/sorted-electron-map-spec.ts
+++ b/tests/utils/sorted-electron-map-spec.ts
@@ -30,16 +30,12 @@ describe('sorted-eletron-map', () => {
       },
       garbage: {
         tag_name: 'garbage'
-      },
-      trash: {
-        tag_name: 'trash'
       }
     };
     const result = sortedElectronMap(map, (_k, e) => e);
 
     expect(result[0]).toEqual({ tag_name: 'garbage' });
-    expect(result[1]).toEqual({ tag_name: 'trash' });
-    expect(result[2]).toEqual({ tag_name: 'v3.0.0' });
-    expect(result[3]).toEqual({ tag_name: 'v1.0.0' });
+    expect(result[1]).toEqual({ tag_name: 'v3.0.0' });
+    expect(result[2]).toEqual({ tag_name: 'v1.0.0' });
   });
 });


### PR DESCRIPTION
In general I like it when buttons are labeled with what's going to happen when I click on them