### PR TITLE
feat: Display only Electron versions with a certain state

### DIFF
--- a/src/renderer/components/commands-version-chooser.tsx
+++ b/src/renderer/components/commands-version-chooser.tsx
@@ -126,20 +126,20 @@ export class VersionChooser extends React.Component<VersionChooserProps, Version
     return sortedElectronMap<ElectronVersion>(versions, (_key, item) => item)
       .filter((item) => {
         if (!item) {
-          return null;
+          return false;
         }
 
         // Check if we want to show the version
         if (!versionsToShow.includes(getReleaseChannel(item))) {
-          return null;
+          return false;
         }
 
         // Check if we want to show the state
         if (!statesToShow.includes(item.state)) {
-          return null;
+          return false;
         }
 
-        return item;
+        return true;
       });
   }
 

--- a/src/renderer/components/commands-version-chooser.tsx
+++ b/src/renderer/components/commands-version-chooser.tsx
@@ -121,10 +121,26 @@ export class VersionChooser extends React.Component<VersionChooserProps, Version
   }
 
   public getItems(): Array<ElectronVersion> {
-    const { versions, versionsToShow } = this.props.appState;
+    const { versions, versionsToShow, statesToShow } = this.props.appState;
 
     return sortedElectronMap<ElectronVersion>(versions, (_key, item) => item)
-      .filter((item) => !!item && versionsToShow.includes(getReleaseChannel(item)));
+      .filter((item) => {
+        if (!item) {
+          return null;
+        }
+
+        // Check if we want to show the version
+        if (!versionsToShow.includes(getReleaseChannel(item))) {
+          return null;
+        }
+
+        // Check if we want to show the state
+        if (!statesToShow.includes(item.state)) {
+          return null;
+        }
+
+        return item;
+      });
   }
 
   public render() {

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -41,6 +41,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
     this.handleDownloadAll = this.handleDownloadAll.bind(this);
     this.handleDeleteAll = this.handleDeleteAll.bind(this);
     this.handleChannelChange = this.handleChannelChange.bind(this);
+    this.handleStateChange = this.handleStateChange.bind(this);
     this.handleDownloadClick = this.handleDownloadClick.bind(this);
     this.handleAddVersion = this.handleAddVersion.bind(this);
 
@@ -52,6 +53,24 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
 
   public handleDownloadClick() {
     this.props.appState.updateElectronVersions();
+  }
+
+  /**
+   * Handles a change in which channels should be displayed.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  public handleStateChange(
+    event: React.FormEvent<HTMLInputElement>
+  ) {
+    const { id, checked } = event.currentTarget;
+    const { appState } = this.props;
+
+    if (!checked) {
+      appState.statesToShow = appState.statesToShow.filter((s) => s !== id);
+    } else {
+      appState.statesToShow.push(id as ElectronVersionState);
+    }
   }
 
   /**
@@ -120,7 +139,10 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
     return (
       <div className='settings-electron'>
         <h2>Electron Settings</h2>
-        {this.renderVersionOptions()}
+        <Callout>
+          {this.renderVersionChannelOptions()}
+          {this.renderVersionStateOptions()}
+        </Callout>
         <br />
         <Callout>
           {this.renderAdvancedButtons()}
@@ -173,51 +195,91 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
 
   /**
    * Renders the various options for which versions should be displayed
+   * in the small dropdown.
    *
    * @private
    * @returns {JSX.Element}
    */
-  private renderVersionOptions(): JSX.Element {
+  private renderVersionStateOptions(): JSX.Element {
+    const { appState } = this.props;
+    const getIsChecked = (state: ElectronVersionState) => {
+      return appState.statesToShow.includes(state);
+    };
+
+    return (
+      <FormGroup
+        label='Include Electron versions that are:'
+      >
+        <Checkbox
+          checked={getIsChecked(ElectronVersionState.downloading)}
+          label='Downloading'
+          id='downloading'
+          onChange={this.handleStateChange}
+          inline={true}
+        />
+        <Checkbox
+          checked={getIsChecked(ElectronVersionState.ready)}
+          label='Downloaded'
+          id='ready'
+          onChange={this.handleStateChange}
+          inline={true}
+        />
+        <Checkbox
+          checked={getIsChecked(ElectronVersionState.unknown)}
+          label='Not Downloaded'
+          id='unknown'
+          onChange={this.handleStateChange}
+          inline={true}
+        />
+      </FormGroup>
+    );
+  }
+
+  /**
+   * Renders the various options for which versions should be displayed
+   *
+   * @private
+   * @returns {JSX.Element}
+   */
+  private renderVersionChannelOptions(): JSX.Element {
     const { appState } = this.props;
     const getIsChecked = (channel: ElectronReleaseChannel) => {
       return appState.versionsToShow.includes(channel);
     };
 
     return (
-      <Callout>
-        <FormGroup
-          label='Include Electron versions from these release channels:'
-        >
-          <Checkbox
-            checked={getIsChecked(ElectronReleaseChannel.stable)}
-            label='Stable'
-            id='Stable'
-            onChange={this.handleChannelChange}
-            inline={true}
-          />
-          <Checkbox
-            checked={getIsChecked(ElectronReleaseChannel.beta)}
-            label='Beta'
-            id='Beta'
-            onChange={this.handleChannelChange}
-            inline={true}
-          />
-          <Checkbox
-            checked={getIsChecked(ElectronReleaseChannel.nightly)}
-            label='Nightly'
-            id='Nightly'
-            onChange={this.handleChannelChange}
-            inline={true}
-          />
-          <Checkbox
-            checked={getIsChecked(ElectronReleaseChannel.unsupported)}
-            label='Unsupported'
-            id='Unsupported'
-            onChange={this.handleChannelChange}
-            inline={true}
-          />
-        </FormGroup>
-      </Callout>
+      <FormGroup
+        label='Include Electron versions from these release channels:'
+      >
+        <Checkbox
+          checked={getIsChecked(ElectronReleaseChannel.stable)}
+          label='Stable'
+          id='Stable'
+          onChange={this.handleChannelChange}
+          inline={true}
+        />
+        <Checkbox
+          checked={getIsChecked(ElectronReleaseChannel.beta)}
+          label='Beta'
+          id='Beta'
+          onChange={this.handleChannelChange}
+          inline={true}
+        />
+        <Checkbox
+          checked={getIsChecked(ElectronReleaseChannel.nightly)}
+          label='Nightly'
+          id='Nightly'
+          onChange={this.handleChannelChange}
+          inline={true}
+        />
+        <Checkbox
+          checked={getIsChecked(ElectronReleaseChannel.unsupported)}
+          label='Unsupported'
+          id='Unsupported'
+          onChange={this.handleChannelChange}
+          inline={true}
+        />
+      </FormGroup>
     );
   }
 
@@ -254,11 +316,16 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
    * @returns {Array<JSX.Element>}
    */
   private renderTableRows(): Array<JSX.Element | null> {
-    const { versions, versionsToShow } = this.props.appState;
+    const { versions, versionsToShow, statesToShow } = this.props.appState;
 
     return sortedElectronMap<JSX.Element | null>(versions, (key, item) => {
       // Check if we want to show the version
       if (!versionsToShow.includes(getReleaseChannel(item))) {
+        return null;
+      }
+
+      // Check if we want to show the state
+      if (!statesToShow.includes(item.state)) {
         return null;
       }
 
@@ -273,7 +340,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
   }
 
   /**
-   * Returns a human-readable state indicator for an Electorn version
+   * Returns a human-readable state indicator for an Electron version
    *
    * @param {ElectronVersion} item
    * @returns {JSX.Element}

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -62,6 +62,9 @@ export class AppState {
   @observable public versionsToShow: Array<ElectronReleaseChannel> =
     this.retrieve('versionsToShow') as Array<ElectronReleaseChannel>
       || [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ];
+  @observable public statesToShow: Array<ElectronVersionState> =
+      this.retrieve('statesToShow') as Array<ElectronVersionState>
+      || [ ElectronVersionState.downloading, ElectronVersionState.ready, ElectronVersionState.unknown ];
   @observable public isKeepingUserDataDirs: boolean = !!this.retrieve('isKeepingUserDataDirs');
 
   @observable public binaryManager: BinaryManager = new BinaryManager();
@@ -116,6 +119,7 @@ export class AppState {
     autorun(() => this.save('isKeepingUserDataDirs', this.isKeepingUserDataDirs));
     autorun(() => this.save('version', this.version));
     autorun(() => this.save('versionsToShow', this.versionsToShow));
+    autorun(() => this.save('statesToShow', this.statesToShow));
 
     autorun(() => {
       if (this.isUnsaved) {

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -9,6 +9,11 @@ exports[`VersionChooser component handles corrupt data 1`] = `
     Array [
       Object {
         "source": "remote",
+        "state": "unknown",
+        "version": "1.0.0",
+      },
+      Object {
+        "source": "remote",
         "state": "ready",
         "version": "2.0.2",
       },
@@ -68,6 +73,11 @@ exports[`VersionChooser component renders 1`] = `
   itemRenderer={[Function]}
   items={
     Array [
+      Object {
+        "source": "remote",
+        "state": "unknown",
+        "version": "1.0.0",
+      },
       Object {
         "source": "remote",
         "state": "ready",

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -9,11 +9,6 @@ exports[`VersionChooser component handles corrupt data 1`] = `
     Array [
       Object {
         "source": "remote",
-        "state": "unknown",
-        "version": "1.0.0",
-      },
-      Object {
-        "source": "remote",
         "state": "ready",
         "version": "2.0.2",
       },
@@ -73,11 +68,6 @@ exports[`VersionChooser component renders 1`] = `
   itemRenderer={[Function]}
   items={
     Array [
-      Object {
-        "source": "remote",
-        "state": "unknown",
-        "version": "1.0.0",
-      },
       Object {
         "source": "remote",
         "state": "ready",

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -47,8 +47,8 @@ exports[`VersionChooser component renderItem() renders an item 1`] = `
 <Blueprint3.MenuItem
   active={true}
   disabled={false}
-  icon="saved"
-  label="Downloaded"
+  icon="cloud"
+  label="Not downloaded"
   multiline={false}
   onClick={[Function]}
   popoverProps={Object {}}

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -40,6 +40,31 @@ exports[`ElectronSettings component renders 1`] = `
         onChange={[Function]}
       />
     </Blueprint3.FormGroup>
+    <Blueprint3.FormGroup
+      label="Include Electron versions that are:"
+    >
+      <Blueprint3.Checkbox
+        checked={true}
+        id="downloading"
+        inline={true}
+        label="Downloading"
+        onChange={[Function]}
+      />
+      <Blueprint3.Checkbox
+        checked={true}
+        id="ready"
+        inline={true}
+        label="Downloaded"
+        onChange={[Function]}
+      />
+      <Blueprint3.Checkbox
+        checked={false}
+        id="unknown"
+        inline={true}
+        label="Not Downloaded"
+        onChange={[Function]}
+      />
+    </Blueprint3.FormGroup>
   </Blueprint3.Callout>
   <br />
   <Blueprint3.Callout>
@@ -168,35 +193,6 @@ exports[`ElectronSettings component renders 1`] = `
               onClick={[Function]}
               small={true}
               text="Delete"
-            />
-          </td>
-        </tr>
-        <tr
-          key="1.8.7"
-        >
-          <td>
-            1.8.7
-          </td>
-          <td>
-            <span>
-              <Blueprint3.Icon
-                icon="cloud"
-              />
-               
-              Not downloaded
-            </span>
-          </td>
-          <td
-            className="action"
-          >
-            <Blueprint3.Button
-              disabled={false}
-              fill={true}
-              icon="cloud-download"
-              loading={false}
-              onClick={[Function]}
-              small={true}
-              text="Download"
             />
           </td>
         </tr>

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -12,16 +12,27 @@ const { remote, local } = ElectronVersionSource;
 describe('VersionChooser component', () => {
   let store: any;
 
-  const mockVersion = {
+  const mockVersion1 = {
     source: remote,
-    state: ready,
+    state: unknown,
     version: '1.0.0'
+  };
+
+  const mockVersion2 = {
+    source: remote,
+    state: unknown,
+    version: '3.0.0-unsupported'
   };
 
   beforeEach(() => {
     store = {
       version: '2.0.2',
-      versions: { ...mockVersions, '3.1.3': undefined, '3.1.4': { ...mockVersion, state: ElectronVersionState.unknown } },
+      versions: {
+        ...mockVersions,
+        '3.1.3': undefined,
+        '1.0.0': { ...mockVersion1 },
+        '3.0.0-unsupported': { ...mockVersion2 }
+      },
       versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
       statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       setVersion: jest.fn(),
@@ -56,7 +67,7 @@ describe('VersionChooser component', () => {
 
   describe('renderItem()', () => {
     it('renders an item', () => {
-      const item = renderItem(mockVersion, {
+      const item = renderItem(mockVersion1, {
         handleClick: () => ({}),
         index: 0,
         modifiers: { active: true, disabled: false, matchesPredicate: true },
@@ -67,7 +78,7 @@ describe('VersionChooser component', () => {
     });
 
     it('returns null if it does not match predicate', () => {
-      const item = renderItem(mockVersion, {
+      const item = renderItem(mockVersion1, {
         handleClick: () => ({}),
         index: 0,
         modifiers: { active: true, disabled: false, matchesPredicate: false },
@@ -81,7 +92,7 @@ describe('VersionChooser component', () => {
   describe('getItemLabel()', () => {
     it('returns the correct label for a local version', () => {
       const input: ElectronVersion = {
-        ...mockVersion,
+        ...mockVersion1,
         source: local,
       };
 
@@ -91,7 +102,7 @@ describe('VersionChooser component', () => {
 
     it('returns the correct label for a version not downloaded', () => {
       const input: ElectronVersion = {
-        ...mockVersion,
+        ...mockVersion1,
         state: unknown
       };
 
@@ -100,7 +111,7 @@ describe('VersionChooser component', () => {
 
     it('returns the correct label for a version downloaded', () => {
       const input: ElectronVersion = {
-        ...mockVersion,
+        ...mockVersion1,
         state: ready
       };
 
@@ -109,7 +120,7 @@ describe('VersionChooser component', () => {
 
     it('returns the correct label for a version downloading', () => {
       const input: ElectronVersion = {
-        ...mockVersion,
+        ...mockVersion1,
         state: downloading
       };
 
@@ -119,21 +130,21 @@ describe('VersionChooser component', () => {
 
   describe('getItemIcon()', () => {
     it('returns the correct icon', () => {
-      const vDownloaded = { ...mockVersion };
+      const vDownloaded = { ...mockVersion1 };
       expect(getItemIcon(vDownloaded)).toBe('saved');
 
-      const vDownloading = { ...mockVersion, state: downloading };
+      const vDownloading = { ...mockVersion1, state: downloading };
       expect(getItemIcon(vDownloading)).toBe('cloud-download');
 
-      const vUnknown = { ...mockVersion, state: unknown };
+      const vUnknown = { ...mockVersion1, state: unknown };
       expect(getItemIcon(vUnknown)).toBe('cloud');
     });
   });
 
   describe('filterItem()', () => {
     it('correctly matches a query', () => {
-      expect(filterItem('test', mockVersion)).toBe(false);
-      expect(filterItem('1.0.0', mockVersion)).toBe(true);
+      expect(filterItem('test', mockVersion1)).toBe(false);
+      expect(filterItem('1.0.0', mockVersion1)).toBe(true);
     });
   });
 });

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -23,6 +23,7 @@ describe('VersionChooser component', () => {
       version: '2.0.2',
       versions: { ...mockVersions },
       versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
+      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       setVersion: jest.fn(),
       get currentElectronVersion() {
         return mockVersions['2.0.2'];

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -21,7 +21,7 @@ describe('VersionChooser component', () => {
   beforeEach(() => {
     store = {
       version: '2.0.2',
-      versions: { ...mockVersions },
+      versions: { ...mockVersions, '3.1.3': undefined, '3.1.4': { ...mockVersion, state: ElectronVersionState.unknown } },
       versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
       statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       setVersion: jest.fn(),

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -130,7 +130,7 @@ describe('VersionChooser component', () => {
 
   describe('getItemIcon()', () => {
     it('returns the correct icon', () => {
-      const vDownloaded = { ...mockVersion1 };
+      const vDownloaded = { ...mockVersion1, state: ready };
       expect(getItemIcon(vDownloaded)).toBe('saved');
 
       const vDownloading = { ...mockVersion1, state: downloading };

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -14,6 +14,7 @@ describe('ElectronSettings component', () => {
       version: '2.0.1',
       versions: { ...mockVersions },
       versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
+      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       downloadVersion: jest.fn(),
       removeVersion: jest.fn(),
       updateElectronVersions: jest.fn(),
@@ -76,6 +77,8 @@ describe('ElectronSettings component', () => {
       }
     };
 
+    store.statesToShow.push(ElectronVersionState.unknown);
+
     const wrapper = mount(<ElectronSettings appState={store} />);
 
     wrapper
@@ -125,6 +128,33 @@ describe('ElectronSettings component', () => {
       instance.handleAddVersion();
 
       expect(store.toggleAddVersionDialog).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleVersionChange()', () => {
+    it('handles a new selection', async () => {
+      const wrapper = shallow(
+        <ElectronSettings appState={store} />
+      );
+      const instance = wrapper.instance() as any;
+      await instance.handleStateChange({
+        currentTarget: {
+          id: ElectronVersionState.ready,
+          checked: false
+        }
+      });
+
+      await instance.handleStateChange({
+        currentTarget: {
+          id: ElectronVersionState.unknown,
+          checked: true
+        }
+      });
+
+      expect(store.statesToShow).toEqual([
+        ElectronVersionState.downloading,
+        ElectronVersionState.unknown
+      ]);
     });
   });
 


### PR DESCRIPTION
This implements #158. In short, it allows users to specify whether or not to display versions that have been downloaded, are downloading, or haven't been downloaded yet.