### PR TITLE
fix: On quit, quit properly

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,6 +29,15 @@ export async function onReady() {
 }
 
 /**
+ * Handle the "before-quit" event
+ *
+ * @export
+ */
+export function onBeforeQuit() {
+  (global as any).isQuitting = true;
+}
+
+/**
  * All windows have been closed, quit on anything but
  * macOS.
  */
@@ -62,6 +71,7 @@ export function main() {
 
   // Launch
   app.on('ready', onReady);
+  app.on('before-quit', onBeforeQuit);
   app.on('window-all-closed', onWindowsAllClosed);
   app.on('activate', getOrCreateMainWindow);
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -132,7 +132,16 @@ export class AppState {
             // The user confirmed, let's close for real.
             if (this.warningDialogLastResult) {
               window.onbeforeunload = null;
-              window.close();
+
+              // Should we just close or quit?
+              const remote = require('electron').remote;
+              const isQuitting = remote.getGlobal('isQuitting');
+
+              if (isQuitting) {
+                remote.app.quit();
+              } else {
+                window.close();
+              }
             }
           });
 

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron';
 
-import { main, onReady, onWindowsAllClosed } from '../../src/main/main';
+import { main, onBeforeQuit, onReady, onWindowsAllClosed } from '../../src/main/main';
 import { shouldQuit } from '../../src/main/squirrel';
 import { setupUpdates } from '../../src/main/update';
 import { getOrCreateMainWindow } from '../../src/main/windows';
@@ -48,7 +48,16 @@ describe('main', () => {
 
     it('listens to core events', () => {
       main();
-      expect(app.on).toHaveBeenCalledTimes(4);
+      expect(app.on).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('onBeforeQuit()', () => {
+    it('sets a global', () => {
+      onBeforeQuit();
+
+      expect((global as any).isQuitting).toBe(true);
+      (global as any).isQuitting = false;
     });
   });
 

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -181,6 +181,7 @@ const electronMock = {
     session,
     BrowserWindow: MockBrowserWindow,
     getCurrentWindow: jest.fn(),
+    getGlobal: jest.fn(),
     Menu: MockMenu,
     MenuItem: MockMenuItem,
     process: {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -64,7 +64,27 @@ describe('AppState', () => {
       });
     });
 
-    it('closes the window', (done) => {
+    it('closes the app', (done) => {
+      const { remote } = require('electron');
+      window.close = jest.fn();
+      appState.isUnsaved = true;
+      (remote.getGlobal as jest.Mock).mockReturnValueOnce(true);
+      expect(window.onbeforeunload).toBeTruthy();
+
+      const result = window.onbeforeunload!(undefined as any);
+      expect(result).toBe(false);
+      expect(appState.isWarningDialogShowing).toBe(true);
+
+      appState.warningDialogLastResult = true;
+      appState.isWarningDialogShowing = false;
+      process.nextTick(() => {
+        expect(window.close).toHaveBeenCalledTimes(0);
+        expect(remote.app.quit).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('does not close the window', (done) => {
       window.close = jest.fn();
       appState.isUnsaved = true;
       expect(window.onbeforeunload).toBeTruthy();


### PR DESCRIPTION
This ensures that we properly quit on macOS. The solution here could be more elegant, but in a nutshell: When we quit, we'll close all windows. If one of the windows has unsaved data, we prevent the closure and ask the user for their opinion.

Then, if the user wants to close the window, we do so. The problem is that a possible application exit has already been prevented, so we _just_ close the window. 

With this PR, we first set a global `isQuitting` in the main process before trying to close the window. If it's true, the window will eventually call `app.quit`.

This will possibly blow up right in my face 😬 

Fixes #164