### PR TITLE
Welcome Tour - formatting bugs (spacing)

### DIFF
--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -114,8 +114,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
             Every Electron app starts with a main script, very similar to how
             a Node.js application is started. The main script runs in the "main
             process". To display a user interface, the main process creates renderer
-            processes – usually in the form of windows, which Electron calls
-            <code>BrowserWindow</code>.
+            processes – usually in the form of windows, which Electron calls <code>BrowserWindow</code>.
           </p>
           <p>
             To get started, pretend that the main process is just like a Node.js

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -135,11 +135,9 @@ export function getWelcomeTour(): Set<TourScriptStep> {
       title: '📝 HTML',
       content: (
         <p>
-          In the default fiddle, this HTML file is loaded in the
-          <code>BrowserWindow</code>. Any HTML, CSS, or JavaScript that works
+          In the default fiddle, this HTML file is loaded in the <code>BrowserWindow</code>. Any HTML, CSS, or JavaScript that works
           in a browser will work here, too. In addition, Electron allows you
-          to execute Node.js code. Take a close look at the
-            <code>&lt;script /&gt;</code> tag and notice how we can call <code>
+          to execute Node.js code. Take a close look at the <code>&lt;script /&gt;</code> tag and notice how we can call <code>
           require()</code> like we would in Node.js.
         </p>
       )

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -153,8 +153,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
             do anything that works in Node.js <i>and</i> anything that works in a browser.
           </p>
           <p>
-            By the way: If you want to use an <code>npm</code> module here, just
-            <code>require</code> it. Electron Fiddle will automatically detect that you
+            By the way: If you want to use an <code>npm</code> module here, just <code>require</code> it. Electron Fiddle will automatically detect that you
             requested a module and install it as soon as you run your fiddle.
           </p>
         </>

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -172,14 +172,7 @@ exports[`Header component renders the tour once started 1`] = `
              anything that works in a browser.
           </p>
           <p>
-            By the way: If you want to use an
-            <code>
-              npm
-            </code>
-             module here, just
-            <code>
-              require
-            </code>
+            By the way: If you want to use an <code>npm</code> module here, just <code>require</code>
              it. Electron Fiddle will automatically detect that you requested a module and install it as soon as you run your fiddle.
           </p>
         </React.Fragment>,

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -146,12 +146,10 @@ exports[`Header component renders the tour once started 1`] = `
       },
       Object {
         "content": <p>
-          In the default fiddle, this HTML file is loaded in the
-          <code>
+          In the default fiddle, this HTML file is loaded in the <code>
             BrowserWindow
           </code>
-          . Any HTML, CSS, or JavaScript that works in a browser will work here, too. In addition, Electron allows you to execute Node.js code. Take a close look at the
-          <code>
+          . Any HTML, CSS, or JavaScript that works in a browser will work here, too. In addition, Electron allows you to execute Node.js code. Take a close look at the <code>
             &lt;script /&gt;
           </code>
            tag and notice how we can call

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -59,11 +59,11 @@ exports[`Header component renders the tour once started 1`] = `
             Electron Fiddle allows you to build little experiments and mini-apps with Electron. Each Fiddle has three files: A main script, a renderer script, and an HTML file.
           </p>
           <p>
-            If you 
+            If you
             <code>
               require()
             </code>
-             a module, Fiddle will install it automatically. It will also automatically provide you with autocomplete information for the 
+             a module, Fiddle will install it automatically. It will also automatically provide you with autocomplete information for the
             <code>
               electron
             </code>
@@ -120,21 +120,20 @@ exports[`Header component renders the tour once started 1`] = `
       Object {
         "content": <React.Fragment>
           <p>
-            Every Electron app starts with a main script, very similar to how a Node.js application is started. The main script runs in the "main process". To display a user interface, the main process creates renderer processes – usually in the form of windows, which Electron calls
-            <code>
+            Every Electron app starts with a main script, very similar to how a Node.js application is started. The main script runs in the "main process". To display a user interface, the main process creates renderer processes – usually in the form of windows, which Electron calls <code>
               BrowserWindow
             </code>
             .
           </p>
           <p>
-            To get started, pretend that the main process is just like a Node.js process. All APIs and features found in Electron are accessible through the 
+            To get started, pretend that the main process is just like a Node.js process. All APIs and features found in Electron are accessible through the
             <code>
               electron
             </code>
              module, which can be required like any other Node.js module.
           </p>
           <p>
-            The default fiddle creates a new 
+            The default fiddle creates a new
             <code>
               BrowserWindow
             </code>
@@ -155,7 +154,7 @@ exports[`Header component renders the tour once started 1`] = `
           <code>
             &lt;script /&gt;
           </code>
-           tag and notice how we can call 
+           tag and notice how we can call
           <code>
             require()
           </code>
@@ -168,14 +167,14 @@ exports[`Header component renders the tour once started 1`] = `
       Object {
         "content": <React.Fragment>
           <p>
-            This is the script we just required from the HTML file. In here, you can do anything that works in Node.js 
+            This is the script we just required from the HTML file. In here, you can do anything that works in Node.js
             <i>
               and
             </i>
              anything that works in a browser.
           </p>
           <p>
-            By the way: If you want to use an 
+            By the way: If you want to use an
             <code>
               npm
             </code>


### PR DESCRIPTION
I loaded the welcome tour up to find a few places where a `code` block was missing a space between itself and the proceeding word. See the screenshots below for all 3 places I saw the problem:

## before
<img width="1194" alt="electron fiddle tutorial - main script - formatting bug" src="https://user-images.githubusercontent.com/1154834/54854260-9ab43580-4caf-11e9-8062-2a7612b2cfe9.png">
<img width="421" alt="Screen Shot 2019-03-22 at 2 22 46 PM" src="https://user-images.githubusercontent.com/1154834/54854262-9ab43580-4caf-11e9-9396-b2a38bf838c7.png">
<img width="432" alt="Screen Shot 2019-03-22 at 2 25 27 PM" src="https://user-images.githubusercontent.com/1154834/54854263-9ab43580-4caf-11e9-8486-231d28ba868d.png">

## after
<img width="433" alt="Screen Shot 2019-03-22 at 2 32 49 PM" src="https://user-images.githubusercontent.com/1154834/54854269-a0118000-4caf-11e9-965b-efbebb3b8406.png">
<img width="412" alt="Screen Shot 2019-03-22 at 2 32 54 PM" src="https://user-images.githubusercontent.com/1154834/54854270-a0118000-4caf-11e9-8005-e03dff3a7160.png">
<img width="389" alt="Screen Shot 2019-03-22 at 2 33 01 PM" src="https://user-images.githubusercontent.com/1154834/54854271-a0118000-4caf-11e9-83d5-89d0e5bb2f72.png">
