### PR TITLE
feat: Publish fiddles as public/private

### DIFF
--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -33,7 +33,7 @@ header {
     &:last-of-type {
       margin-right: 10px;
 
-      button {
+      .bp3-button-group {
         margin-left: 5px;
       }
     }

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@blueprintjs/core';
+import { Button, ButtonGroup, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -77,13 +77,13 @@ export class PublishButton extends React.Component<PublishButtonProps, PublishBu
       token: this.props.appState.gitHubToken!
     });
 
+    const { gitHubPublishAsPublic } = this.props.appState;
     const options = { includeDependencies: true, includeElectron: true };
     const values = await window.ElectronFiddle.app.getValues(options);
 
-
     try {
       const gist = await octo.gists.create({
-        public: true,
+        public: !!gitHubPublishAsPublic,
         description: 'Electron Fiddle Gist',
         files: {
           [INDEX_HTML_NAME]: {
@@ -115,17 +115,51 @@ export class PublishButton extends React.Component<PublishButtonProps, PublishBu
     this.setState({ isPublishing: false });
   }
 
+  public setPrivacy(publishAsPublic: boolean) {
+    this.props.appState.gitHubPublishAsPublic = publishAsPublic;
+  }
+
   public render() {
+    const { gitHubPublishAsPublic } = this.props.appState;
     const { isPublishing } = this.state;
 
+    const privacyIcon = gitHubPublishAsPublic ? 'unlock' : 'lock';
+    const privacyMenu = (
+      <Menu>
+        <MenuItem
+          text='Private'
+          icon='lock'
+          active={!gitHubPublishAsPublic}
+          onClick={() => this.setPrivacy(false)}
+        />
+        <MenuItem
+          text='Public'
+          icon='unlock'
+          active={gitHubPublishAsPublic}
+          onClick={() => this.setPrivacy(true)}
+        />
+      </Menu>
+    );
+
     return (
-      <Button
-        onClick={this.handleClick}
-        loading={isPublishing}
-        disabled={isPublishing}
-        icon='upload'
-        text={isPublishing ? 'Publishing...' : 'Publish'}
-      />
+      <ButtonGroup>
+        <Popover
+          content={privacyMenu}
+          position={Position.BOTTOM}
+          disabled={isPublishing}
+        >
+          <Button
+            icon={privacyIcon}
+          />
+        </Popover>
+        <Button
+          onClick={this.handleClick}
+          loading={isPublishing}
+          disabled={isPublishing}
+          icon='upload'
+          text={isPublishing ? 'Publishing...' : 'Publish'}
+        />
+      </ButtonGroup>
     );
   }
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -44,6 +44,7 @@ export class AppState {
   @observable public gitHubName: string | null = localStorage.getItem('gitHubName');
   @observable public gitHubLogin: string | null = localStorage.getItem('gitHubLogin');
   @observable public gitHubToken: string | null = localStorage.getItem('gitHubToken') || null;
+  @observable public gitHubPublishAsPublic: boolean = !!this.retrieve('gitHubPublishAsPublic', true);
   @observable public versionPagesToFetch: number = parseInt(
     localStorage.getItem('versionPagesToFetch') || '2', 10
   );
@@ -89,12 +90,13 @@ export class AppState {
     ipcRendererManager.on(IpcEvents.OPEN_SETTINGS, this.toggleSettings);
     ipcRendererManager.on(IpcEvents.SHOW_WELCOME_TOUR, this.showTour);
 
-    // Setup autoruns
+    // Setup auto-runs
     autorun(() => this.save('theme', this.theme));
     autorun(() => this.save('gitHubAvatarUrl', this.gitHubAvatarUrl));
     autorun(() => this.save('gitHubLogin', this.gitHubLogin));
     autorun(() => this.save('gitHubName', this.gitHubName));
     autorun(() => this.save('gitHubToken', this.gitHubToken));
+    autorun(() => this.save('gitHubPublishAsPublic', this.gitHubPublishAsPublic));
     autorun(() => this.save('version', this.version));
     autorun(() => this.save('versionPagesToFetch', this.versionPagesToFetch));
     autorun(() => this.save('versionsToShow', this.versionsToShow));
@@ -419,7 +421,7 @@ export class AppState {
    * @param {string} key
    * @param {(string | number | object)} [value]
    */
-  private save(key: string, value?: string | number | object | null) {
+  private save(key: string, value?: string | number | object | null | boolean) {
     if (value) {
       const _value = typeof value === 'object'
         ? JSON.stringify(value)

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -1,11 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Publish button component renders 1`] = `
-<Blueprint3.Button
-  disabled={false}
-  icon="upload"
-  loading={false}
-  onClick={[Function]}
-  text="Publish"
-/>
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Popover
+    boundary="scrollParent"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Menu>
+        <Blueprint3.MenuItem
+          active={false}
+          disabled={false}
+          icon="lock"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Private"
+        />
+        <Blueprint3.MenuItem
+          active={true}
+          disabled={false}
+          icon="unlock"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Public"
+        />
+      </Blueprint3.Menu>
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    modifiers={Object {}}
+    openOnTargetFocus={true}
+    position="bottom"
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+    wrapperTagName="span"
+  >
+    <Blueprint3.Button
+      icon="unlock"
+    />
+  </Blueprint3.Popover>
+  <Blueprint3.Button
+    disabled={false}
+    icon="upload"
+    loading={false}
+    onClick={[Function]}
+    text="Publish"
+  />
+</Blueprint3.ButtonGroup>
 `;


### PR DESCRIPTION
This feature is best explained with an image:

<img width="462" alt="screen shot 2018-12-17 at 4 43 28 pm" src="https://user-images.githubusercontent.com/1426799/50124763-ebcd0d00-021a-11e9-9d16-4899be6690ca.png">

Closes https://github.com/electron/fiddle/issues/99