### PR TITLE
fix: Confusing "Fiddle unsaved" dialog

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,6 +43,11 @@ export interface OutputOptions {
   isNotPre?: boolean;
 }
 
+export interface WarningDialogTexts {
+  ok?: string;
+  cancel?: string;
+  label: string;
+}
 
 export interface Templates {
   [index: string]: string | Templates;

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,3 +1,4 @@
+import { when } from 'mobx';
 import * as MonacoType from 'monaco-editor';
 
 import { EditorValues } from '../interfaces';
@@ -28,17 +29,22 @@ export class App {
    * Sets the values on all three editors.
    *
    * @param {EditorValues} values
+   * @param {warn} warn - Should we warn before overwriting unsaved data?
    */
-  public async setValues(values: Partial<EditorValues>): Promise<boolean> {
+  public async setValues(values: Partial<EditorValues>, warn: boolean = true): Promise<boolean> {
     const { ElectronFiddle: fiddle } = window;
 
     if (!fiddle) {
       throw new Error('Fiddle not ready');
     }
 
-    if (appState.isUnsaved) {
-      const isUserSure = confirm('Your current fiddle is unsaved. Are you sure you want to overwrite it?');
-      if (!isUserSure) return false;
+    if (appState.isUnsaved && warn) {
+      this.state.isWarningDialogShowing = true;
+      await when(() => !this.state.isWarningDialogShowing);
+
+      if (!this.state.warningDialogLastResult) {
+        return false;
+      }
     }
 
     const { main, html, renderer } = fiddle.editors;

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -79,14 +79,14 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
   public async loadFiddle(): Promise<boolean> {
     const { appState } = this.props;
 
-    if (!confirm('Are you sure you want to load a new fiddle, all current progress will be lost?')) {
-      return false;
-    }
-
     try {
       const octo = await getOctokit();
       const gist = await octo.gists.get({
         gist_id: appState.gistId
+      });
+
+      this.props.appState.setWarningDialogTexts({
+        label: 'Loading the fiddle will replace your current unsaved changes. Do you want to discard them?'
       });
 
       await window.ElectronFiddle.app.setValues({

--- a/src/renderer/components/dialog-warning.tsx
+++ b/src/renderer/components/dialog-warning.tsx
@@ -1,0 +1,52 @@
+
+import { Alert, Intent } from '@blueprintjs/core';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+import { AppState } from '../state';
+
+export interface WarningDialogProps {
+  appState: AppState;
+}
+
+export interface WarningDialogState {
+}
+
+/**
+ * The token dialog asks the user for a GitHub Personal Access Token.
+ * It's also responsible for checking if the token is correct.
+ *
+ * @export
+ * @class WarningDialog
+ * @extends {React.Component<WarningDialogProps, WarningDialogState>}
+ */
+@observer
+export class WarningDialog extends React.Component<WarningDialogProps, WarningDialogState> {
+  constructor(props: WarningDialogProps) {
+    super(props);
+
+    this.onClose = this.onClose.bind(this);
+  }
+
+  public onClose(result: boolean) {
+    this.props.appState.warningDialogLastResult = result;
+    this.props.appState.toogleWarningDialog();
+  }
+
+  public render() {
+    const { isWarningDialogShowing, warningDialogTexts } = this.props.appState;
+
+    return (
+      <Alert
+        isOpen={isWarningDialogShowing}
+        onClose={this.onClose}
+        icon='warning-sign'
+        confirmButtonText={warningDialogTexts.ok}
+        cancelButtonText={warningDialogTexts.cancel}
+        intent={Intent.DANGER}
+      >
+        <p>{warningDialogTexts.label}</p>
+      </Alert>
+    );
+  }
+}

--- a/src/renderer/components/dialogs.tsx
+++ b/src/renderer/components/dialogs.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { AppState } from '../state';
 import { AddVersionDialog } from './add-version-dialog';
 import { TokenDialog } from './dialog-token';
+import { WarningDialog } from './dialog-warning';
 import { Settings } from './settings';
 
 export interface DialogsProps {
@@ -36,6 +37,7 @@ export class Dialogs extends React.Component<DialogsProps, {}> {
         {maybeToken}
         {maybeSettings}
         {maybeAddLocalVersion}
+        <WarningDialog appState={appState} />
       </div>
     );
   }

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -65,10 +65,14 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     ipcRendererManager.on(IpcEvents.FS_NEW_FIDDLE, async (_event) => {
       const { version } = this.props.appState;
 
+      this.props.appState.setWarningDialogTexts({
+        label: 'Your current fiddle is unsaved. Do you want to discard it?'
+      });
+
       window.ElectronFiddle.app.setValues({
         html: await getContent(ContentNames.HTML, version),
         renderer: await getContent(ContentNames.RENDERER, version),
-        main: await getContent(ContentNames.MAIN, version)
+        main: await getContent(ContentNames.MAIN, version),
       });
     });
 

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -72,6 +72,12 @@ export class FileManager {
     this.appState.gistId = '';
     this.appState.isMyGist = false;
     this.appState.localPath = filePath || null;
+
+    this.appState.setWarningDialogTexts({
+      label: `Opening this fiddle will replace your unsaved changes. Do you want to proceed?`,
+      ok: 'Yes'
+    });
+
     await window.ElectronFiddle.app.setValues(values);
     document.title = getTitle(this.appState);
   }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -86,7 +86,6 @@ export class AppState {
 
   private outputBuffer: string = '';
   private name: string;
-  private isClosing = false;
 
   constructor() {
     // Bind all actions
@@ -124,7 +123,6 @@ export class AppState {
           });
 
           this.isWarningDialogShowing = true;
-          this.isClosing = true;
 
           // We'll wait until the warning dialog was closed
           when(() => !this.isWarningDialogShowing).then(() => {

--- a/tests/renderer/components/__snapshots__/dialogs-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialogs-spec.tsx.snap
@@ -4,5 +4,20 @@ exports[`Dialogs component renders initially without visible dialogs 1`] = `
 <div
   className="dialogs"
   key="dialogs"
-/>
+>
+  <WarningDialog
+    appState={
+      Object {
+        "isAddVersionDialogShowing": false,
+        "isSettingsShowing": false,
+        "isTokenDialogShowing": false,
+        "warningDialogTexts": Object {
+          "cancel": "",
+          "label": "",
+          "ok": "",
+        },
+      }
+    }
+  />
+</div>
 `;

--- a/tests/renderer/components/commands-address-bar-spec.tsx
+++ b/tests/renderer/components/commands-address-bar-spec.tsx
@@ -11,7 +11,8 @@ describe('AddressBar component', () => {
 
   beforeEach(() => {
     store = {
-      gistId: null
+      gistId: null,
+      setWarningDialogTexts: jest.fn()
     };
   });
 
@@ -69,7 +70,6 @@ describe('AddressBar component', () => {
     const instance: AddressBar = wrapper.instance() as any;
 
     store.gistId = 'abcdtestid';
-    (global as any).window.confirm.mockReturnValueOnce(true);
 
     instance.handleChange({ target: { value: 'abcdtestid' } } as any);
     await (wrapper.instance() as AddressBar).loadFiddle();

--- a/tests/renderer/components/dialogs-spec.tsx
+++ b/tests/renderer/components/dialogs-spec.tsx
@@ -18,6 +18,7 @@ describe('Dialogs component', () => {
       isTokenDialogShowing: false,
       isSettingsShowing: false,
       isAddVersionDialogShowing: false,
+      warningDialogTexts: { label: '', ok: '', cancel: '' }
     };
   });
 
@@ -34,18 +35,18 @@ describe('Dialogs component', () => {
   it('renders the token dialog', () => {
     store.isTokenDialogShowing = true;
     const wrapper = shallow(<Dialogs appState={store} />);
-    expect(wrapper.text()).toBe('<TokenDialog />');
+    expect(wrapper.text()).toBe('<TokenDialog /><WarningDialog />');
   });
 
   it('renders the settings dialog', () => {
     store.isSettingsShowing = true;
     const wrapper = shallow(<Dialogs appState={store} />);
-    expect(wrapper.text()).toBe('<Settings />');
+    expect(wrapper.text()).toBe('<Settings /><WarningDialog />');
   });
 
   it('renders the settings dialog', () => {
     store.isAddVersionDialogShowing = true;
     const wrapper = shallow(<Dialogs appState={store} />);
-    expect(wrapper.text()).toBe('<AddVersionDialog />');
+    expect(wrapper.text()).toBe('<AddVersionDialog /><WarningDialog />');
   });
 });

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -17,7 +17,7 @@ jest.mock('../../src/renderer/templates', () => ({
     renderer: ''
   })
 }));
-jest.mock('../../src/renderer/state');
+
 jest.mock('../../src/utils/import', () => ({
   fancyImport: async (p: string) => require(p)
 }));
@@ -29,7 +29,9 @@ describe('FileManager', () => {
     window.ElectronFiddle = new ElectronFiddleMock() as any;
     ipcRendererManager.send = jest.fn();
 
-    fm = new FileManager({} as any);
+    fm = new FileManager({
+      setWarningDialogTexts: jest.fn()
+    } as any);
   });
 
   afterEach(() => {
@@ -53,7 +55,7 @@ describe('FileManager', () => {
       expect(window.ElectronFiddle.app.setValues).toHaveBeenCalledWith({
         html: '',
         renderer: '',
-        main: ''
+        main: '',
       });
     });
 


### PR DESCRIPTION
The dialog that warns users before getting rid of an unsaved dialog isn't the best part of Fiddle. This PR makes things a bit more clear – and the dialog a bit nicer.

This also fixes a small issue with our `beforeunload` handling, which didn't quite work before.

<img width="903" alt="screen shot 2018-12-19 at 4 59 15 pm" src="https://user-images.githubusercontent.com/1426799/50257285-7e9eb080-03af-11e9-95ad-e3896052b30a.png">
