### PR TITLE
fix: use the latest version of Forge v6 for Fiddle Forge actions

### DIFF
--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -15,11 +15,11 @@ export async function forgeTransform(files: Files): Promise<Files> {
 
       // devDependencies
       parsed.devDependencies = parsed.devDependencies || {};
-      parsed.devDependencies['@electron-forge/cli'] = '6.0.0-beta.22';
-      parsed.devDependencies['@electron-forge/maker-deb'] = '6.0.0-beta.22';
-      parsed.devDependencies['@electron-forge/maker-rpm'] = '6.0.0-beta.22';
-      parsed.devDependencies['@electron-forge/maker-squirrel'] = '6.0.0-beta.22';
-      parsed.devDependencies['@electron-forge/maker-zip'] = '6.0.0-beta.22';
+      parsed.devDependencies['@electron-forge/cli'] = '6.0.0-beta.34';
+      parsed.devDependencies['@electron-forge/maker-deb'] = '6.0.0-beta.34';
+      parsed.devDependencies['@electron-forge/maker-rpm'] = '6.0.0-beta.34';
+      parsed.devDependencies['@electron-forge/maker-squirrel'] = '6.0.0-beta.34';
+      parsed.devDependencies['@electron-forge/maker-zip'] = '6.0.0-beta.34';
 
       // Scripts
       parsed.scripts = parsed.scripts || {};

--- a/tests/transforms/forge-spec.ts
+++ b/tests/transforms/forge-spec.ts
@@ -12,11 +12,11 @@ describe('forgeTransform()', () => {
     const files = await forgeTransform(filesBefore);
     expect(JSON.parse(files.get('package.json')!)).toEqual({
       devDependencies: {
-        '@electron-forge/cli': '6.0.0-beta.22',
-        '@electron-forge/maker-deb': '6.0.0-beta.22',
-        '@electron-forge/maker-rpm': '6.0.0-beta.22',
-        '@electron-forge/maker-squirrel': '6.0.0-beta.22',
-        '@electron-forge/maker-zip': '6.0.0-beta.22'
+        '@electron-forge/cli': '6.0.0-beta.34',
+        '@electron-forge/maker-deb': '6.0.0-beta.34',
+        '@electron-forge/maker-rpm': '6.0.0-beta.34',
+        '@electron-forge/maker-squirrel': '6.0.0-beta.34',
+        '@electron-forge/maker-zip': '6.0.0-beta.34'
       },
       scripts: {
         start: 'electron-forge start',


### PR DESCRIPTION
Fixes #186.