### PR TITLE
chore: update Electron Forge to 6.0.0-beta.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -907,16 +907,16 @@
       }
     },
     "@electron-forge/async-ora": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.30.tgz",
-      "integrity": "sha512-jy2FLtdjaADe+eb4UuRPyDDTLeklwQNb4vzTIRgZa0PEXwe7/fqHrIG2PUaTrt7mqy9wuMj39EhCEq1DuwXBRA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/async-ora/-/async-ora-6.0.0-beta.32.tgz",
+      "integrity": "sha512-lGw1iUWIDq4pG6VlPy0n948+R3c/V3iXL/2vxqGmCceI68ah7j+/f4Y3oWfg13CU6YUcUwuk1GV308heFCiOBQ==",
       "dev": true,
       "requires": {
         "colors": "^1.2.0",
-        "debug": "^3.0.0",
+        "debug": "^4.1.0",
         "log-symbols": "^2.0.0",
         "ora": "^3.0.0",
-        "pretty-ms": "^3.2.0"
+        "pretty-ms": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -926,9 +926,9 @@
           "dev": true
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -966,25 +966,25 @@
       }
     },
     "@electron-forge/cli": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.0-beta.30.tgz",
-      "integrity": "sha512-ONtQii3CnIGkMqrNVOxFWizk/4DZtfBwGjc+ti1idCGkq7m8a4RzQVF9nppN2L6CMGqyTkQZoiAfKvzeBt3JaQ==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.0-beta.32.tgz",
+      "integrity": "sha512-Z/lOcAdsCc3MOc+supxgQeWsGDdSI5dF7ppyP+XYOdiN2TkLMjsBjjbN36zkI7z5kWiDTNEkqvvDof9rwpCmVA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30",
-        "@electron-forge/core": "6.0.0-beta.30",
+        "@electron-forge/async-ora": "6.0.0-beta.32",
+        "@electron-forge/core": "6.0.0-beta.32",
         "colors": "^1.2.0",
         "commander": "^2.9.0",
-        "debug": "^3.0.0",
+        "debug": "^4.1.0",
         "fs-extra": "^7.0.0",
         "inquirer": "^6.2.0",
         "semver": "^5.3.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -999,29 +999,30 @@
       }
     },
     "@electron-forge/core": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.0-beta.30.tgz",
-      "integrity": "sha512-pvM7gYiLwof1KbOAmxFgtYKbimbC3L6X/4yD/g2I+A6SVIASw2u7oXV1dwkh0KXsYA/FvgMEpwe9H/nDkbMwag==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.0-beta.32.tgz",
+      "integrity": "sha512-yj9VPmni74L3B6cVI7iF9bEED/H65r7soLHTLPVvIzd5vUiQz9sK7An+sKwpt0YsxCRE8CQMtU7uWtzJJckhFA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30",
-        "@electron-forge/installer-base": "6.0.0-beta.30",
-        "@electron-forge/installer-deb": "6.0.0-beta.30",
-        "@electron-forge/installer-dmg": "6.0.0-beta.30",
-        "@electron-forge/installer-exe": "6.0.0-beta.30",
-        "@electron-forge/installer-rpm": "6.0.0-beta.30",
-        "@electron-forge/installer-zip": "6.0.0-beta.30",
-        "@electron-forge/maker-base": "6.0.0-beta.30",
-        "@electron-forge/plugin-base": "6.0.0-beta.30",
-        "@electron-forge/publisher-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
+        "@electron-forge/async-ora": "6.0.0-beta.32",
+        "@electron-forge/installer-base": "6.0.0-beta.32",
+        "@electron-forge/installer-deb": "6.0.0-beta.32",
+        "@electron-forge/installer-dmg": "6.0.0-beta.32",
+        "@electron-forge/installer-exe": "6.0.0-beta.32",
+        "@electron-forge/installer-rpm": "6.0.0-beta.32",
+        "@electron-forge/installer-zip": "6.0.0-beta.32",
+        "@electron-forge/maker-base": "6.0.0-beta.32",
+        "@electron-forge/plugin-base": "6.0.0-beta.32",
+        "@electron-forge/publisher-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
         "colors": "^1.2.0",
         "cross-spawn-promise": "^0.10.1",
-        "debug": "^3.0.0",
-        "electron-packager": "^12.0.1",
+        "debug": "^4.1.0",
+        "electron-packager": "^13.0.0",
         "electron-rebuild": "^1.6.0",
         "fs-extra": "^7.0.0",
         "glob": "^7.1.1",
+        "lodash.merge": "^4.6.0",
         "lodash.template": "^4.4.0",
         "log-symbols": "^2.0.0",
         "node-fetch": "^2.0.0",
@@ -1036,9 +1037,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1059,22 +1060,22 @@
       }
     },
     "@electron-forge/installer-base": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-base/-/installer-base-6.0.0-beta.30.tgz",
-      "integrity": "sha512-+0R3Xch6SLZa1l6hyZeIizeKudWgsYrHGLpKDzKbDidQiRfJVHEjcCpGeGdl0kSL8qoX0EConciaP3CUmSDd/A==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-base/-/installer-base-6.0.0-beta.32.tgz",
+      "integrity": "sha512-yaRBgubwyU2a2e1w9yxL1gncTFVBcqhUsuiSQ9ZEnVjaVYEKqgioa34xEUdbh0C4ScugdznPEOQNGrGtjGpLIw==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30"
+        "@electron-forge/async-ora": "6.0.0-beta.32"
       }
     },
     "@electron-forge/installer-darwin": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.30.tgz",
-      "integrity": "sha512-zoEWARYhHfxrosloQJDCFrdnxNUj43KHMmx0sMWm3kfLUNx1b351QjxKQ9CzeZuE51IRn2mJVX0CwFYpFvZ3eA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-darwin/-/installer-darwin-6.0.0-beta.32.tgz",
+      "integrity": "sha512-UZpTDBbHtFd/Faabwjlzj22jKjgtR+CqObWkq+rWoltFklJmlIZznWSLXDc7SfZuUxWMCmnsiSDlDeaKaBfozA==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30",
-        "@electron-forge/installer-base": "6.0.0-beta.30",
+        "@electron-forge/async-ora": "6.0.0-beta.32",
+        "@electron-forge/installer-base": "6.0.0-beta.32",
         "fs-extra": "^7.0.0",
         "pify": "^4.0.0",
         "sudo-prompt": "^8.0.0"
@@ -1089,30 +1090,30 @@
       }
     },
     "@electron-forge/installer-deb": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.30.tgz",
-      "integrity": "sha512-sPgViYo7jCYcyN396i8vVf79snaKvN/jLEMNVr2fLw6lTMbutYEmEQQ2CW7Fff9S2a6PrIy+eJmp0gtHzd+gpQ==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-deb/-/installer-deb-6.0.0-beta.32.tgz",
+      "integrity": "sha512-+33wb7xOSGhPwaY0CzYvEcx6QqJq4X650tBB8LakIHib4NT4tMZ3IwDRZSbmLq4ifOBPPZLkEJDmSYIkR6cpAQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-linux": "6.0.0-beta.30"
+        "@electron-forge/installer-linux": "6.0.0-beta.32"
       }
     },
     "@electron-forge/installer-dmg": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.30.tgz",
-      "integrity": "sha512-L77pdu2uYSjnqA9JKdgXjtR8hIJ6HRgBXkCDblqhqtbNp3we2QJ55qIwYX7NvPzAL7Gy90HsJBtUPGJ6Sv29iA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-dmg/-/installer-dmg-6.0.0-beta.32.tgz",
+      "integrity": "sha512-TqpKvs+S3B8IfyKT+Vc97NGuOTe1obrOuqAig1mhKQC7a/vV/z4j1jwHuLOpu3aOW6QV0kIhW4ItfPgB1suN1w==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-darwin": "6.0.0-beta.30",
+        "@electron-forge/installer-darwin": "6.0.0-beta.32",
         "cross-spawn-promise": "^0.10.1",
-        "debug": "^3.0.0",
+        "debug": "^4.1.0",
         "fs-extra": "^7.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1127,22 +1128,22 @@
       }
     },
     "@electron-forge/installer-exe": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.30.tgz",
-      "integrity": "sha512-wrPlQLwNvTOXMNpNYxptWK+opUj3kZ4nUnKhfQzdI51214VqpNi1fFcbdKbYXbro301TMJHdSx981A0FMvfTaQ==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-exe/-/installer-exe-6.0.0-beta.32.tgz",
+      "integrity": "sha512-MviEjleA3H9MjXJeeJu/MLARezEceYLnUMx+LO5k5UG2AF+zDku+Ve8LF4nfy3hvenEKDZ8T5TeOxvZzNFbtJQ==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-base": "6.0.0-beta.30",
+        "@electron-forge/installer-base": "6.0.0-beta.32",
         "opn": "^5.0.0"
       }
     },
     "@electron-forge/installer-linux": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.30.tgz",
-      "integrity": "sha512-8vR0vn0YyQYt0SyBvRWNZ5WiBZPUJkAthR1AEVBkYhJzD3008RaFsajplkyDqA6KOAFkdg880UhzsM/lyXPf3g==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-linux/-/installer-linux-6.0.0-beta.32.tgz",
+      "integrity": "sha512-MtD8IRjmIjXaV0wp38cusqGX7Lvocv1Dz0CO5OnDmTL7lvZqkZjI8MKye8QFObTmTxc9MiSZoFkSny4iChkN0w==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-base": "6.0.0-beta.30",
+        "@electron-forge/installer-base": "6.0.0-beta.32",
         "pify": "^4.0.0",
         "sudo-prompt": "^8.0.0"
       },
@@ -1156,86 +1157,77 @@
       }
     },
     "@electron-forge/installer-rpm": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.30.tgz",
-      "integrity": "sha512-Que4KzE42m2YPz4t/v0+DKovfZms8PdvB08AUp5LViDmOUAJVCkR2scNjMJUZ34SDcx4d1/gZHuDMM1FIZQ4Tw==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-rpm/-/installer-rpm-6.0.0-beta.32.tgz",
+      "integrity": "sha512-/RO/GKUUnb44/lJXWC9P+JotH3RBwTSlwQmFfM3OSov9S+Rpo982yXzf60gkXH0z3v17xToFdLHGLE/GlR7+pw==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-linux": "6.0.0-beta.30"
+        "@electron-forge/installer-linux": "6.0.0-beta.32"
       }
     },
     "@electron-forge/installer-zip": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.30.tgz",
-      "integrity": "sha512-bpjYT/Rw+TOqEWZjkTNu43qV/xem4MIbcW91yQZbRxg1apJnb8FdKntCo0pC6qrfD2i29SRZXY3ASoOGZoNmbg==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/installer-zip/-/installer-zip-6.0.0-beta.32.tgz",
+      "integrity": "sha512-vpU702nyhaz6gWCiet3XopYY9l9NzqmCsXlAZKfqjlqk9RsRGQZWayq4OwSANW189xCLVs1dN9ES3WNpDx9ebg==",
       "dev": true,
       "requires": {
-        "@electron-forge/installer-darwin": "6.0.0-beta.30",
+        "@electron-forge/installer-darwin": "6.0.0-beta.32",
         "cross-spawn-promise": "^0.10.1",
         "fs-extra": "^7.0.0"
       }
     },
     "@electron-forge/maker-base": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.0-beta.30.tgz",
-      "integrity": "sha512-5hygs7VEEDFrQV9ieKPtv3LSKGBw5mPUlwbhdfBCYiC/a+zyoDPuVVgdWOK2hJFsIdeMII9+xkd9CUUCb135KQ==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.0-beta.32.tgz",
+      "integrity": "sha512-2pWC0PG2jmIWMpm6NvvV6mY2v2nJ64WfR0sN9hNEdUrz6Zf7gi4omV9tyzuEIrubtjYgmRmJdAnELAvTnX2IKg==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "6.0.0-beta.30",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
         "fs-extra": "^7.0.0"
       }
     },
     "@electron-forge/maker-deb": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.0-beta.30.tgz",
-      "integrity": "sha512-FUAF+ciuGyKdc1bK/az93f4zz/nQnpjP/Y9X+PSsCkQOuGEwzPAKNYZf//ZGZWrzi0pjYvMeh1kVcziEHVJ3QA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.0-beta.32.tgz",
+      "integrity": "sha512-67O9/srneHoAj5OiJ+bKkOUHceOqOb3UOxU77bLNkH/mJEvB8axdApGsgDTiKxyJLiF1A8GKsu3n6KptC0Ramw==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
-        "electron-installer-debian": "^1.0.0"
+        "@electron-forge/maker-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
+        "electron-installer-debian": "^1.1.0"
       }
     },
     "@electron-forge/maker-rpm": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.0-beta.30.tgz",
-      "integrity": "sha512-hg7m9NpO3jD14IhQRNJ8URG71rOy4ZGxWrk8exwss1f6Htg9zsCakDbvIExv4MxB55IdR2PLWGC8/3/1ANHyOQ==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.0-beta.32.tgz",
+      "integrity": "sha512-RmqrUEFGh4GMSij2Prn2QtIuPbYSvC0Q1QjNuTYBdheePPQQB8jVQnxU3LKDLK+Aeqay2ENbE4GlnvtZXw/yiA==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
-        "electron-installer-redhat": "^0.5.0",
-        "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        }
+        "@electron-forge/maker-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
+        "electron-installer-redhat": "^1.0.0"
       }
     },
     "@electron-forge/maker-squirrel": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.0-beta.30.tgz",
-      "integrity": "sha512-48cNavOxid8rPWn+hXnv+MbSa0pVrMIMaFUffGck5cOspLP4FJpU0cT4zcimQ6Gu2MSfqwYHPY9wwxQIrmEpIw==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.0-beta.32.tgz",
+      "integrity": "sha512-oMBrV4691Je5iVk8v7Hc0YyIs46qD3+veZ0nLhXY/yOd0hmS/X51+TcE1n5cZVFE97TU7uoQdGsWMQmAHZsoSw==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
+        "@electron-forge/maker-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
         "electron-winstaller": "^2.5.0",
         "fs-extra": "^7.0.0"
       }
     },
     "@electron-forge/maker-zip": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.0-beta.30.tgz",
-      "integrity": "sha512-vsoNnoeMqN8xWwCe658JDNSqcjq4HAQgwNjxNpyZv5hgYWd9n2mLfuSSJuFkkq4h8TPJVFx7RDh9pq3WowcNlA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.0-beta.32.tgz",
+      "integrity": "sha512-FKE/GWaFXW+67Y3vky+eDzKSPAJGZsWA2r4K3o0SnFKll3w4OjbkwjmY8v44xDXrvf2FJBeS4sjFhb2/An+Nnw==",
       "dev": true,
       "requires": {
-        "@electron-forge/maker-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
+        "@electron-forge/maker-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
         "cross-zip": "^2.1.5",
         "fs-extra": "^7.0.0",
         "pify": "^4.0.0"
@@ -1250,35 +1242,59 @@
       }
     },
     "@electron-forge/plugin-base": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.30.tgz",
-      "integrity": "sha512-dXPJqHRSHuL/2Z6/Vuf/6s0Zx913rpumsYQneAE+J7KTMtL/4pSCnin1MuELbwGtZOOW7m/pnJjG3f6YGSCZTw==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.0-beta.32.tgz",
+      "integrity": "sha512-85Z0vkRUwhOuppFGRwel2fXfN70l9dfvx5uGa/t3VJ0m5QjIsQHFypO9TmKO/gMuW0usDjMqn+VElYAt7hZwzA==",
       "dev": true,
       "requires": {
-        "@electron-forge/shared-types": "6.0.0-beta.30"
+        "@electron-forge/shared-types": "6.0.0-beta.32"
       }
     },
     "@electron-forge/publisher-base": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.30.tgz",
-      "integrity": "sha512-eXgnopRpgSndZJnWG/PaqEnwSk9CfOSiAaENHPQmzC5cAqrm6VaYSuIwTyxXieR8+QkKA78AZzU2aC4VAd2biA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.0-beta.32.tgz",
+      "integrity": "sha512-FqElwDqAKZmIGDp3q/zyzKu6YQS53BDeHx8sWHFhZiT1u+PAA8N8WiJO6PmcTJmmgdZZ/zhaIT5syksK4UTJtA==",
       "dev": true
     },
     "@electron-forge/publisher-github": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-6.0.0-beta.30.tgz",
-      "integrity": "sha512-ISZCKJhslhPuLhOp++P6zOUvReqtIyJJEmJVe3YxjfdgX2kC6+bQl4Vx7xRYZbkCU4aMW4yCniWJRC+/d2W2hw==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-6.0.0-beta.32.tgz",
+      "integrity": "sha512-UYUgqteIfuvqQ8+hkK3y6o8B8fYepDhNsiuO/UJZBxcH8oTtO7EcRhi8ttGKDoWgsjtzKqjuynZheWZ/onVsdg==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30",
-        "@electron-forge/publisher-base": "6.0.0-beta.30",
-        "@electron-forge/shared-types": "6.0.0-beta.30",
-        "@octokit/rest": "^15.2.6",
+        "@electron-forge/async-ora": "6.0.0-beta.32",
+        "@electron-forge/publisher-base": "6.0.0-beta.32",
+        "@electron-forge/shared-types": "6.0.0-beta.32",
+        "@octokit/rest": "^16.0.1",
         "fs-extra": "^7.0.0",
         "lodash.merge": "^4.6.0",
         "mime-types": "2.1.21"
       },
       "dependencies": {
+        "@octokit/rest": {
+          "version": "16.9.0",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.9.0.tgz",
+          "integrity": "sha512-B34ViPeGypYcZzYFocIVZFEdd2/peOJX2/rYk7UhhvyTvSfG4aaQWLr0f+yQKl8y8fjbglh33rvzaFiO9ZnBTw==",
+          "dev": true,
+          "requires": {
+            "@octokit/request": "2.2.1",
+            "before-after-hook": "^1.2.0",
+            "btoa-lite": "^1.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.pick": "^4.4.0",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "universal-user-agent": "^2.0.0",
+            "url-template": "^2.0.8"
+          }
+        },
+        "before-after-hook": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
+          "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==",
+          "dev": true
+        },
         "mime-db": {
           "version": "1.37.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
@@ -1297,13 +1313,13 @@
       }
     },
     "@electron-forge/shared-types": {
-      "version": "6.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.0-beta.30.tgz",
-      "integrity": "sha512-9ZQ0TDif/5O42csHfID2mK+VsJ8nb/12aKJfMWQPhSO26F0hH2+iB2jDWpnxVnjrTK7omD4ILgjvvlxq8yOWRA==",
+      "version": "6.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.0-beta.32.tgz",
+      "integrity": "sha512-X96sDKVDHwhaIr+Ngy5QWgeJCbwvoBUly9Ij064WaQNbQJM9jxDsw9bIosyOz9nlNAYlgSFppgshHRBrtBQIDw==",
       "dev": true,
       "requires": {
-        "@electron-forge/async-ora": "6.0.0-beta.30",
-        "@types/electron-packager": "^12.0.0",
+        "@electron-forge/async-ora": "6.0.0-beta.32",
+        "@types/electron-packager": "^13.0.0",
         "electron-rebuild": "^1.6.0",
         "ora": "^3.0.0"
       },
@@ -1360,6 +1376,30 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.1.tgz",
+      "integrity": "sha512-KPkoTvKwCTetu/UqonLs1pfwFO5HAqTv/Ksp9y4NAg//ZgUCpvJsT4Hrst85uEzJvkB8+LxKyR4Bfv2X8O4cmQ==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.0.0",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      }
+    },
+    "@octokit/request": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.2.1.tgz",
+      "integrity": "sha512-enwbVOl3vWWIUuEj0LJRq+mxWNyv95fa13GJitz7qGt/ycYCwtSoVssW3pCqvxS4GlJfHfO2OA+8czIcEF522A==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^3.1.1",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
+      }
     },
     "@octokit/rest": {
       "version": "15.12.1",
@@ -1483,9 +1523,9 @@
       "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
     },
     "@types/electron-packager": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@types/electron-packager/-/electron-packager-12.0.0.tgz",
-      "integrity": "sha512-IocNGjkMkUm/lcUVXCYw0mIqXkoce1NEZ4oV4Td4LwHKXZqWzxdKlPjwnP52LNX6ghddjjXUPukPeKHMHMpxEA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/electron-packager/-/electron-packager-13.0.0.tgz",
+      "integrity": "sha512-Q0e/ja/TfSSPM5rV9RxaPz8yew7dWSSufFsziw08hCZYQuafXkbhxs83UvQ/Hte3+c3U+ogLQKXFasGn1umn5A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1501,12 +1541,31 @@
         "@types/react": "*"
       }
     },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+      "dev": true,
+      "optional": true
+    },
     "@types/fs-extra": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
       "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
         "@types/node": "*"
       }
     },
@@ -1521,6 +1580,13 @@
       "resolved": "https://registry.npmjs.org/@types/log-symbols/-/log-symbols-2.0.0.tgz",
       "integrity": "sha512-YJhbp0sz3egFFKl3BcCNPQKzuGFOP4PACcsifhK6ROGnJUW9ViYLuLybQ9GQZm7Zejy3tkGuiXYMq3GiyGkU4g==",
       "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true,
+      "optional": true
     },
     "@types/node": {
       "version": "10.11.1",
@@ -1880,9 +1946,9 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asar": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/asar/-/asar-0.14.5.tgz",
-      "integrity": "sha512-2Di/TnY1sridHFKMFgxBh0Wk0gVxSZN4qQhRhjJn3UywZAvP5MHI0RNVSkpzmJ+n6t0BC8w/+1257wtSgQ3Kdg==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-0.14.6.tgz",
+      "integrity": "sha512-ZqybKcdO5At6y3ge2RHxVImc6Eltb2t3sxT7lk4T4zjZBSFUuIGCIZY6f41dCjlvJSizN5QPRr8YTgMhpgBjLg==",
       "dev": true,
       "requires": {
         "chromium-pickle-js": "^0.2.0",
@@ -1891,7 +1957,7 @@
         "glob": "^6.0.4",
         "minimatch": "^3.0.3",
         "mkdirp": "^0.5.0",
-        "mksnapshot": "^0.3.0",
+        "mksnapshot": "^0.3.4",
         "tmp": "0.0.28"
       },
       "dependencies": {
@@ -1977,16 +2043,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "lodash": "^4.17.10"
-      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -3339,9 +3395,9 @@
       }
     },
     "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -3993,6 +4049,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
+      "integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw==",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -4485,23 +4547,62 @@
         }
       }
     },
-    "electron-installer-debian": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-1.0.0.tgz",
-      "integrity": "sha512-urcw3RN5F4OL3ppmki65Yw+8dfvhrA2Ous//ZFx+2bJtL6OKW1jEYwdJPiB3VF8UceBYR4EFj55pnnrH5Wuvbg==",
+    "electron-installer-common": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.5.0.tgz",
+      "integrity": "sha512-BNIPjCI4LB+I0f5gK+1+NVxM9Hez8xLck48yKr6yosyze5S2p0K87QvNGZu8KBY8+X32RcHeI5Dfdyt+NK+fnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "asar": "^0.14.0",
+        "asar": "^0.14.6",
         "cross-spawn-promise": "^0.10.1",
+        "fs-extra": "^7.0.1",
+        "glob": "^7.1.3",
+        "glob-promise": "^3.4.0",
+        "lodash": "^4.17.11",
+        "parse-author": "^2.0.0",
+        "semver": "^5.6.0",
+        "tmp-promise": "^1.0.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "electron-installer-debian": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-1.1.0.tgz",
+      "integrity": "sha512-PqWNjVBsfjHiyCYxWBB4W22wSS1DpDfwmAhRsCA2W/0NtOE2yQrnnOrIOC77TcmxY2HmsNlv+n0Aabp8O6b0SA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
         "debug": "^4.0.1",
+        "electron-installer-common": "^0.5.0",
         "fs-extra": "^7.0.0",
         "get-folder-size": "^2.0.0",
-        "glob": "^7.1.2",
         "lodash": "^4.17.4",
         "pify": "^4.0.0",
         "semver": "^5.4.1",
-        "temp": "^0.8.3",
         "word-wrap": "^1.2.3",
         "yargs": "^12.0.2"
       },
@@ -4546,9 +4647,9 @@
           }
         },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4556,14 +4657,14 @@
           }
         },
         "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "optional": true,
           "requires": {
             "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -4579,6 +4680,16 @@
           "optional": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pump": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -4635,21 +4746,21 @@
           "optional": true
         },
         "os-locale": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "optional": true,
           "requires": {
-            "execa": "^0.10.0",
+            "execa": "^1.0.0",
             "lcid": "^2.0.0",
             "mem": "^4.0.0"
           }
         },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4741,115 +4852,254 @@
       }
     },
     "electron-installer-redhat": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-0.5.0.tgz",
-      "integrity": "sha1-CWmc03vJEc9/+ZWHuneqIF6DbNI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-1.0.0.tgz",
+      "integrity": "sha512-ZKEx2Ou9e2U2q5Mpjsi1Vo494aZc2qtC0rw/Pno/d1+7ndm7EFWLcTY5vDeoKuTOKd+3amRlxBZ12sIrcjLFOQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "asar": "^0.13.0",
-        "async": "^2.1.5",
-        "debug": "^2.6.3",
-        "fs-extra": "^2.1.2",
-        "glob": "^7.1.1",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.5.0",
+        "fs-extra": "^7.0.1",
         "lodash": "^4.17.4",
-        "parse-author": "^2.0.0",
-        "temp": "^0.8.3",
-        "word-wrap": "^1.2.1",
-        "yargs": "7.0.2"
+        "nodeify": "^1.0.1",
+        "word-wrap": "^1.2.3",
+        "yargs": "^12.0.5"
       },
       "dependencies": {
-        "asar": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/asar/-/asar-0.13.1.tgz",
-          "integrity": "sha512-HJnZadTbDVDhBDv3tMyDov3ZnwMYYmz80/+a7S6cFPvulUyRz55UG5hOyHeWSP1iZud6vjFq8GOYM6xxtxJECQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chromium-pickle-js": "^0.2.0",
-            "commander": "^2.9.0",
-            "cuint": "^0.2.1",
-            "glob": "^6.0.4",
-            "minimatch": "^3.0.3",
-            "mkdirp": "^0.5.0",
-            "mksnapshot": "^0.3.0",
-            "tmp": "0.0.28"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
-          }
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true,
           "optional": true
         },
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
-        "tmp": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
-            "os-tmpdir": "~1.0.1"
+            "ms": "^2.1.1"
           }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true,
+          "optional": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true,
+          "optional": true
         },
         "yargs": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
-          "integrity": "sha1-EVuX3xMhgj6Lhkjolox4JSEiH2c=",
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -4858,6 +5108,33 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
       "integrity": "sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="
+    },
+    "electron-notarize": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.0.5.tgz",
+      "integrity": "sha512-YzrqZ6RDQ7Wt2RWlxzRoQUuxnTeXrfp7laH7XKcmQqrZ6GaAr50DMPvFMpqDKdrZSHSbcgZgB7ktIQbjvITmCQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "electron-osx-sign": {
       "version": "0.4.11",
@@ -4873,80 +5150,52 @@
         "plist": "^3.0.1"
       },
       "dependencies": {
-        "base64-js": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "plist": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-          "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.2.3",
-            "xmlbuilder": "^9.0.7",
-            "xmldom": "0.1.x"
-          }
         }
       }
     },
     "electron-packager": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-12.2.0.tgz",
-      "integrity": "sha512-T5W/FIK4VXhYIOWxkehmz6zXt2S/sA9JZ3AL+/jeKCicQY6QVQ0K8B7W801L+GPTwbgTPycHjO+iqEf1BhZ+Iw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-13.0.1.tgz",
+      "integrity": "sha512-fXfldaZ1wihpPaMTSGMxvCeETJwVArlnMmKafVXLJbbZwS+WTjY4iL7ju9WMQ0LNGuiiIwSMCQFxt5iA087mqg==",
       "dev": true,
       "requires": {
         "asar": "^0.14.0",
-        "debug": "^3.0.0",
+        "debug": "^4.0.1",
         "electron-download": "^4.1.1",
-        "electron-osx-sign": "^0.4.1",
+        "electron-notarize": "^0.0.5",
+        "electron-osx-sign": "^0.4.11",
         "extract-zip": "^1.0.3",
-        "fs-extra": "^5.0.0",
+        "fs-extra": "^7.0.0",
         "galactus": "^0.2.1",
         "get-package-info": "^1.0.0",
-        "nodeify": "^1.0.1",
         "parse-author": "^2.0.0",
-        "pify": "^3.0.0",
-        "plist": "^2.0.0",
+        "pify": "^4.0.0",
+        "plist": "^3.0.0",
         "rcedit": "^1.0.0",
         "resolve": "^1.1.6",
         "sanitize-filename": "^1.6.0",
         "semver": "^5.3.0",
-        "yargs-parser": "^10.0.0"
+        "yargs-parser": "^11.0.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
           }
         },
         "ms": {
@@ -4955,13 +5204,20 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
         "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -6004,7 +6260,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -7032,9 +7288,9 @@
       }
     },
     "gar": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.3.tgz",
-      "integrity": "sha512-zDpwk/l3HbhjVAvdxNUTJFzgXiNy0a7EmE/50XT38o1z+7NJbFhp+8CDsv1Qgy2adBAwUVYlMpIX2fZUbmlUJw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
       "dev": true,
       "optional": true
     },
@@ -7265,6 +7521,16 @@
             "is-extglob": "^2.1.0"
           }
         }
+      }
+    },
+    "glob-promise": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/glob": "*"
       }
     },
     "glob-to-regexp": {
@@ -8247,9 +8513,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -8263,7 +8529,7 @@
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
@@ -8322,15 +8588,34 @@
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+              "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+              "dev": true
+            }
           }
         }
       }
@@ -9949,6 +10234,18 @@
       "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10450,14 +10747,14 @@
       "dev": true
     },
     "mksnapshot": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.1.tgz",
-      "integrity": "sha1-JQHAVldDbXQs6Vik/5LHfkDdN+Y=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.4.tgz",
+      "integrity": "sha512-FgUTiWiY+35LgL95P/MDYrBuQO5o0s3MmaWKX6ZJWoX4vMOY9vPsAv763l1OSSelL9jPsBQ/wf4bzfqTLNPSFg==",
       "dev": true,
       "requires": {
         "decompress-zip": "0.3.0",
         "fs-extra": "0.26.7",
-        "request": "^2.79.0"
+        "request": "2.x"
       },
       "dependencies": {
         "fs-extra": {
@@ -10755,6 +11052,7 @@
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
       "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-promise": "~1.0.0",
         "promise": "~1.3.0"
@@ -11117,6 +11415,12 @@
         "has": "^1.0.1"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -11275,7 +11579,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -11520,9 +11824,9 @@
       }
     },
     "parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.0.0.tgz",
+      "integrity": "sha512-AddiXFSLLCqj+tCRJ9MrUtHZB4DWojO3tk0NVZ+g5MaMQHF2+p2ktqxuoXyPFLljz/aUK0Nfhd/uGWnhXVXEyA==",
       "dev": true
     },
     "parse-passwd": {
@@ -11752,20 +12056,20 @@
       }
     },
     "plist": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.0",
-        "xmlbuilder": "8.2.2",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
         "xmldom": "0.1.x"
       },
       "dependencies": {
-        "xmlbuilder": {
-          "version": "8.2.2",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+        "base64-js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
           "dev": true
         }
       }
@@ -12738,12 +13042,12 @@
       }
     },
     "pretty-ms": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
-      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-4.0.0.tgz",
+      "integrity": "sha512-qG66ahoLCwpLXD09ZPHSCbUWYTqdosB7SMP4OffgTgL2PBKXMuUsrk5Bwg8q4qPkjTXsKBMr+YK3Ltd/6F9s/Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "^1.0.0"
+        "parse-ms": "^2.0.0"
       }
     },
     "private": {
@@ -12783,6 +13087,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
       "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-promise": "~1"
       }
@@ -15320,9 +15625,9 @@
       }
     },
     "sudo-prompt": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.3.tgz",
-      "integrity": "sha512-bjoT7WAPnrKj7CBO9T6DJVqPNC4IB+WxWyIL6zVhq8vJJsTWbUXrFV1qfvaxQRcyLgkSVGN47yNoAYxj+GNwHA==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.5.tgz",
+      "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==",
       "dev": true
     },
     "sugarss": {
@@ -15615,6 +15920,17 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmp-promise": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.5.tgz",
+      "integrity": "sha512-hOabTz9Tp49wCozFwuJe5ISrOqkECm6kzw66XTP23DuzNU7QS/KiZq5LC9Y7QSy8f1rPSLy4bKaViP0OwGI1cA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "tmp": "0.0.33"
       }
     },
     "tmpl": {
@@ -16646,7 +16962,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "update-electron-app": "^1.3.0"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^6.0.0-beta.30",
-    "@electron-forge/maker-deb": "^6.0.0-beta.30",
-    "@electron-forge/maker-rpm": "^6.0.0-beta.30",
-    "@electron-forge/maker-squirrel": "^6.0.0-beta.30",
-    "@electron-forge/maker-zip": "^6.0.0-beta.30",
-    "@electron-forge/publisher-github": "^6.0.0-beta.30",
+    "@electron-forge/cli": "^6.0.0-beta.32",
+    "@electron-forge/maker-deb": "^6.0.0-beta.32",
+    "@electron-forge/maker-rpm": "^6.0.0-beta.32",
+    "@electron-forge/maker-squirrel": "^6.0.0-beta.32",
+    "@electron-forge/maker-zip": "^6.0.0-beta.32",
+    "@electron-forge/publisher-github": "^6.0.0-beta.32",
     "@types/builtin-modules": "^2.0.0",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.13",


### PR DESCRIPTION
Forge v6 beta 32 has an updated Electron Packager and `electron-installer-*` modules. Offhand, there are two things that are relevant to Fiddle:

* Linux packages no longer include a dependency on `GConf` (dropped in Electron 3)
* macOS notarize support