### PR TITLE
fix: Ensure correct version selection & display

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -78,9 +78,12 @@ export class BinaryManager {
 
     const zipPath = await eDownload({ version });
     const extractPath = this.getDownloadPath(version);
-    console.log(`BinaryManager: Electron ${version} downloaded, now unpacking`);
+    console.log(`BinaryManager: Electron ${version} downloaded, now unpacking to ${extractPath}`);
 
     try {
+      // Ensure the target path is empty
+      await fs.emptyDir(extractPath);
+
       const electronFiles = await this.unzip(zipPath, extractPath);
       console.log(`Unzipped ${version}`, electronFiles);
     } catch (error) {
@@ -179,7 +182,11 @@ export class BinaryManager {
 
       process.noAsar = true;
 
-      extract(zipPath, { dir: extractPath }, (error: Error) => {
+      const options = {
+        dir: extractPath,
+      };
+
+      extract(zipPath, options, (error: Error) => {
         if (error) {
           reject(error);
           return;

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -1,4 +1,4 @@
-import { Button, IButtonProps } from '@blueprintjs/core';
+import { Button, IButtonProps, Spinner } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -30,7 +30,7 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
     if (state === ElectronVersionState.downloading) {
       props.text = 'Downloading';
       props.disabled = true;
-      props.loading = true;
+      props.icon = <Spinner size={16} />;
     } else if (state === ElectronVersionState.ready) {
       if (isRunning) {
         props.active = true;
@@ -43,7 +43,9 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
         props.icon = 'play';
       }
     } else {
-      return null;
+      props.text = 'Checking status';
+      props.disabled = true;
+      props.icon = <Spinner size={16} />;
     }
 
     return <Button {...props} />;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -358,12 +358,12 @@ export class AppState {
     const downloadedVersions = await this.binaryManager.getDownloadedVersions();
     const updatedVersions = { ...this.versions };
 
-    console.log(`State: Updating version state`);
     (downloadedVersions || []).forEach((version) => {
       if (updatedVersions[version]) {
         updatedVersions[version].state = ElectronVersionState.ready;
       }
     });
+    console.log(`State: Updated version state`, updatedVersions);
 
     this.versions = updatedVersions;
   }

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -31,14 +31,10 @@ export function getDefaultVersion(
     }
   }
 
-  // Self-heal: Unknown version
-  if (ls && knownVersions[0]) {
-    return knownVersions[0].version;
-  }
-
   // Alright, the first version?
-  if (knownVersions && knownVersions[0] && knownVersions[0].version) {
-    return knownVersions[0].version;
+  const last = knownVersions[knownVersions.length - 1];
+  if (last) {
+    return last.version;
   }
 
   // Report error

--- a/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Runner component renders "checking status" 1`] = `
+<Blueprint3.Button
+  className="button-run"
+  disabled={true}
+  icon={
+    <Blueprint3.Spinner
+      size={16}
+    />
+  }
+  text="Checking status"
+/>
+`;
+
 exports[`Runner component renders default 1`] = `
 <Blueprint3.Button
   className="button-run"
@@ -13,7 +26,11 @@ exports[`Runner component renders downloading 1`] = `
 <Blueprint3.Button
   className="button-run"
   disabled={true}
-  loading={true}
+  icon={
+    <Blueprint3.Spinner
+      size={16}
+    />
+  }
   text="Downloading"
 />
 `;

--- a/tests/renderer/components/commands-runner-spec.tsx
+++ b/tests/renderer/components/commands-runner-spec.tsx
@@ -47,9 +47,9 @@ describe('Runner component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders null if there is no Electron version', () => {
-    store.version = '';
+  it('renders "checking status"', () => {
+    store.versions['2.0.2'].state = ElectronVersionState.unknown;
     const wrapper = shallow(<Runner appState={store} />);
-    expect(wrapper.html()).toBe(null);
+    expect(wrapper).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR fixed #147. There were three different issues:

1) If the current version state is unknown, we didn't display any run button. We now display a loading indicator.
2) We selected Electron 0.1 by default (instead of the latest known version)
3) A previous failed unzip operation in the binary manager would silently fail with `EEXIST`