### PR TITLE
chore: update windows installer icon

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -41,7 +41,7 @@ module.exports = {
         name: 'electron-fiddle',
         authors: 'Electron Community',
         exe: 'electron-fiddle.exe',
-        iconUrl: 'https://raw.githubusercontent.com/electron/fiddle/b5bf652df0ba159ec40a62001dbb298649c3b985/assets/icons/fiddle.ico',
+        iconUrl: 'https://raw.githubusercontent.com/electron/fiddle/0119f0ce697f5ff7dec4fe51f17620c78cfd488b/assets/icons/fiddle.ico',
         loadingGif: './assets/loading.gif',
         noMsi: true,
         remoteReleases: '',


### PR DESCRIPTION
Now that #118 is merged, there's a stable URL for the new icon that `electron-winstaller` can use.