### PR TITLE
feat: support double click action on custom mac window title

### DIFF
--- a/src/less/components/output.less
+++ b/src/less/components/output.less
@@ -12,8 +12,7 @@
   padding-left: 10px;
   height: 0;
   overflow-y: scroll;
-  transition: height 0.2s;
-  transition: padding 0.2s;
+  transition: height 0.2s linear, padding 0.2s linear;
   -webkit-app-region: no-drag;
 
   &.showing {

--- a/src/renderer/components/chrome-mac.tsx
+++ b/src/renderer/components/chrome-mac.tsx
@@ -1,3 +1,4 @@
+import { remote } from 'electron';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -10,11 +11,25 @@ export interface ChromeMacProps {
 
 @observer
 export class ChromeMac extends React.Component<ChromeMacProps> {
+  public handleDoubleClick = () => {
+    const doubleClickAction = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string');
+    const win = remote.getCurrentWindow();
+    if (doubleClickAction === 'Minimize') {
+      win.minimize();
+    } else if (doubleClickAction === 'Maximize') {
+      if (!win.isMaximized()) {
+        win.maximize();
+      } else {
+        win.unmaximize();
+      }
+    }
+  }
+
   public render() {
     if (process.platform !== 'darwin') return null;
 
     return (
-      <div className='chrome drag'>
+      <div className='chrome drag' onDoubleClick={this.handleDoubleClick}>
         <small>{getTitle(this.props.appState)}</small>
       </div>
     );

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -127,6 +127,10 @@ const shell = {
   showItemInFolder: jest.fn()
 };
 
+const systemPreferences = {
+  getUserDefault: jest.fn()
+};
+
 const electronMock = {
   app,
   autoUpdater,
@@ -183,12 +187,14 @@ const electronMock = {
       argv: [ '/Applications/Electron Fiddle.app/Contents/MacOS/electron-fiddle' ]
     },
     shell,
-    require: jest.fn()
+    require: jest.fn(),
+    systemPreferences,
   },
   require: jest.fn(),
   screen: new Screen(),
   session,
   shell,
+  systemPreferences,
   webContents: MockWebContents
 };
 

--- a/tests/renderer/components/__snapshots__/chrome-mac-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/chrome-mac-spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Chrome-Mac component renders 1`] = `
 <div
   className="chrome drag"
+  onDoubleClick={[Function]}
 >
   <small>
     Electron Fiddle - Unsaved

--- a/tests/renderer/components/chrome-mac-spec.tsx
+++ b/tests/renderer/components/chrome-mac-spec.tsx
@@ -1,7 +1,9 @@
-import { shallow } from 'enzyme';
+import * as electron from 'electron';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
 import { ChromeMac } from '../../../src/renderer/components/chrome-mac';
+import { MockBrowserWindow } from '../../mocks/browser-window';
 import { overridePlatform, resetPlatform } from '../../utils';
 
 describe('Chrome-Mac component', () => {
@@ -21,5 +23,69 @@ describe('Chrome-Mac component', () => {
 
     const wrapper = shallow(<ChromeMac appState={store} />);
     expect(wrapper.html()).toBe(null);
+  });
+
+  describe('handleDoubleClick', () => {
+    it('should minimize the window if AppleActionOnDoubleClick is minimize', () => {
+      const wrapper = mount(<ChromeMac appState={store} />);
+      const chrome = wrapper.instance() as ChromeMac;
+      const fakeWindow = new MockBrowserWindow();
+      (electron.remote.systemPreferences.getUserDefault as jest.Mock).mockReturnValue('Minimize');
+      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(fakeWindow);
+
+      chrome.handleDoubleClick();
+
+      expect(electron.remote.systemPreferences.getUserDefault).toHaveBeenCalled();
+      expect(fakeWindow.minimize).toHaveBeenCalled();
+      expect(fakeWindow.maximize).not.toHaveBeenCalled();
+      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
+    });
+
+    it('should maximize the window if AppleActionOnDoubleClick is maximize and the window is not maximized', () => {
+      const wrapper = mount(<ChromeMac appState={store} />);
+      const chrome = wrapper.instance() as ChromeMac;
+      const fakeWindow = new MockBrowserWindow();
+      (electron.remote.systemPreferences.getUserDefault as jest.Mock).mockReturnValue('Maximize');
+      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(fakeWindow);
+      fakeWindow.isMaximized.mockReturnValue(false);
+
+      chrome.handleDoubleClick();
+
+      expect(electron.remote.systemPreferences.getUserDefault).toHaveBeenCalled();
+      expect(fakeWindow.minimize).not.toHaveBeenCalled();
+      expect(fakeWindow.maximize).toHaveBeenCalled();
+      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
+    });
+
+    it('should unmaximize the window if AppleActionOnDoubleClick is maximize and the window is maximized', () => {
+      const wrapper = mount(<ChromeMac appState={store} />);
+      const chrome = wrapper.instance() as ChromeMac;
+      const fakeWindow = new MockBrowserWindow();
+      (electron.remote.systemPreferences.getUserDefault as jest.Mock).mockReturnValue('Maximize');
+      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(fakeWindow);
+      fakeWindow.isMaximized.mockReturnValue(true);
+
+      chrome.handleDoubleClick();
+
+      expect(electron.remote.systemPreferences.getUserDefault).toHaveBeenCalled();
+      expect(fakeWindow.minimize).not.toHaveBeenCalled();
+      expect(fakeWindow.maximize).not.toHaveBeenCalled();
+      expect(fakeWindow.unmaximize).toHaveBeenCalled();
+    });
+
+    it('should do nothingif AppleActionOnDoubleClick is an unknown value', () => {
+      const wrapper = mount(<ChromeMac appState={store} />);
+      const chrome = wrapper.instance() as ChromeMac;
+      const fakeWindow = new MockBrowserWindow();
+      (electron.remote.systemPreferences.getUserDefault as jest.Mock).mockReturnValue('Nonsense');
+      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(fakeWindow);
+
+      chrome.handleDoubleClick();
+
+      expect(electron.remote.systemPreferences.getUserDefault).toHaveBeenCalled();
+      expect(fakeWindow.minimize).not.toHaveBeenCalled();
+      expect(fakeWindow.maximize).not.toHaveBeenCalled();
+      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
* Implements the native double-click behavior on our custom title bar
* Fixes the animation of the console opening / closing