### PR TITLE
ci: Properly find Windows codesign certificate

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ init:
 install:
   # Setup the code signing certificate
   - ps: >-
-      if (Test-Path $env:WINDOWS_CERTIFICATE_P12) {
+      if (Test-Path Env:\WINDOWS_CERTIFICATE_P12) {
         $filename = Convert-Path .\cert.p12
         $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
         [IO.File]::WriteAllBytes($filename, $bytes)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,8 @@ install:
   # Setup the code signing certificate
   - ps: >-
       if (Test-Path Env:\WINDOWS_CERTIFICATE_P12) {
-        $filename = Convert-Path .\cert.p12
+        $workingDirectory = Convert-Path (Resolve-Path -path ".")
+        $filename = "$workingDirectory\cert.p12"
         $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
         [IO.File]::WriteAllBytes($filename, $bytes)
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,6 @@ install:
         $filename = Convert-Path .\cert.p12
         $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
         [IO.File]::WriteAllBytes($filename, $bytes)
-
-        $env:WINDOWS_CERTIFICATE_FILE = $filename
       }
   - ps: Install-Product node $env:nodejs_version x64
   - node --version

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,7 @@
 /* tslint:disable */
 
 const path = require('path')
+const fs = require('fs')
 const packageJson = require('./package.json')
 
 const { version } = packageJson
@@ -39,6 +40,14 @@ module.exports = {
       name: '@electron-forge/maker-squirrel',
       platforms: ['win32'],
       config: (arch) => {
+        const certificateFile = process.env.CI
+          ? path.join(__dirname, 'cert.p12')
+          : process.env.WINDOWS_CERTIFICATE_FILE;
+
+        if (!certificateFile || !fs.existsSync(certificateFile)) {
+          console.warn(`Warning: Could not find certificate file at ${certificateFile}`)
+        }
+
         return {
           name: 'electron-fiddle',
           authors: 'Electron Community',
@@ -49,8 +58,8 @@ module.exports = {
           remoteReleases: '',
           setupExe: `electron-fiddle-${version}-${arch}-setup.exe`,
           setupIcon: path.resolve(iconDir, 'fiddle.ico'),
-          certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
-          certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD
+          certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD,
+          certificateFile
         }
       }
     },


### PR DESCRIPTION
The way we were looking for a certificate file wasn't quite correct. This fixes that.