### PR TITLE
fix: Allow contributors.js to use GitHub credentials

### DIFF
--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -1,11 +1,15 @@
-const fetch = require('node-fetch');
-const fs = require('fs-extra');
-const util = require('util');
-const path = require('path');
-const logSymbols = require('log-symbols');
+const fetch = require('node-fetch')
+const fs = require('fs-extra')
+const util = require('util')
+const path = require('path')
+const logSymbols = require('log-symbols')
 
-const CONTRIBUTORS_FILE_PATH = path.join(__dirname, '../static/contributors.json');
+const { GITHUB_TOKEN, GITHUB_USERNAME } = process.env;
+const CONTRIBUTORS_FILE_PATH = path.join(__dirname, '../static/contributors.json')
 const CONTRIBUTORS_URL = 'https://api.github.com/repos/electron/fiddle/contributors'
+const HEADERS = GITHUB_TOKEN && GITHUB_USERNAME
+  ? { Authorization: `Basic ${Buffer.from(GITHUB_USERNAME + ":" + GITHUB_TOKEN).toString('base64')}` }
+  : {};
 
 // 💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖💖
 // 💖                                                     💖
@@ -25,27 +29,27 @@ const CONTRIBUTORS_WHITELIST = [
   'benicheni',
   'hashimotoyt',
   'ada-lovecraft'
-];
+]
 
-async function maybeFetchContributors() {
+async function maybeFetchContributors () {
   try {
-    const stats = fs.statSync(CONTRIBUTORS_FILE_PATH);
-    const mtime = new Date(util.inspect(stats.mtime));
-    const maxAge = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+    const stats = fs.statSync(CONTRIBUTORS_FILE_PATH)
+    const mtime = new Date(util.inspect(stats.mtime))
+    const maxAge = new Date(new Date().getTime() - (24 * 60 * 60 * 1000))
 
     if (mtime < maxAge) {
       // File exists, but is too old
       console.log(logSymbols.warning, 'Contributors file on disk, but older than 24 hours.')
-      await fetchAndWriteContributorsFile();
+      await fetchAndWriteContributorsFile()
     } else {
       console.log(logSymbols.success, 'Contributors file on disk and recent.')
     }
   } catch (error) {
     if (error.code === 'ENOENT') {
       // File does not exist, move to fetch right away
-      await fetchAndWriteContributorsFile();
+      await fetchAndWriteContributorsFile()
     } else if (error) {
-      throw error;
+      throw error
     };
   };
 }
@@ -60,9 +64,9 @@ async function maybeFetchContributors() {
  * @param contributor - Contributor object
  * @returns {Promise}
  */
-function fetchDetailsContributor(contributor) {
-  return fetch(contributor.api)
-    .then((response) => response.json());
+function fetchDetailsContributor (contributor) {
+  return fetch(contributor.api, { headers: HEADERS })
+    .then((response) => response.json())
 }
 
 /**
@@ -71,24 +75,24 @@ function fetchDetailsContributor(contributor) {
  * @param contributors - Array of contributor
  * @returns {Promise}
  */
-function fetchDetailsContributors(contributors) {
+function fetchDetailsContributors (contributors) {
   return new Promise((resolve) => {
-    const withDetails = contributors;
-    const promises = [];
+    const withDetails = contributors
+    const promises = []
 
     contributors.forEach((contributor, i) => {
       const detailFetcher = fetchDetailsContributor(contributor)
         .then(({ name, bio, location }) => {
-          withDetails[i].name = name;
-          withDetails[i].bio = bio;
-          withDetails[i].location = location;
-        });
+          withDetails[i].name = name
+          withDetails[i].bio = bio
+          withDetails[i].location = location
+        })
 
-      promises.push(detailFetcher);
-    });
+      promises.push(detailFetcher)
+    })
 
-    Promise.all(promises).then(() => resolve(withDetails));
-  });
+    Promise.all(promises).then(() => resolve(withDetails))
+  })
 }
 
 /**
@@ -97,10 +101,10 @@ function fetchDetailsContributors(contributors) {
  * @export
  * @returns {Promise}
  */
-function fetchContributors() {
-  const contributors = [];
+function fetchContributors () {
+  const contributors = []
 
-  return fetch(CONTRIBUTORS_URL)
+  return fetch(CONTRIBUTORS_URL, { headers: HEADERS })
     .then((response) => response.json())
     .then(async (data) => {
       if (data && data.forEach) {
@@ -111,47 +115,53 @@ function fetchContributors() {
               api: url,
               login: login,
               avatar: avatar_url
-            });
+            })
           }
-        });
+        })
       }
 
-      return fetchDetailsContributors(contributors);
-    });
+      return fetchDetailsContributors(contributors)
+    })
 }
 
 /**
  * Fetch the contributors and write the result to disk
  */
-async function fetchAndWriteContributorsFile() {
+async function fetchAndWriteContributorsFile () {
   await new Promise((resolve) => {
     fs.access(CONTRIBUTORS_FILE_PATH, fs.constants.F_OK | fs.constants.R_OK | fs.constants.W_OK, async (error) => {
       if (!error) {
-        console.log(logSymbols.info, 'Deleting existing contributors file');
-        fs.unlinkSync(CONTRIBUTORS_FILE_PATH);
+        console.log(logSymbols.info, 'Deleting existing contributors file')
+        fs.unlinkSync(CONTRIBUTORS_FILE_PATH)
       }
 
-      console.log(logSymbols.info, 'Fetching contributors');
-      let data;
+      console.log(logSymbols.info, 'Fetching contributors')
+      let data
 
       try {
         data = await fetchContributors()
+
+        if (!data || data.length === 0) {
+          throw new Error('Contributors array is empty')
+        }
       } catch (error) {
-        console.warn(`Fetching contributors failed!`, error);
-        console.log(`We'll continue without.`);
-        data = [];
+        if (process.env.CI) throw error;
+
+        console.warn(`Fetching contributors failed!`, error)
+        console.log(`We'll continue without.`)
+        data = []
       }
 
-      await fs.outputFile(CONTRIBUTORS_FILE_PATH, JSON.stringify(data));
+      await fs.outputFile(CONTRIBUTORS_FILE_PATH, JSON.stringify(data))
 
-      console.log(logSymbols.success, 'Contributors fetched');
-      resolve();
-    });
-  });
+      console.log(logSymbols.success, `${data.length} Contributors fetched`)
+      resolve()
+    })
+  })
 }
 
 module.exports = {
   maybeFetchContributors
 }
 
-if (require.main === module) maybeFetchContributors();
+if (require.main === module) maybeFetchContributors()

--- a/tools/run-bin.js
+++ b/tools/run-bin.js
@@ -1,14 +1,14 @@
 /* tslint:disable */
 
-const childProcess = require('child_process');
-const path = require('path');
-const logSymbols = require('log-symbols');
+const childProcess = require('child_process')
+const path = require('path')
+const logSymbols = require('log-symbols')
 
-async function run(name, bin, args = []) {
+async function run (name, bin, args = []) {
   await new Promise((resolve, reject) => {
-    console.info(logSymbols.info, `Running ${name}`);
+    console.info(logSymbols.info, `Running ${name}`)
 
-    const cmd = process.platform === 'win32' ? `${bin}.cmd` : bin;
+    const cmd = process.platform === 'win32' ? `${bin}.cmd` : bin
     const child = childProcess.spawn(
       path.resolve(__dirname, '..', 'node_modules', '.bin', cmd),
       args,
@@ -16,14 +16,14 @@ async function run(name, bin, args = []) {
         cwd: path.resolve(__dirname, '..'),
         stdio: 'inherit'
       }
-    );
+    )
 
     child.on('exit', (code) => {
-      console.log('');
-      if (code === 0) return resolve();
-      reject(new Error(`${name} failed`));
-    });
-  });
+      console.log('')
+      if (code === 0) return resolve()
+      reject(new Error(`${name} failed`))
+    })
+  })
 };
 
 module.exports = {

--- a/tools/tsc.js
+++ b/tools/tsc.js
@@ -1,13 +1,13 @@
 /* tslint:disable */
 
-const { run } = require('./run-bin');
+const { run } = require('./run-bin')
 
-async function compileTypeScript() {
-  await run('TypeScript', 'tsc', ['-p', 'tsconfig.json']);
+async function compileTypeScript () {
+  await run('TypeScript', 'tsc', ['-p', 'tsconfig.json'])
 };
 
 module.exports = {
   compileTypeScript
 }
 
-if (require.main === module) compileTypeScript();
+if (require.main === module) compileTypeScript()


### PR DESCRIPTION
Turns out, CI doesn’t correctly fetch contributors if the GitHub API is rate-limited. As you can guess, that’s always the case for Travis.

This has `contributors.js` use environment variables to fetch contributors if they are available.