### PR TITLE
ci: Allow AppVeyor to codesign

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "8"
+    - nodejs_version: ""
 
 init:
 - git config --global core.symlinks true
@@ -22,12 +22,17 @@ install:
 cache:
   - '%APPDATA%\npm-cache -> appveyor.yml'
 
+artifacts:
+  - path: out/make/
+    name: MyApp
+
 test_script:
   - node --version
   - npm --version
   - npm run lint
   - npm run test
-  - if %APPVEYOR_REPO_TAG% EQU false npm run make
 
 build_script:
+  - if %APPVEYOR_REPO_TAG% EQU false npm run make
   - if %APPVEYOR_REPO_TAG% EQU true npm run publish
+  - ps: Tree ./out/make /F

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: ""
+    - nodejs_version: "10"
 
 init:
 - git config --global core.symlinks true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,17 +22,17 @@ install:
 cache:
   - '%APPDATA%\npm-cache -> appveyor.yml'
 
-artifacts:
-  - path: out/make/
-    name: MyApp
-
 test_script:
   - node --version
   - npm --version
   - npm run lint
   - npm run test
 
+artifacts:
+  - path: 'out\make\squirrel.windows\**\*.exe'
+
 build_script:
   - if %APPVEYOR_REPO_TAG% EQU false npm run make
   - if %APPVEYOR_REPO_TAG% EQU true npm run publish
+  - if %APPVEYOR_REPO_TAG% EQU true npm run publish -- --arch=ia32
   - ps: Tree ./out/make /F

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,18 @@ environment:
     - nodejs_version: "8"
 
 init:
-  - git config --global core.symlinks true
+- git config --global core.symlinks true
 
 install:
+  # Setup the code signing certificate
+  - ps: >-
+      if (Test-Path $env:WINDOWS_CERTIFICATE_P12) {
+        $filename = Convert-Path .\cert.p12
+        $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
+        [IO.File]::WriteAllBytes($filename, $bytes)
+
+        $env:WINDOWS_CERTIFICATE_FILE = $filename
+      }
   - ps: Install-Product node $env:nodejs_version x64
   - node --version
   - npm ci


### PR DESCRIPTION
Walking further down the path of enabling a Fiddle release from a phone, if need be: This PR enables AppVeyor to create signed builds.