### PR TITLE
feat: Prune appData directories after runs

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import { EditorValues } from '../interfaces';
 import { updateEditorLayout } from '../utils/editor-layout';
 import { getPackageJson, PackageJsonOptions } from '../utils/get-package';
 import { FileManager } from './file-manager';
+import { Runner } from './runner';
 import { appState } from './state';
 import { getTheme } from './themes';
 
@@ -19,6 +20,7 @@ export class App {
   public monaco: typeof MonacoType | null = null;
   public state = appState;
   public fileManager = new FileManager(appState);
+  public runner = new Runner(appState);
 
   constructor() {
     this.getValues = this.getValues.bind(this);

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -1,29 +1,16 @@
 import { Button, IButtonProps } from '@blueprintjs/core';
-import { ChildProcess, spawn } from 'child_process';
 import { observer } from 'mobx-react';
-import * as path from 'path';
 import * as React from 'react';
 
-import { EditorValues, ElectronVersionSource, ElectronVersionState, FileTransform } from '../../interfaces';
-import { IpcEvents } from '../../ipc-events';
-import { PackageJsonOptions } from '../../utils/get-package';
+import { ElectronVersionState } from '../../interfaces';
 import { normalizeVersion } from '../../utils/normalize-version';
-import { maybePlural } from '../../utils/plural-maybe';
-import { ipcRendererManager } from '../ipc';
-import { findModulesInEditors, getIsNpmInstalled, installModules, npmRun } from '../npm';
 import { AppState } from '../state';
 
 export interface RunnerState {
-  isRunning: boolean;
 }
 
 export interface RunnerProps {
   appState: AppState;
-}
-
-export enum ForgeCommands {
-  PACKAGE = 'package',
-  MAKE = 'make'
 }
 
 /**
@@ -35,32 +22,8 @@ export enum ForgeCommands {
  */
 @observer
 export class Runner extends React.Component<RunnerProps, RunnerState> {
-  public child: ChildProcess | null = null;
-
-  constructor(props: RunnerProps) {
-    super(props);
-
-    this.run = this.run.bind(this);
-    this.performForgeOperation = this.performForgeOperation.bind(this);
-    this.stop = this.stop.bind(this);
-    this.state = { isRunning: false };
-
-    this.props.appState.pushOutput('Console ready 🔬');
-  }
-
-  public componentDidMount() {
-    ipcRendererManager.on(IpcEvents.FIDDLE_RUN, this.run);
-    ipcRendererManager.on(IpcEvents.FIDDLE_PACKAGE, () => {
-      this.performForgeOperation(ForgeCommands.PACKAGE);
-    });
-    ipcRendererManager.on(IpcEvents.FIDDLE_MAKE, () => {
-      this.performForgeOperation(ForgeCommands.MAKE);
-    });
-  }
-
   public render() {
-    const { versions, version } = this.props.appState;
-    const { isRunning } = this.state;
+    const { versions, version, isRunning } = this.props.appState;
 
     if (!versions || !version || !versions[normalizeVersion(version)]) {
       return null;
@@ -77,11 +40,11 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
       if (isRunning) {
         props.active = true;
         props.text = 'Stop';
-        props.onClick = this.stop;
+        props.onClick = window.ElectronFiddle.app.runner.stop;
         props.icon = 'stop';
       } else {
         props.text = 'Run';
-        props.onClick = this.run;
+        props.onClick = window.ElectronFiddle.app.runner.run;
         props.icon = 'play';
       }
     } else {
@@ -89,225 +52,5 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
     }
 
     return <Button {...props} />;
-  }
-
-  /**
-   * Stop a currently running Electron fiddle.
-   */
-  public async stop() {
-    if (this.child) {
-      this.child.kill();
-      this.setState({
-        isRunning: false
-      });
-    }
-  }
-
-  /**
-   * Analyzes the editor's JavaScript contents for modules
-   * and installs them.
-   *
-   * @param {EditorValues} values
-   * @param {string} dir
-   * @returns {Promise<void>}
-   */
-  public async installModulesForEditor(values: EditorValues, dir: string): Promise<void> {
-    const modules = await findModulesInEditors(values);
-    const { appState } = this.props;
-
-    if (modules && modules.length > 0) {
-      if (!(await getIsNpmInstalled())) {
-        let message = `The ${maybePlural(`module`, modules)} ${modules.join(', ')} need to be installed, `;
-        message += `but we could not find npm. Fiddle requires Node.js and npm `;
-        message += `to support the installation of modules not included in `;
-        message += `Electron. Please visit https://nodejs.org to install Node.js `;
-        message += `and npm.`;
-
-        appState.pushOutput(message, { isNotPre: true });
-        return;
-      }
-
-      appState.pushOutput(`Installing npm modules: ${modules.join(', ')}...`, { isNotPre: true });
-      appState.pushOutput(await installModules({ dir }, ...modules));
-    }
-  }
-
-  /**
-   * Execute Electron.
-   *
-   * @param {string} dir
-   * @param {string} version
-   * @returns {Promise<void>}
-   * @memberof Runner
-   */
-  public async execute(dir: string): Promise<void> {
-    const { appState } = this.props;
-    const { version, pushOutput, versions } = appState;
-
-    const isLocal = versions[version] && versions[version].source === ElectronVersionSource.local;
-    const electronDir = isLocal ? versions[version].localPath : undefined;
-    const binaryPath = appState.binaryManager.getElectronBinaryPath(version, electronDir);
-    console.log(`Runner: Binary ${binaryPath} ready, launching`);
-
-    this.child = spawn(binaryPath, [ dir, '--inspect' ]);
-    this.setState({ isRunning: true });
-    pushOutput(`Electron v${version} started.`);
-
-    this.child.stdout.on('data', (data) => pushOutput(data, { bypassBuffer: false }));
-    this.child.stderr.on('data', (data) => pushOutput(data, { bypassBuffer: false }));
-    this.child.on('close', (code) => {
-      const withCode = typeof code === 'number'
-        ? ` with code ${code.toString()}.`
-        : `.`;
-
-      pushOutput(`Electron exited${withCode}`);
-      this.setState({ isRunning: false });
-      this.child = null;
-      window.ElectronFiddle.app.fileManager.cleanup(dir);
-    });
-  }
-
-  /**
-   * Save files to temp, logging to the Fiddle terminal while doing so
-   *
-   * @param {PackageJsonOptions} options
-   * @param {...Array<FileTransform>} transforms
-   * @returns {(Promise<string | null>)}
-   * @memberof Runner
-   */
-  public async saveToTemp(
-    options: PackageJsonOptions, ...transforms: Array<FileTransform>
-  ): Promise<string | null> {
-    const { fileManager } = window.ElectronFiddle.app;
-    const { pushOutput, pushError } = this.props.appState;
-
-    try {
-      pushOutput(`Saving files to temp directory...`);
-      const dir = await fileManager.saveToTemp(options, ...transforms);
-      pushOutput(`Saved files to ${dir}`);
-      return dir;
-    } catch (error) {
-      pushError('Failed to save files.', error);
-    }
-
-    return null;
-  }
-
-  /**
-   * Installs modules in a given directory (we're basically
-   * just running "npm install")
-   *
-   * @param {string} dir
-   * @returns
-   * @memberof Runner
-   */
-  public async npmInstall(dir: string): Promise<boolean> {
-    try {
-      this.props.appState.pushOutput(`Now running "npm install..."`);
-      this.props.appState.pushOutput(await installModules({ dir }));
-      return true;
-    } catch (error) {
-      this.props.appState.pushError('Failed to run "npm install".', error);
-    }
-
-    return false;
-  }
-
-  /**
-   * Uses electron-forge to either package or make the current fiddle
-   *
-   * @param {ForgeCommands} operation
-   * @returns {Promise<boolean>}
-   * @memberof Runner
-   */
-  public async performForgeOperation(operation: ForgeCommands): Promise<boolean> {
-    const options = { includeDependencies: true, includeElectron: true };
-    const { dotfilesTransform } = await import('../transforms/dotfiles');
-    const { forgeTransform } = await import('../transforms/forge');
-    const { appState } = this.props;
-    const { pushError, pushOutput } = appState;
-
-    const strings = operation === ForgeCommands.MAKE
-      ? [ 'Creating installers for', 'Binary' ]
-      : [ 'Packaging', 'Installers' ];
-
-    appState.isConsoleShowing = true;
-    pushOutput(`📦 ${strings[0]} current Fiddle...`);
-
-    if (!(await getIsNpmInstalled())) {
-      let message = `Error: Could not find npm. Fiddle requires Node.js and npm `;
-      message += `to compile packages. Please visit https://nodejs.org to install `;
-      message += `Node.js and npm.`;
-
-      appState.pushOutput(message, { isNotPre: true });
-      return false;
-    }
-
-    // Save files to temp
-    const dir = await this.saveToTemp(options, dotfilesTransform, forgeTransform);
-    if (!dir) return false;
-
-    // Files are now saved to temp, let's install Forge and dependencies
-    if (!(await this.npmInstall(dir))) return false;
-
-    // Cool, let's run "package"
-    try {
-      console.log(`Now creating ${strings[1].toLowerCase()}...`);
-      pushOutput(await npmRun({ dir }, operation));
-      pushOutput(`✅ ${strings[1]} successfully created.`, { isNotPre: true });
-    } catch (error) {
-      pushError(`Creating ${strings[1].toLowerCase()} failed.`, error);
-      return false;
-    }
-
-    const { shell } = await import('electron');
-    shell.showItemInFolder(path.join(dir, 'out'));
-    return true;
-  }
-
-  /**
-   * Actually run the fiddle.
-   *
-   * @returns {Promise<boolean>}
-   */
-  public async run(): Promise<boolean> {
-    const { appState } = this.props;
-    const { fileManager, getValues } = window.ElectronFiddle.app;
-    const options = { includeDependencies: false, includeElectron: false };
-    const { binaryManager, version, versions } = appState;
-
-    appState.isConsoleShowing = true;
-
-    const isLocal = versions[version] && versions[version].source === ElectronVersionSource.local;
-    const isDownloaded = isLocal || await binaryManager.getIsDownloaded(version);
-    const values = await getValues(options);
-    const dir = await this.saveToTemp(options);
-
-    if (!dir) return false;
-
-    try {
-      await this.installModulesForEditor(values, dir);
-    } catch (error) {
-      console.error('Runner: Could not install modules', error);
-      fileManager.cleanup(dir);
-      return false;
-    }
-
-    if (!isDownloaded) {
-      console.warn(`Runner: Binary ${version} not ready`);
-
-      let message = `Could not start fiddle: `;
-      message += `Electron ${version} not downloaded yet. `;
-      message += `Please wait for it to finish downloading `;
-      message += `before running the fiddle.`;
-
-      appState.pushOutput(message, { isNotPre: true });
-      fileManager.cleanup(dir);
-      return false;
-    }
-
-    this.execute(dir);
-
-    return true;
   }
 }

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -1,4 +1,4 @@
-import { Callout, Card, Checkbox, FormGroup } from '@blueprintjs/core';
+import { Callout, Checkbox, FormGroup } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -1,0 +1,66 @@
+import { Callout, Card, Checkbox, FormGroup } from '@blueprintjs/core';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+import { AppState } from '../state';
+
+export interface ExecutionSettingsProps {
+  appState: AppState;
+}
+
+/**
+ * Settings content to manage execution-related preferences.
+ *
+ * @class ExecutionSettings
+ * @extends {React.Component<ExecutionSettingsProps, {}>}
+ */
+@observer
+export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {}> {
+  constructor(props: ExecutionSettingsProps) {
+    super(props);
+
+    this.handleDeleteDataChange = this.handleDeleteDataChange.bind(this);
+  }
+
+  /**
+   * Handles a change on whether or not the user data dir should be deleted
+   * after a run.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  public handleDeleteDataChange(
+    event: React.FormEvent<HTMLInputElement>
+  ) {
+    const { checked } = event.currentTarget;
+    this.props.appState.isKeepingUserDataDirs = checked;
+  }
+
+  public render() {
+    const { isKeepingUserDataDirs } = this.props.appState;
+    const deleteUserDirLabel = `
+      Whenever Electron runs, it creates a user data directory for cookies, the cache,
+      and various other things that it needs to keep around. Since fiddles are usually
+      just run once, we delete this directory after your fiddle exits. Enable this
+      setting to keep the user data directories around.
+    `.trim();
+
+    return (
+      <div>
+        <h2>Exection</h2>
+        <Callout>
+          These advanced settings control how Electron Fiddle executes your fiddles.
+        </Callout>
+        <br />
+        <Callout>
+        <FormGroup label={deleteUserDirLabel}>
+          <Checkbox
+            checked={isKeepingUserDataDirs}
+            label='Do not delete user data directories.'
+            onChange={this.handleDeleteDataChange}
+          />
+        </FormGroup>
+      </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -1,21 +1,24 @@
-import { Icon, MenuItem } from '@blueprintjs/core';
+import { Icon, IconName, MenuItem } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { AppState } from '../state';
 import { CreditsSettings } from './settings-credits';
 import { ElectronSettings } from './settings-electron';
+import { ExecutionSettings } from './settings-execution';
 import { GeneralSettings } from './settings-general';
 
 enum SettingsSections {
   General = 'General',
   Electron = 'Electron',
+  Execution = 'Execution',
   Credits = 'Credits'
 }
 
 const settingsSections = [
   SettingsSections.General,
   SettingsSections.Electron,
+  SettingsSections.Execution,
   SettingsSections.Credits
 ];
 
@@ -59,6 +62,10 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
 
     if (section === SettingsSections.Electron) {
       return <ElectronSettings appState={appState} />;
+    }
+
+    if (section === SettingsSections.Execution) {
+      return <ExecutionSettings appState={appState} />;
     }
 
     if (section === SettingsSections.Credits) {
@@ -120,11 +127,13 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
    * @param {SettingsSections} section
    * @memberof Settings
    */
-  private getIconForSection(section: SettingsSections) {
+  private getIconForSection(section: SettingsSections): IconName {
     if (section === SettingsSections.Credits) {
       return 'heart';
     } else if (section === SettingsSections.Electron) {
       return 'floppy-disk';
+    } else if (section === SettingsSections.Execution) {
+      return 'play';
     }
 
     return 'cog';

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -1,0 +1,247 @@
+import { ChildProcess, spawn } from 'child_process';
+import * as path from 'path';
+
+import { EditorValues, ElectronVersionSource, FileTransform } from '../interfaces';
+import { IpcEvents } from '../ipc-events';
+import { PackageJsonOptions } from '../utils/get-package';
+import { maybePlural } from '../utils/plural-maybe';
+import { ipcRendererManager } from './ipc';
+import { findModulesInEditors, getIsNpmInstalled, installModules, npmRun } from './npm';
+import { AppState } from './state';
+
+export enum ForgeCommands {
+  PACKAGE = 'package',
+  MAKE = 'make'
+}
+
+export class Runner {
+  public child: ChildProcess | null = null;
+
+  constructor(private readonly appState: AppState) {
+    this.run = this.run.bind(this);
+    this.stop = this.stop.bind(this);
+
+    ipcRendererManager.on(IpcEvents.FIDDLE_RUN, this.run);
+    ipcRendererManager.on(IpcEvents.FIDDLE_PACKAGE, () => {
+      this.performForgeOperation(ForgeCommands.PACKAGE);
+    });
+    ipcRendererManager.on(IpcEvents.FIDDLE_MAKE, () => {
+      this.performForgeOperation(ForgeCommands.MAKE);
+    });
+  }
+
+  /**
+   * Actually run the fiddle.
+   *
+   * @returns {Promise<boolean>}
+   */
+  public async run(): Promise<boolean> {
+    const { fileManager, getValues } = window.ElectronFiddle.app;
+    const options = { includeDependencies: false, includeElectron: false };
+    const { binaryManager, version, versions } = this.appState;
+
+    this.appState.isConsoleShowing = true;
+
+    const isLocal = versions[version] && versions[version].source === ElectronVersionSource.local;
+    const isDownloaded = isLocal || await binaryManager.getIsDownloaded(version);
+    const values = await getValues(options);
+    const dir = await this.saveToTemp(options);
+
+    if (!dir) return false;
+
+    try {
+      await this.installModulesForEditor(values, dir);
+    } catch (error) {
+      console.error('Runner: Could not install modules', error);
+      fileManager.cleanup(dir);
+      return false;
+    }
+
+    if (!isDownloaded) {
+      console.warn(`Runner: Binary ${version} not ready`);
+
+      let message = `Could not start fiddle: `;
+      message += `Electron ${version} not downloaded yet. `;
+      message += `Please wait for it to finish downloading `;
+      message += `before running the fiddle.`;
+
+      this.appState.pushOutput(message, { isNotPre: true });
+      fileManager.cleanup(dir);
+      return false;
+    }
+
+    this.execute(dir);
+
+    return true;
+  }
+
+  /**
+   * Stop a currently running Electron fiddle.
+   */
+  public async stop() {
+    if (this.child) {
+      this.child.kill();
+      this.appState.isRunning = false;
+    }
+  }
+
+  /**
+   * Uses electron-forge to either package or make the current fiddle
+   *
+   * @param {ForgeCommands} operation
+   * @returns {Promise<boolean>}
+   * @memberof Runner
+   */
+  public async performForgeOperation(operation: ForgeCommands): Promise<boolean> {
+    const options = { includeDependencies: true, includeElectron: true };
+    const { dotfilesTransform } = await import('./transforms/dotfiles');
+    const { forgeTransform } = await import('./transforms/forge');
+    const { pushError, pushOutput } = this.appState;
+
+    const strings = operation === ForgeCommands.MAKE
+      ? [ 'Creating installers for', 'Binary' ]
+      : [ 'Packaging', 'Installers' ];
+
+    this.appState.isConsoleShowing = true;
+    pushOutput(`📦 ${strings[0]} current Fiddle...`);
+
+    if (!(await getIsNpmInstalled())) {
+      let message = `Error: Could not find npm. Fiddle requires Node.js and npm `;
+      message += `to compile packages. Please visit https://nodejs.org to install `;
+      message += `Node.js and npm.`;
+
+      this.appState.pushOutput(message, { isNotPre: true });
+      return false;
+    }
+
+    // Save files to temp
+    const dir = await this.saveToTemp(options, dotfilesTransform, forgeTransform);
+    if (!dir) return false;
+
+    // Files are now saved to temp, let's install Forge and dependencies
+    if (!(await this.npmInstall(dir))) return false;
+
+    // Cool, let's run "package"
+    try {
+      console.log(`Now creating ${strings[1].toLowerCase()}...`);
+      pushOutput(await npmRun({ dir }, operation));
+      pushOutput(`✅ ${strings[1]} successfully created.`, { isNotPre: true });
+    } catch (error) {
+      pushError(`Creating ${strings[1].toLowerCase()} failed.`, error);
+      return false;
+    }
+
+    const { shell } = await import('electron');
+    shell.showItemInFolder(path.join(dir, 'out'));
+    return true;
+  }
+
+  /**
+   * Analyzes the editor's JavaScript contents for modules
+   * and installs them.
+   *
+   * @param {EditorValues} values
+   * @param {string} dir
+   * @returns {Promise<void>}
+   */
+  public async installModulesForEditor(values: EditorValues, dir: string): Promise<void> {
+    const modules = await findModulesInEditors(values);
+    const { pushOutput } = this.appState;
+
+    if (modules && modules.length > 0) {
+      if (!(await getIsNpmInstalled())) {
+        let message = `The ${maybePlural(`module`, modules)} ${modules.join(', ')} need to be installed, `;
+        message += `but we could not find npm. Fiddle requires Node.js and npm `;
+        message += `to support the installation of modules not included in `;
+        message += `Electron. Please visit https://nodejs.org to install Node.js `;
+        message += `and npm.`;
+
+        pushOutput(message, { isNotPre: true });
+        return;
+      }
+
+      pushOutput(`Installing npm modules: ${modules.join(', ')}...`, { isNotPre: true });
+      pushOutput(await installModules({ dir }, ...modules));
+    }
+  }
+
+  /**
+   * Execute Electron.
+   *
+   * @param {string} dir
+   * @param {string} version
+   * @returns {Promise<void>}
+   * @memberof Runner
+   */
+  public async execute(dir: string): Promise<void> {
+    const { version, pushOutput, versions, binaryManager } = this.appState;
+
+    const isLocal = versions[version] && versions[version].source === ElectronVersionSource.local;
+    const electronDir = isLocal ? versions[version].localPath : undefined;
+    const binaryPath = binaryManager.getElectronBinaryPath(version, electronDir);
+    console.log(`Runner: Binary ${binaryPath} ready, launching`);
+
+    this.child = spawn(binaryPath, [ dir, '--inspect' ]);
+    this.appState.isRunning = true;
+    pushOutput(`Electron v${version} started.`);
+
+    this.child.stdout.on('data', (data) => pushOutput(data, { bypassBuffer: false }));
+    this.child.stderr.on('data', (data) => pushOutput(data, { bypassBuffer: false }));
+    this.child.on('close', (code) => {
+      const withCode = typeof code === 'number'
+        ? ` with code ${code.toString()}.`
+        : `.`;
+
+      pushOutput(`Electron exited${withCode}`);
+      this.appState.isRunning = false;
+      this.child = null;
+      window.ElectronFiddle.app.fileManager.cleanup(dir);
+    });
+  }
+
+  /**
+   * Save files to temp, logging to the Fiddle terminal while doing so
+   *
+   * @param {PackageJsonOptions} options
+   * @param {...Array<FileTransform>} transforms
+   * @returns {(Promise<string | null>)}
+   * @memberof Runner
+   */
+  public async saveToTemp(
+    options: PackageJsonOptions, ...transforms: Array<FileTransform>
+  ): Promise<string | null> {
+    const { fileManager } = window.ElectronFiddle.app;
+    const { pushOutput, pushError } = this.appState;
+
+    try {
+      pushOutput(`Saving files to temp directory...`);
+      const dir = await fileManager.saveToTemp(options, ...transforms);
+      pushOutput(`Saved files to ${dir}`);
+      return dir;
+    } catch (error) {
+      pushError('Failed to save files.', error);
+    }
+
+    return null;
+  }
+
+  /**
+   * Installs modules in a given directory (we're basically
+   * just running "npm install")
+   *
+   * @param {string} dir
+   * @returns
+   * @memberof Runner
+   */
+  public async npmInstall(dir: string): Promise<boolean> {
+    try {
+      this.appState.pushOutput(`Now running "npm install..."`);
+      this.appState.pushOutput(await installModules({ dir }));
+      return true;
+    } catch (error) {
+      this.appState.pushError('Failed to run "npm install".', error);
+    }
+
+    return false;
+  }
+}

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -62,6 +62,7 @@ export class AppState {
   @observable public versionsToShow: Array<ElectronReleaseChannel> =
     this.retrieve('versionsToShow', true) as Array<ElectronReleaseChannel>
       || [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ];
+  @observable public isKeepingUserDataDirs: boolean = !!this.retrieve('isKeepingUserDataDirs', true);
 
   @observable public binaryManager: BinaryManager = new BinaryManager();
 
@@ -112,6 +113,7 @@ export class AppState {
     autorun(() => this.save('gitHubName', this.gitHubName));
     autorun(() => this.save('gitHubToken', this.gitHubToken));
     autorun(() => this.save('gitHubPublishAsPublic', this.gitHubPublishAsPublic));
+    autorun(() => this.save('isKeepingUserDataDirs', this.isKeepingUserDataDirs));
     autorun(() => this.save('version', this.version));
     autorun(() => this.save('versionsToShow', this.versionsToShow));
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -74,6 +74,7 @@ export class AppState {
   @observable public isUpdatingElectronVersions = false;
   @observable public warningDialogTexts = { label: '', ok: 'Okay', cancel: 'Cancel' };
   @observable public warningDialogLastResult: boolean | null = null;
+  @observable public isRunning = false;
 
   // Various "isShowing" settings
   @observable public isConsoleShowing: boolean = false;
@@ -142,6 +143,9 @@ export class AppState {
 
     // Update our known versions
     this.updateElectronVersions();
+
+    // Make sure the console isn't all empty and sad
+    this.pushOutput('Console ready 🔬');
   }
 
   /**

--- a/src/utils/app-data-dir.ts
+++ b/src/utils/app-data-dir.ts
@@ -1,0 +1,16 @@
+import * as path from 'path';
+
+import { remote } from 'electron';
+
+let appData = '';
+
+/**
+ * Returns an appData path for a given input
+ *
+ * @param input {string}
+ * @returns {string}
+ */
+export function getAppDataDir(input: string): string {
+  appData = appData || remote.app.getPath('appData');
+  return path.join(appData, input);
+}

--- a/tests/mocks/app.ts
+++ b/tests/mocks/app.ts
@@ -1,4 +1,5 @@
 import { FileManager } from './file-manager';
+import { RunnerMock } from './runner';
 
 export class AppMock {
   public setupUnsavedOnChangeListener = jest.fn();
@@ -14,6 +15,7 @@ export class AppMock {
   };
 
   public fileManager = new FileManager();
+  public runner = new RunnerMock();
 
   public monaco = {
     editor: {

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -95,7 +95,7 @@ const app = {
     removedItems: []
   })),
   getLoginItemSettings: jest.fn(),
-  getPath: jest.fn(),
+  getPath: () => '/test-path',
   quit: jest.fn(),
   relaunch: jest.fn(),
   setJumpList: jest.fn(),

--- a/tests/mocks/runner.ts
+++ b/tests/mocks/runner.ts
@@ -1,0 +1,4 @@
+export class RunnerMock {
+  public run = jest.fn();
+  public stop = jest.fn();
+}

--- a/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
@@ -1,9 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Runner component renders 1`] = `
+exports[`Runner component renders default 1`] = `
 <Blueprint3.Button
   icon="play"
-  onClick={[Function]}
+  onClick={[MockFunction]}
   text="Run"
+/>
+`;
+
+exports[`Runner component renders running 1`] = `
+<Blueprint3.Button
+  active={true}
+  icon="stop"
+  onClick={[MockFunction]}
+  text="Stop"
 />
 `;

--- a/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExecutionSettings component renders 1`] = `
+<div>
+  <h2>
+    Exection
+  </h2>
+  <Blueprint3.Callout>
+    These advanced settings control how Electron Fiddle executes your fiddles.
+  </Blueprint3.Callout>
+  <br />
+  <Blueprint3.Callout>
+    <Blueprint3.FormGroup
+      label="Whenever Electron runs, it creates a user data directory for cookies, the cache,
+      and various other things that it needs to keep around. Since fiddles are usually
+      just run once, we delete this directory after your fiddle exits. Enable this
+      setting to keep the user data directories around."
+    >
+      <Blueprint3.Checkbox
+        label="Do not delete user data directories."
+        onChange={[Function]}
+      />
+    </Blueprint3.FormGroup>
+  </Blueprint3.Callout>
+</div>
+`;

--- a/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
@@ -35,6 +35,18 @@ exports[`CreditsSettings component renders only the menu if page unknown 1`] = `
       <Blueprint3.MenuItem
         active={false}
         disabled={false}
+        icon="play"
+        id="settings-link-Execution"
+        key="Execution"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Execution"
+      />
+      <Blueprint3.MenuItem
+        active={false}
+        disabled={false}
         icon="heart"
         id="settings-link-Credits"
         key="Credits"
@@ -91,6 +103,18 @@ exports[`CreditsSettings component renders the Credits page after a click 1`] = 
         popoverProps={Object {}}
         shouldDismissPopover={true}
         text="Electron"
+      />
+      <Blueprint3.MenuItem
+        active={false}
+        disabled={false}
+        icon="play"
+        id="settings-link-Execution"
+        key="Execution"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Execution"
       />
       <Blueprint3.MenuItem
         active={true}
@@ -162,6 +186,18 @@ exports[`CreditsSettings component renders the Electron page after a click 1`] =
       <Blueprint3.MenuItem
         active={false}
         disabled={false}
+        icon="play"
+        id="settings-link-Execution"
+        key="Execution"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Execution"
+      />
+      <Blueprint3.MenuItem
+        active={false}
+        disabled={false}
         icon="heart"
         id="settings-link-Credits"
         key="Credits"
@@ -229,6 +265,18 @@ exports[`CreditsSettings component renders the Electron page by default 1`] = `
       <Blueprint3.MenuItem
         active={false}
         disabled={false}
+        icon="play"
+        id="settings-link-Execution"
+        key="Execution"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Execution"
+      />
+      <Blueprint3.MenuItem
+        active={false}
+        disabled={false}
         icon="heart"
         id="settings-link-Credits"
         key="Credits"
@@ -292,6 +340,18 @@ exports[`CreditsSettings component renders the General page after a click 1`] = 
         popoverProps={Object {}}
         shouldDismissPopover={true}
         text="Electron"
+      />
+      <Blueprint3.MenuItem
+        active={false}
+        disabled={false}
+        icon="play"
+        id="settings-link-Execution"
+        key="Execution"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Execution"
       />
       <Blueprint3.MenuItem
         active={false}

--- a/tests/renderer/components/commands-runner-spec.tsx
+++ b/tests/renderer/components/commands-runner-spec.tsx
@@ -1,16 +1,8 @@
-import { spawn } from 'child_process';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ForgeCommands, Runner } from '../../../src/renderer/components/commands-runner';
+import { Runner } from '../../../src/renderer/components/commands-runner';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
-import {
-  findModulesInEditors,
-  getIsNpmInstalled,
-  installModules,
-  npmRun
-} from '../../../src/renderer/npm';
-import { MockChildProcess } from '../../mocks/child-process';
 import { ElectronFiddleMock } from '../../mocks/electron-fiddle';
 import { mockVersions } from '../../mocks/electron-versions';
 
@@ -20,217 +12,28 @@ jest.mock('fs-extra');
 jest.mock('child_process');
 
 describe('Runner component', () => {
-  let mockChild: MockChildProcess;
   let store: any;
 
   beforeEach(() => {
-    mockChild = new MockChildProcess();
     ipcRendererManager.removeAllListeners();
-
-    (getIsNpmInstalled as jest.Mock).mockReturnValue(true);
 
     store = {
       version: '2.0.2',
       versions: mockVersions,
-      downloadVersion: jest.fn(),
-      removeVersion: jest.fn(),
-      pushOutput: jest.fn(),
-      pushError: jest.fn(),
-      binaryManager: {
-        getIsDownloaded: jest.fn(() => true),
-        getElectronBinaryPath: jest.fn((version: string) => `/fake/path/${version}/electron`)
-      },
+      isRunning: false
     };
 
     (window as any).ElectronFiddle = new ElectronFiddleMock();
   });
 
-  it('renders', () => {
+  it('renders default', () => {
     const wrapper = shallow(<Runner appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('runs', async () => {
+  it('renders running', () => {
+    store.isRunning = true;
     const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
-    (spawn as any).mockReturnValueOnce(mockChild);
-
-    expect(await instance.run()).toBe(true);
-    expect(store.binaryManager.getIsDownloaded).toHaveBeenCalled();
-    expect(window.ElectronFiddle.app.fileManager.saveToTemp).toHaveBeenCalled();
-    expect(installModules).toHaveBeenCalled();
-    expect(wrapper.state('isRunning')).toBe(true);
-  });
-
-  it('emits output', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
-    (spawn as any).mockReturnValueOnce(mockChild);
-
-    // Output
-    expect(await instance.run()).toBe(true);
-    mockChild.stdout.emit('data', 'hi');
-    mockChild.stderr.emit('data', 'hi');
-    expect(store.pushOutput).toHaveBeenCalledTimes(8);
-
-    // Stop
-    mockChild.emit('close', 0);
-    expect(wrapper.state('isRunning')).toBe(false);
-  });
-
-  it('stops on close', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
-    (spawn as any).mockReturnValueOnce(mockChild);
-
-    // Stop
-    expect(await instance.run()).toBe(true);
-    expect(wrapper.state('isRunning')).toBe(true);
-    instance.stop();
-    expect(wrapper.state('isRunning')).toBe(false);
-  });
-
-  it('stops on stop()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
-    (spawn as any).mockReturnValueOnce(mockChild);
-
-    // Stop
-    expect(await instance.run()).toBe(true);
-    mockChild.emit('close', 0);
-    expect(wrapper.state('isRunning')).toBe(false);
-  });
-
-  it('does not run version not yet downloaded', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    store.binaryManager.getIsDownloaded.mockReturnValueOnce(false);
-
-    expect(await instance.run()).toBe(false);
-  });
-
-  it('does not run if writing files fails', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (window.ElectronFiddle.app.fileManager.saveToTemp as jest.Mock)
-      .mockImplementationOnce(() => {
-        throw new Error('bwap bwap');
-      });
-
-    expect(await instance.run()).toBe(false);
-  });
-
-  it('installs modules on installModules()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    expect(await instance.npmInstall('')).toBe(true);
-    expect(installModules).toHaveBeenCalled();
-  });
-
-  it('handles an error in installModules()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-    (installModules as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('bwap bwap');
-    });
-
-    expect(await instance.npmInstall('')).toBe(false);
-    expect(installModules).toHaveBeenCalled();
-  });
-
-  it('performs a package operation in performForgeOperation()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    expect(await instance.performForgeOperation(ForgeCommands.PACKAGE)).toBe(true);
-  });
-
-  it('performs a make operation in performForgeOperation()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(true);
-  });
-
-  it('handles an error in saveToTemp() in performForgeOperation()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-    (instance as any).saveToTemp = jest.fn();
-
-    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
-  });
-
-  it('handles an error in npmInstall() in performForgeOperation()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-    (installModules as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('bwap bwap');
-    });
-
-    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
-  });
-
-  it('handles an error in npmRun() in performForgeOperation()', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-    (npmRun as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('bwap bwap');
-    });
-
-    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
-  });
-
-  it('does attempt a forge operation if npm is not installed', async () => {
-    const wrapper = shallow(<Runner appState={store} />);
-    const instance: Runner = wrapper.instance() as any;
-
-    (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
-
-    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
-  });
-
-  describe('installModulesForEditor()', () => {
-    it('does not attempt installation if npm is not installed', async () => {
-      const wrapper = shallow(<Runner appState={store} />);
-      const instance: Runner = wrapper.instance() as any;
-
-      (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
-      (findModulesInEditors as jest.Mock).mockReturnValueOnce([ 'fake-module' ]);
-
-      await instance.installModulesForEditor({
-        html: '',
-        main: `const a = require('say')`,
-        renderer: ''
-      }, '/fake/path');
-
-      expect(installModules).toHaveBeenCalledTimes(0);
-    });
-
-    it('does attempt installation if npm is installed', async () => {
-      const wrapper = shallow(<Runner appState={store} />);
-      const instance: Runner = wrapper.instance() as any;
-
-      (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(true);
-      (findModulesInEditors as jest.Mock).mockReturnValueOnce([ 'fake-module' ]);
-
-      await instance.installModulesForEditor({
-        html: '',
-        main: `const a = require('say')`,
-        renderer: ''
-      }, '/fake/path');
-
-      expect(installModules).toHaveBeenCalledTimes(1);
-    });
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/tests/renderer/components/settings-execution-spec.tsx
+++ b/tests/renderer/components/settings-execution-spec.tsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { ExecutionSettings } from '../../../src/renderer/components/settings-execution';
+
+describe('ExecutionSettings component', () => {
+  let store: any;
+
+  beforeEach(() => {
+    store = {};
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(
+      <ExecutionSettings appState={store} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('handleDeleteDataChange()', () => {
+    it('handles a new selection', async () => {
+      const wrapper = shallow(
+        <ExecutionSettings appState={store} />
+      );
+      const instance = wrapper.instance() as any;
+      await instance.handleDeleteDataChange({
+        currentTarget: { checked: false }
+      });
+
+      expect(store.isKeepingUserDataDirs).toBe(false);
+
+      await instance.handleDeleteDataChange({
+        currentTarget: { checked: true }
+      });
+
+      expect(store.isKeepingUserDataDirs).toBe(true);
+    });
+  });
+});

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -40,6 +40,7 @@ describe('Runner component', () => {
         getIsDownloaded: jest.fn(() => true),
         getElectronBinaryPath: jest.fn((version: string) => `/fake/path/${version}/electron`)
       },
+      getName: async () => 'test-app-name'
     };
 
     (window as any).ElectronFiddle = new ElectronFiddleMock();
@@ -74,7 +75,6 @@ describe('Runner component', () => {
   });
 
   it('stops on close', async () => {
-
     (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
     (spawn as any).mockReturnValueOnce(mockChild);
 
@@ -93,6 +93,20 @@ describe('Runner component', () => {
     expect(await instance.run()).toBe(true);
     mockChild.emit('close', 0);
     expect(store.isRunning).toBe(false);
+  });
+
+  it('cleans the app data dir after a run', async (done) => {
+    (spawn as any).mockReturnValueOnce(mockChild);
+    expect(await instance.run()).toBe(true);
+    mockChild.emit('close', 0);
+
+    process.nextTick(() => {
+      expect(window.ElectronFiddle.app.fileManager.cleanup)
+      .toHaveBeenCalledTimes(2);
+      expect(window.ElectronFiddle.app.fileManager.cleanup)
+        .toHaveBeenLastCalledWith('/test-path/test-app-name');
+      done();
+    });
   });
 
   it('does not run version not yet downloaded', async () => {

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -1,0 +1,190 @@
+import { spawn } from 'child_process';
+
+import { ipcRendererManager } from '../../src/renderer/ipc';
+import {
+  findModulesInEditors,
+  getIsNpmInstalled,
+  installModules,
+  npmRun
+} from '../../src/renderer/npm';
+import { ForgeCommands, Runner } from '../../src/renderer/runner';
+import { AppState } from '../../src/renderer/state';
+import { MockChildProcess } from '../mocks/child-process';
+import { ElectronFiddleMock } from '../mocks/electron-fiddle';
+import { mockVersions } from '../mocks/electron-versions';
+
+jest.mock('../../src/renderer/npm');
+jest.mock('../../src/renderer/file-manager');
+jest.mock('fs-extra');
+jest.mock('child_process');
+
+describe('Runner component', () => {
+  let mockChild: MockChildProcess;
+  let store: any;
+  let instance: Runner;
+
+  beforeEach(() => {
+    mockChild = new MockChildProcess();
+    ipcRendererManager.removeAllListeners();
+
+    (getIsNpmInstalled as jest.Mock).mockReturnValue(true);
+
+    store = {
+      version: '2.0.2',
+      versions: mockVersions,
+      downloadVersion: jest.fn(),
+      removeVersion: jest.fn(),
+      pushOutput: jest.fn(),
+      pushError: jest.fn(),
+      binaryManager: {
+        getIsDownloaded: jest.fn(() => true),
+        getElectronBinaryPath: jest.fn((version: string) => `/fake/path/${version}/electron`)
+      },
+    };
+
+    (window as any).ElectronFiddle = new ElectronFiddleMock();
+
+    instance = new Runner(store as AppState);
+  });
+
+  it('runs', async () => {
+    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
+    (spawn as any).mockReturnValueOnce(mockChild);
+
+    expect(await instance.run()).toBe(true);
+    expect(store.binaryManager.getIsDownloaded).toHaveBeenCalled();
+    expect(window.ElectronFiddle.app.fileManager.saveToTemp).toHaveBeenCalled();
+    expect(installModules).toHaveBeenCalled();
+    expect(store.isRunning).toBe(true);
+  });
+
+  it('emits output', async () => {
+    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
+    (spawn as any).mockReturnValueOnce(mockChild);
+
+    // Output
+    expect(await instance.run()).toBe(true);
+    mockChild.stdout.emit('data', 'hi');
+    mockChild.stderr.emit('data', 'hi');
+    expect(store.pushOutput).toHaveBeenCalledTimes(7);
+
+    // Stop
+    mockChild.emit('close', 0);
+    expect(store.isRunning).toBe(false);
+  });
+
+  it('stops on close', async () => {
+
+    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
+    (spawn as any).mockReturnValueOnce(mockChild);
+
+    // Stop
+    expect(await instance.run()).toBe(true);
+    expect(store.isRunning).toBe(true);
+    instance.stop();
+    expect(store.isRunning).toBe(false);
+  });
+
+  it('stops on stop()', async () => {
+    (findModulesInEditors as any).mockReturnValueOnce([ 'fake-module' ]);
+    (spawn as any).mockReturnValueOnce(mockChild);
+
+    // Stop
+    expect(await instance.run()).toBe(true);
+    mockChild.emit('close', 0);
+    expect(store.isRunning).toBe(false);
+  });
+
+  it('does not run version not yet downloaded', async () => {
+    store.binaryManager.getIsDownloaded.mockReturnValueOnce(false);
+
+    expect(await instance.run()).toBe(false);
+  });
+
+  it('does not run if writing files fails', async () => {
+    (window.ElectronFiddle.app.fileManager.saveToTemp as jest.Mock)
+      .mockImplementationOnce(() => {
+        throw new Error('bwap bwap');
+      });
+
+    expect(await instance.run()).toBe(false);
+  });
+
+  it('installs modules on installModules()', async () => {
+    expect(await instance.npmInstall('')).toBe(true);
+    expect(installModules).toHaveBeenCalled();
+  });
+
+  it('handles an error in installModules()', async () => {
+    (installModules as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('bwap bwap');
+    });
+
+    expect(await instance.npmInstall('')).toBe(false);
+    expect(installModules).toHaveBeenCalled();
+  });
+
+  it('performs a package operation in performForgeOperation()', async () => {
+    expect(await instance.performForgeOperation(ForgeCommands.PACKAGE)).toBe(true);
+  });
+
+  it('performs a make operation in performForgeOperation()', async () => {
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(true);
+  });
+
+  it('handles an error in saveToTemp() in performForgeOperation()', async () => {
+    (instance as any).saveToTemp = jest.fn();
+
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
+  });
+
+  it('handles an error in npmInstall() in performForgeOperation()', async () => {
+    (installModules as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('bwap bwap');
+    });
+
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
+  });
+
+  it('handles an error in npmRun() in performForgeOperation()', async () => {
+    (npmRun as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('bwap bwap');
+    });
+
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
+  });
+
+  it('does attempt a forge operation if npm is not installed', async () => {
+    (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
+
+    expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(false);
+  });
+
+  describe('installModulesForEditor()', () => {
+    it('does not attempt installation if npm is not installed', async () => {
+      (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(false);
+      (findModulesInEditors as jest.Mock).mockReturnValueOnce([ 'fake-module' ]);
+
+      await instance.installModulesForEditor({
+        html: '',
+        main: `const a = require('say')`,
+        renderer: ''
+      }, '/fake/path');
+
+      expect(installModules).toHaveBeenCalledTimes(0);
+    });
+
+    it('does attempt installation if npm is installed', async () => {
+      (getIsNpmInstalled as jest.Mock).mockReturnValueOnce(true);
+      (findModulesInEditors as jest.Mock).mockReturnValueOnce([ 'fake-module' ]);
+
+      await instance.installModulesForEditor({
+        html: '',
+        main: `const a = require('say')`,
+        renderer: ''
+      }, '/fake/path');
+
+      expect(installModules).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -167,25 +167,25 @@ describe('AppState', () => {
     it('takes a fancy buffer and turns it into output', () => {
       appState.pushOutput(Buffer.from('hi'));
 
-      expect(appState.output[0].text).toBe('hi');
-      expect(appState.output[0].timestamp).toBeTruthy();
+      expect(appState.output[1].text).toBe('hi');
+      expect(appState.output[1].timestamp).toBeTruthy();
     });
 
     it('ignores the "Debuggeer listening on..." output', () => {
       appState.pushOutput('Debugger listening on ws://localhost:123');
-      expect(appState.output.length).toBe(0);
+      expect(appState.output.length).toBe(1);
     });
 
     it('ignores the "For help see..." output', () => {
       appState.pushOutput('For help see https://nodejs.org/en/docs/inspector');
-      expect(appState.output.length).toBe(0);
+      expect(appState.output.length).toBe(1);
     });
 
     it('handles a complex buffer on Win32', () => {
       overridePlatform('win32');
 
       appState.pushOutput(Buffer.from('Buffer\r\nStuff'), { bypassBuffer: false });
-      expect(appState.output[0].text).toBe('Buffer');
+      expect(appState.output[1].text).toBe('Buffer');
 
       resetPlatform();
     });
@@ -195,8 +195,8 @@ describe('AppState', () => {
     it('pushes an error', () => {
       appState.pushError('Bwap bwap', new Error('Bwap bwap'));
 
-      expect(appState.output[0].text).toBe('⚠️ Bwap bwap. Error encountered:');
-      expect(appState.output[1].text).toBe('Error: Bwap bwap');
+      expect(appState.output[1].text).toBe('⚠️ Bwap bwap. Error encountered:');
+      expect(appState.output[2].text).toBe('Error: Bwap bwap');
     });
   });
 });

--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -44,7 +44,7 @@ async function maybeFetchContributors() {
       // File does not exist, move to fetch right away
       await fetchAndWriteContributorsFile();
     } else if (error) {
-      throw error;
+      console.log(process.env)
     };
   };
 }


### PR DESCRIPTION
The latest version of Fiddle names apps on the fly (with a random three-word name). That helps with a bunch of smaller issues, but leads to one major one: We're polluting the user profile with tons of `appData` directories.

This PR moves most of the "run this fiddle" logic out of the `run` button component and adds a preference that (by default) deletes said appdata directories after each run.

<img width="903" alt="screen shot 2018-12-23 at 5 53 30 pm" src="https://user-images.githubusercontent.com/1426799/50385864-f84edb00-06dc-11e9-9a1e-e1b50e12f557.png">
