### PR TITLE
feat: Panels

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -68,13 +68,13 @@ export const enum EditorId {
 
 // Panels that can show up as a mosaic
 export const enum PanelId {
-  'showMe' = 'showMe'
+  'docsDemo' = 'docsDemo'
 }
 
 export type MosaicId = EditorId | PanelId;
 
 export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.html ];
-export const ALL_PANELS = [ PanelId.showMe ];
+export const ALL_PANELS = [ PanelId.docsDemo ];
 export const ALL_MOSAICS = [ ...ALL_EDITORS, ...ALL_PANELS ];
 
 export type ArrowPosition = 'top' | 'left' | 'bottom' | 'right';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -78,3 +78,8 @@ export const ALL_PANELS = [ PanelId.showMe ];
 export const ALL_MOSAICS = [ ...ALL_EDITORS, ...ALL_PANELS ];
 
 export type ArrowPosition = 'top' | 'left' | 'bottom' | 'right';
+
+export const enum DocsDemoPage {
+  DEFAULT = 'DEFAULT',
+  DEMO_APP = 'DEMO_APP'
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,12 @@ export interface ElectronVersion extends NpmVersion {
   source: ElectronVersionSource;
 }
 
+export interface SetFiddleOptions {
+  values: EditorValues;
+  filePath?: string;
+  templateName?: string;
+}
+
 export interface OutputEntry {
   text: string;
   timestamp: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -53,11 +53,19 @@ export interface Templates {
   [index: string]: string | Templates;
 }
 
+// Editors
 export const enum EditorId {
   'main' = 'main',
   'renderer' = 'renderer',
   'html' = 'html'
 }
+
+// Panels that can show up as a mosaic
+export const enum PanelId {
+  'show-me' = 'show-me'
+}
+
+export type MosaicId = EditorId | PanelId;
 
 export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.html ];
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,11 +62,13 @@ export const enum EditorId {
 
 // Panels that can show up as a mosaic
 export const enum PanelId {
-  'show-me' = 'show-me'
+  'showMe' = 'showMe'
 }
 
 export type MosaicId = EditorId | PanelId;
 
 export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.html ];
+export const ALL_PANELS = [ PanelId.showMe ];
+export const ALL_MOSAICS = [ ...ALL_EDITORS, ...ALL_PANELS ];
 
 export type ArrowPosition = 'top' | 'left' | 'bottom' | 'right';

--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -18,6 +18,15 @@
     background-color: @background-1;
   }
 
+  .bp3-button:hover,
+  .bp3-button.bp3-minimal:hover {
+    background-color: rgba(138, 155, 168, 0.15)
+  }
+
+  .bp3-button.bp3-minimal {
+    background-color: unset;
+  }
+
   .bp3-menu-item.bp3-active.bp3-intent-primary {
     background-color: @foreground-3;
   }
@@ -28,5 +37,9 @@
     .bp3-dialog-header {
       background-color: @background-3;
     }
+  }
+
+  .bp3-running-text {
+    font-size: 14px;
   }
 }

--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -18,13 +18,13 @@
     background-color: @background-1;
   }
 
-  .bp3-button:hover,
-  .bp3-button.bp3-minimal:hover {
-    background-color: rgba(138, 155, 168, 0.15)
-  }
-
   .bp3-button.bp3-minimal {
     background-color: unset;
+  }
+
+  .bp3-button:hover,
+  .bp3-button.bp3-minimal:hover {
+    background-color: rgba(138, 155, 168, 0.15);
   }
 
   .bp3-menu-item.bp3-active.bp3-intent-primary {

--- a/src/less/components/editors.less
+++ b/src/less/components/editors.less
@@ -7,10 +7,11 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
-    padding: 0 3px 0 29px;
+    padding: 0 5px 0 5px;
 
     .mosaic-controls {
-      transform: scale(0.7);
+      transform: scale(0.75);
+      transform-origin: right;
     }
 
     h5 {

--- a/src/less/components/mosaic.less
+++ b/src/less/components/mosaic.less
@@ -34,7 +34,6 @@
     flex-wrap: nowrap;
     align-items: stretch;
     align-content: stretch;
-    font-size: 12px;
     overflow: visible;
     z-index: 4;
     background-color: @background-4;

--- a/src/less/components/mosaic.less
+++ b/src/less/components/mosaic.less
@@ -37,6 +37,7 @@
     font-size: 12px;
     overflow: visible;
     z-index: 4;
+    background-color: @background-4;
   }
 
   .mosaic {

--- a/src/less/components/show-me.less
+++ b/src/less/components/show-me.less
@@ -5,6 +5,10 @@
   & > *:first-child {
     margin-top: 0;
   };
+
+  .bp3-callout {
+    margin-bottom: 10px;
+  }
 }
 
 .show-me-list {

--- a/src/less/components/show-me.less
+++ b/src/less/components/show-me.less
@@ -1,0 +1,7 @@
+.show-me-panel {
+  padding: 10px;
+
+  & > *:first-child {
+    margin-top: 0;
+  };
+}

--- a/src/less/components/show-me.less
+++ b/src/less/components/show-me.less
@@ -1,7 +1,17 @@
 .show-me-panel {
   padding: 10px;
+  overflow: scroll;
 
   & > *:first-child {
     margin-top: 0;
   };
+}
+
+.show-me-list {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  max-height: 400px;
 }

--- a/src/less/root.less
+++ b/src/less/root.less
@@ -17,3 +17,4 @@
 @import "components/editors.less";
 @import "components/tour.less";
 @import "components/commands-version-chooser.less";
+@import "components/show-me.less";

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import { ALL_EDITORS, EditorId, EditorValues } from '../interfaces';
 import { updateEditorLayout } from '../utils/editor-layout';
 import { getEditorValue } from '../utils/editor-value';
 import { getPackageJson, PackageJsonOptions } from '../utils/get-package';
+import { isEditorBackup } from '../utils/type-checks';
 import { FileManager } from './file-manager';
 import { Runner } from './runner';
 import { appState } from './state';
@@ -52,9 +53,9 @@ export class App {
 
     for (const name of ALL_EDITORS) {
       const editor = fiddle.editors[name];
-      const backup = this.state.closedEditors[name];
+      const backup = this.state.closedPanels[name];
 
-      if (backup && backup.model && values[name]) {
+      if (isEditorBackup(backup) && backup.model && values[name]) {
         // The editor does not exist, attempt to set it on the backup
         backup.model.setValue(values[name]!);
       } else if (editor && editor.setValue && values[name]) {

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -110,7 +110,8 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
 
       document.title = getTitle(appState);
       appState.gistId = gistId;
-      appState.localPath = null;
+      appState.localPath = undefined;
+      appState.templateName = undefined;
     } catch (error) {
       appState.setWarningDialogTexts({
         label: `Loading the fiddle failed: ${error}`,

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -2,7 +2,7 @@ import { Button, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ALL_MOSAICS, MosaicId } from '../../interfaces';
+import { ALL_EDITORS, MosaicId, PanelId } from '../../interfaces';
 import { getVisibleMosaics } from '../../utils/editors-mosaic-arrangement';
 import { AppState } from '../state';
 import { TITLE_MAP } from './editors';
@@ -29,12 +29,20 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
     this.onItemClick = this.onItemClick.bind(this);
   }
 
-
   public render() {
     return (
-      <Popover content={this.renderMenu()} position={Position.BOTTOM}>
-        <Button icon='applications' text='Editors' />
-      </Popover>
+      <>
+        <Popover content={this.renderMenu()} position={Position.BOTTOM}>
+          <Button icon='applications' text='Editors' />
+        </Popover>
+        <Button
+          icon='help'
+          text='Docs & Info'
+          id={PanelId.showMe}
+          onClick={this.onItemClick}
+          active={!this.props.appState.closedPanels.showMe}
+        />
+      </>
     );
   }
 
@@ -51,7 +59,7 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
     const result: Array<JSX.Element> = [];
     const visibleMosaics = getVisibleMosaics(appState.mosaicArrangement);
 
-    for (const id of ALL_MOSAICS) {
+    for (const id of ALL_EDITORS) {
       result.push(
         <MenuItem
           icon={visibleMosaics.includes(id) ? 'eye-open' : 'eye-off'}

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -35,14 +35,24 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
         <Popover content={this.renderMenu()} position={Position.BOTTOM}>
           <Button icon='applications' text='Editors' />
         </Popover>
-        <Button
-          icon='help'
-          text='Docs & Demos'
-          id={PanelId.docsDemo}
-          onClick={this.onItemClick}
-          active={!this.props.appState.closedPanels.docsDemo}
-        />
+        {this.renderDocsDemos()}
       </>
+    );
+  }
+
+  public renderDocsDemos() {
+    if (!process.env.FIDDLE_DOCS_DEMOS) {
+      return null;
+    }
+
+    return (
+      <Button
+        icon='help'
+        text='Docs & Demos'
+        id={PanelId.docsDemo}
+        onClick={this.onItemClick}
+        active={!this.props.appState.closedPanels.docsDemo}
+      />
     );
   }
 

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -2,8 +2,8 @@ import { Button, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ALL_EDITORS, EditorId } from '../../interfaces';
-import { getVisibleEditors } from '../../utils/editors-mosaic-arrangement';
+import { ALL_MOSAICS, MosaicId } from '../../interfaces';
+import { getVisibleMosaics } from '../../utils/editors-mosaic-arrangement';
 import { AppState } from '../state';
 import { TITLE_MAP } from './editors';
 
@@ -49,12 +49,12 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
   public renderMenuItems() {
     const { appState } = this.props;
     const result: Array<JSX.Element> = [];
-    const visibleEditors = getVisibleEditors(appState.mosaicArrangement);
+    const visibleMosaics = getVisibleMosaics(appState.mosaicArrangement);
 
-    for (const id of ALL_EDITORS) {
+    for (const id of ALL_MOSAICS) {
       result.push(
         <MenuItem
-          icon={visibleEditors.includes(id) ? 'eye-open' : 'eye-off'}
+          icon={visibleMosaics.includes(id) ? 'eye-open' : 'eye-off'}
           key={id}
           text={TITLE_MAP[id]}
           id={id}
@@ -69,12 +69,14 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
   public onItemClick(event: React.MouseEvent) {
     const { id } = event.currentTarget;
     const { appState } = this.props;
-    const visibleEditors = getVisibleEditors(appState.mosaicArrangement);
+    const visibleMosaics = getVisibleMosaics(appState.mosaicArrangement);
 
-    if (visibleEditors.includes(id as EditorId)) {
-      appState.hideAndBackupEditor(id as EditorId);
+    if (visibleMosaics.includes(id as MosaicId)) {
+      console.log(`EditorDropdown: Closing ${id}`);
+      appState.hideAndBackupMosaic(id as MosaicId);
     } else {
-      appState.showEditor(id as EditorId);
+      console.log(`EditorDropdown: Opening ${id}`);
+      appState.showMosaic(id as MosaicId);
     }
   }
 }

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -37,7 +37,7 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
         </Popover>
         <Button
           icon='help'
-          text='Docs & Info'
+          text='Docs & Demos'
           id={PanelId.showMe}
           onClick={this.onItemClick}
           active={!this.props.appState.closedPanels.showMe}

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -38,9 +38,9 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
         <Button
           icon='help'
           text='Docs & Demos'
-          id={PanelId.showMe}
+          id={PanelId.docsDemo}
           onClick={this.onItemClick}
-          active={!this.props.appState.closedPanels.showMe}
+          active={!this.props.appState.closedPanels.docsDemo}
         />
       </>
     );

--- a/src/renderer/components/editors-non-ideal-state.tsx
+++ b/src/renderer/components/editors-non-ideal-state.tsx
@@ -10,7 +10,7 @@ export function renderNonIdealState(appState: AppState) {
   const resolveButton = (
     <Button
       text='Open all editors'
-      onClick={() => appState.setVisibleEditors(allEditors)}
+      onClick={() => appState.setVisibleMosaics(allEditors)}
     />
   );
 

--- a/src/renderer/components/editors-toolbar-button.tsx
+++ b/src/renderer/components/editors-toolbar-button.tsx
@@ -3,17 +3,18 @@ import * as React from 'react';
 import { Button } from '@blueprintjs/core';
 import { MosaicWindowContext } from 'react-mosaic-component';
 
-import { EditorId } from '../../interfaces';
+import { MosaicId } from '../../interfaces';
+import { isEditorId } from '../../utils/type-checks';
 import { AppState } from '../state';
 
 export interface ToolbarButtonProps {
   appState: AppState;
-  id: EditorId;
+  id: MosaicId;
 }
 
 export class MaximizeButton extends React.PureComponent<ToolbarButtonProps> {
   public static contextTypes = MosaicWindowContext;
-  public context: MosaicWindowContext<EditorId>;
+  public context: MosaicWindowContext<MosaicId>;
 
   constructor(props: ToolbarButtonProps) {
     super(props);
@@ -31,6 +32,9 @@ export class MaximizeButton extends React.PureComponent<ToolbarButtonProps> {
     );
   }
 
+  /**
+   * Expand this panel
+   */
   public expand() {
     const path = this.context.mosaicWindowActions.getPath();
     return this.context.mosaicActions.expand(path);
@@ -39,7 +43,7 @@ export class MaximizeButton extends React.PureComponent<ToolbarButtonProps> {
 
 export class RemoveButton extends React.PureComponent<ToolbarButtonProps> {
   public static contextTypes = MosaicWindowContext;
-  public context: MosaicWindowContext<EditorId>;
+  public context: MosaicWindowContext<MosaicId>;
 
   constructor(props: ToolbarButtonProps) {
     super(props);
@@ -56,7 +60,14 @@ export class RemoveButton extends React.PureComponent<ToolbarButtonProps> {
     );
   }
 
+  /**
+   * Remove this panel
+   */
   public remove() {
-    this.props.appState.hideAndBackupEditor(this.props.id);
+    const { id } = this.props;
+
+    if (isEditorId(id)) {
+      this.props.appState.hideAndBackupEditor(id);
+    }
   }
 }

--- a/src/renderer/components/editors-toolbar-button.tsx
+++ b/src/renderer/components/editors-toolbar-button.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import { Button } from '@blueprintjs/core';
 import { MosaicWindowContext } from 'react-mosaic-component';
 
-import { MosaicId } from '../../interfaces';
-import { isEditorId } from '../../utils/type-checks';
+import { DocsDemoPage, MosaicId } from '../../interfaces';
 import { AppState } from '../state';
 
 export interface ToolbarButtonProps {
@@ -65,5 +64,33 @@ export class RemoveButton extends React.PureComponent<ToolbarButtonProps> {
    */
   public remove() {
     this.props.appState.hideAndBackupMosaic(this.props.id);
+  }
+}
+
+export class DocsDemoGoHomeButton extends React.PureComponent<ToolbarButtonProps> {
+  public static contextTypes = MosaicWindowContext;
+  public context: MosaicWindowContext<MosaicId>;
+
+  constructor(props: ToolbarButtonProps) {
+    super(props);
+    this.goHome = this.goHome.bind(this);
+  }
+
+  public render() {
+    return (
+      <Button
+        icon='home'
+        className='bp3-small'
+        onClick={this.goHome}
+        text='Overview'
+      />
+    );
+  }
+
+  /**
+   * Remove this panel
+   */
+  public goHome() {
+    this.props.appState.currentDocsDemoPage = DocsDemoPage.DEFAULT;
   }
 }

--- a/src/renderer/components/editors-toolbar-button.tsx
+++ b/src/renderer/components/editors-toolbar-button.tsx
@@ -64,10 +64,6 @@ export class RemoveButton extends React.PureComponent<ToolbarButtonProps> {
    * Remove this panel
    */
   public remove() {
-    const { id } = this.props;
-
-    if (isEditorId(id)) {
-      this.props.appState.hideAndBackupEditor(id);
-    }
+    this.props.appState.hideAndBackupMosaic(this.props.id);
   }
 }

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -17,7 +17,7 @@ import { AppState } from '../state';
 import { activateTheme } from '../themes';
 import { Editor } from './editor';
 import { renderNonIdealState } from './editors-non-ideal-state';
-import { MaximizeButton, RemoveButton } from './editors-toolbar-button';
+import { DocsDemoGoHomeButton, MaximizeButton, RemoveButton } from './editors-toolbar-button';
 import { ShowMe } from './show-me';
 
 const defaultMonacoOptions: MonacoType.editor.IEditorOptions = {
@@ -34,7 +34,7 @@ export const TITLE_MAP: Record<MosaicId, string> = {
   main: 'Main Process',
   renderer: 'Renderer Process',
   html: 'HTML',
-  showMe: 'Docs & Demos'
+  docsDemo: 'Docs & Demos'
 };
 
 export interface EditorsProps {
@@ -168,6 +168,10 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
   public renderToolbar(
     { title }: MosaicWindowProps<MosaicId>, id: MosaicId
   ): JSX.Element {
+    const docsDemoGoHomeMaybe = id === PanelId.docsDemo
+      ? <DocsDemoGoHomeButton id={id} appState={this.props.appState} />
+      : null;
+
     return (
       <div>
         {/* Left */}
@@ -180,6 +184,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
         <div />
         {/* Right */}
         <div className='mosaic-controls'>
+          {docsDemoGoHomeMaybe}
           <MaximizeButton id={id} appState={this.props.appState} />
           <RemoveButton id={id} appState={this.props.appState} />
         </div>

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -29,10 +29,11 @@ const defaultMonacoOptions: MonacoType.editor.IEditorOptions = {
 const ViewIdMosaic = Mosaic.ofType<EditorId>() as any;
 const ViewIdMosaicWindow = MosaicWindow.ofType<EditorId>() as any;
 
-export const TITLE_MAP: Record<EditorId, string> = {
+export const TITLE_MAP: Record<MosaicId, string> = {
   main: 'Main Process',
   renderer: 'Renderer Process',
-  html: 'HTML'
+  html: 'HTML',
+  showMe: 'Docs & Info'
 };
 
 export interface EditorsProps {

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -18,6 +18,7 @@ import { activateTheme } from '../themes';
 import { Editor } from './editor';
 import { renderNonIdealState } from './editors-non-ideal-state';
 import { MaximizeButton, RemoveButton } from './editors-toolbar-button';
+import { ShowMe } from './show-me';
 
 const defaultMonacoOptions: MonacoType.editor.IEditorOptions = {
   minimap: {
@@ -85,10 +86,12 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
         label: 'Your current fiddle is unsaved. Do you want to discard it?'
       });
 
-      window.ElectronFiddle.app.setValues({
-        html: await getContent(EditorId.html, version),
-        renderer: await getContent(EditorId.renderer, version),
-        main: await getContent(EditorId.main, version),
+      window.ElectronFiddle.app.fileManager.setFiddle({
+        values: {
+          html: await getContent(EditorId.html, version),
+          renderer: await getContent(EditorId.renderer, version),
+          main: await getContent(EditorId.main, version),
+        }
       });
     });
 
@@ -216,10 +219,8 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
    * @param {AppState} _appState
    * @returns {JSX.Element}
    */
-  public renderGenericPanel(_id: PanelId, _appState: AppState): JSX.Element {
-    return (
-      <div />
-    );
+  public renderGenericPanel(_id: PanelId, appState: AppState): JSX.Element {
+    return <ShowMe appState={appState} />;
   }
 
   /**

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -31,9 +31,9 @@ const ViewIdMosaic = Mosaic.ofType<EditorId>() as any;
 const ViewIdMosaicWindow = MosaicWindow.ofType<EditorId>() as any;
 
 export const TITLE_MAP: Record<MosaicId, string> = {
-  main: 'Main Process',
-  renderer: 'Renderer Process',
-  html: 'HTML',
+  main: 'Main Process (main.js)',
+  renderer: 'Renderer Process (renderer.js)',
+  html: 'HTML (index.html)',
   docsDemo: 'Docs & Demos'
 };
 

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -233,12 +233,10 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     const { appState } = this.props;
     const { monaco } = this.state;
 
-    if (!monaco) return null;
-
     return (
       <Editor
         id={id}
-        monaco={monaco}
+        monaco={monaco!}
         appState={appState}
         monoacoOptions={defaultMonacoOptions}
       />

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -34,7 +34,7 @@ export const TITLE_MAP: Record<MosaicId, string> = {
   main: 'Main Process',
   renderer: 'Renderer Process',
   html: 'HTML',
-  showMe: 'Docs & Info'
+  showMe: 'Docs & Demos'
 };
 
 export interface EditorsProps {

--- a/src/renderer/components/show-me.tsx
+++ b/src/renderer/components/show-me.tsx
@@ -19,7 +19,7 @@ export interface ShowMeProps {
 export class ShowMe extends React.Component<ShowMeProps, {}> {
   public render() {
     const { currentDocsDemoPage: showMeName } = this.props.appState;
-    const Content = DOCS_DEMO_COMPONENTS[showMeName];
+    const Content = DOCS_DEMO_COMPONENTS[showMeName] || DOCS_DEMO_COMPONENTS.DEFAULT;
 
     return (
       <div className='show-me-panel'>

--- a/src/renderer/components/show-me.tsx
+++ b/src/renderer/components/show-me.tsx
@@ -1,0 +1,31 @@
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+import { AppState } from '../state';
+
+export interface ShowMeProps {
+  appState: AppState;
+}
+
+/**
+ * The root component for "show me" content - the fourth helpful
+ * panel.
+ *
+ * @class ShowMe
+ * @extends {React.Component<ShowMeProps, ShowMeState>}
+ */
+@observer
+export class ShowMe extends React.Component<ShowMeProps, {}> {
+  public render() {
+    const { templateName } = this.props.appState;
+
+    return (
+      <div className='show-me-panel'>
+        <h2>What's {templateName}?</h2>
+        <p className='bp3r-running-text'>
+          We're just trying to help.
+        </p>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/show-me.tsx
+++ b/src/renderer/components/show-me.tsx
@@ -2,12 +2,13 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { AppState } from '../state';
+import { DOCS_DEMO_COMPONENTS } from './show-me/index';
 
 export interface ShowMeProps {
   appState: AppState;
 }
 
-/**
+/**3
  * The root component for "show me" content - the fourth helpful
  * panel.
  *
@@ -17,14 +18,12 @@ export interface ShowMeProps {
 @observer
 export class ShowMe extends React.Component<ShowMeProps, {}> {
   public render() {
-    const { templateName } = this.props.appState;
+    const { currentDocsDemoPage: showMeName } = this.props.appState;
+    const Content = DOCS_DEMO_COMPONENTS[showMeName];
 
     return (
       <div className='show-me-panel'>
-        <h2>What's {templateName}?</h2>
-        <p className='bp3r-running-text'>
-          We're just trying to help.
-        </p>
+        <Content appState={this.props.appState} />
       </div>
     );
   }

--- a/src/renderer/components/show-me/app.tsx
+++ b/src/renderer/components/show-me/app.tsx
@@ -7,7 +7,7 @@ import { renderMoreDocumentation } from './more-information';
 import { getSubsetOnly } from './subset-only';
 
 /**
- * Show and hide button examples, only rendererd on macOS
+ * Show and hide button examples, only rendered on macOS
  *
  * @returns {JSX.Element | null}
  */

--- a/src/renderer/components/show-me/app.tsx
+++ b/src/renderer/components/show-me/app.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import { Button, Callout, Icon } from '@blueprintjs/core';
+import { remote } from 'electron';
+
+import { renderMoreDocumentation } from './more-information';
+import { getSubsetOnly } from './subset-only';
+
+/**
+ * Show and hide button examples, only rendererd on macOS
+ *
+ * @returns {JSX.Element | null}
+ */
+function ShowHide() {
+  if (process.platform !== 'darwin') return null;
+
+  const onClick = () => {
+    remote.app.hide();
+    setTimeout(() => {
+      remote.app.show();
+      remote.app.focus();
+    }, 1500);
+  };
+
+  return (
+    <>
+      <p>This button hides Electron Fiddle right away, showing it again in two seconds.</p>
+      <Button
+        icon='eye-off'
+        text='Hide Electron Fiddle'
+        onClick={onClick}
+      />
+    </>
+  );
+}
+
+export function ShowMeApp(_props: any): JSX.Element {
+  const [ secondsLeft, setSeconds ] = React.useState(-1);
+  const playFocus = () => {
+    setSeconds(3);
+    setTimeout(() => setSeconds(2), 1000);
+    setTimeout(() => setSeconds(1), 2000);
+    setTimeout(() => {
+      remote.app.focus();
+      setSeconds(-1);
+    }, 3000);
+  };
+
+  const [ paths, setPaths ] = React.useState('');
+  const playPaths = () => {
+    const pathsToQuery = [
+      'home',
+      'appData',
+      'userData',
+      'temp',
+      'downloads',
+      'desktop'
+    ];
+
+    let result = '';
+    pathsToQuery.forEach((item) => {
+      result += `${item}: ${remote.app.getPath(item)}\n`;
+    });
+
+    setPaths(result);
+  };
+
+  const [ metrics, setMetrics ] = React.useState('');
+  const playMetrics = () => {
+    setMetrics(JSON.stringify(remote.app.getAppMetrics(), undefined, 2));
+  };
+
+  return (
+    <>
+      <Icon icon='help' iconSize={40} style={{ float: 'left', margin: '0 10px 0 0' }} />
+      <p className='bp3r-running-text'>
+        The <code>app</code> module controls the app's application life-cycle. Most of the
+        events and methods available on this module are responsible for handling how your
+        interacts with the operating system or to set application-wide settings.
+      </p>
+      <h3>API Demos</h3>
+      {getSubsetOnly('app')}
+      <Callout
+        title='Hiding, Showing, Focussing'
+        icon='eye-open'
+      >
+        <p>
+          The app can ask the operating system for window focus. On macOS, it can additionally
+          request that the app be hidden or shown. Give it a try: Click on the button below,
+          focus another app, and wait for two seconds to see Electron Fiddle become the focused
+          app again.
+        </p>
+        <Button
+          icon='lightbulb'
+          text={`Focus Electron Fiddle${secondsLeft > 0 ? ` in ${secondsLeft}s` : ''}`}
+          onClick={playFocus}
+        />
+        <ShowHide />
+      </Callout>
+      <Callout
+        title='Paths'
+        icon='folder-open'
+      >
+        <p>
+          Need to query information about various paths in a cross-platform manner? Electron
+          can help. The button queries the operating system for some of them.
+        </p>
+        <Button
+          icon='play'
+          text={`Get special directory paths`}
+          onClick={playPaths}
+        />
+        <pre>
+          {paths}
+        </pre>
+      </Callout>
+      <Callout
+        title='Process & Device Information'
+        icon='pulse'
+      >
+        <p>
+          Need to query information about the process or system? The <code>app</code> module lets
+          developers query for information about the running app, hardware, and operating system.
+          A good example are process metrics.
+        </p>
+        <Button
+          icon='play'
+          text={`Get process metrics`}
+          onClick={playMetrics}
+        />
+        <pre>
+          {metrics}
+        </pre>
+      </Callout>
+      {renderMoreDocumentation()}
+    </>
+  );
+}

--- a/src/renderer/components/show-me/app.tsx
+++ b/src/renderer/components/show-me/app.tsx
@@ -91,6 +91,7 @@ export function ShowMeApp(_props: any): JSX.Element {
           app again.
         </p>
         <Button
+          id='focus'
           icon='lightbulb'
           text={`Focus Electron Fiddle${secondsLeft > 0 ? ` in ${secondsLeft}s` : ''}`}
           onClick={playFocus}
@@ -106,6 +107,7 @@ export function ShowMeApp(_props: any): JSX.Element {
           can help. The button queries the operating system for some of them.
         </p>
         <Button
+          id='special-paths'
           icon='play'
           text={`Get special directory paths`}
           onClick={playPaths}
@@ -124,6 +126,7 @@ export function ShowMeApp(_props: any): JSX.Element {
           A good example are process metrics.
         </p>
         <Button
+          id='process-metrics'
           icon='play'
           text={`Get process metrics`}
           onClick={playMetrics}

--- a/src/renderer/components/show-me/app.tsx
+++ b/src/renderer/components/show-me/app.tsx
@@ -26,6 +26,7 @@ function ShowHide() {
     <>
       <p>This button hides Electron Fiddle right away, showing it again in two seconds.</p>
       <Button
+        id='show-hide'
         icon='eye-off'
         text='Hide Electron Fiddle'
         onClick={onClick}
@@ -33,9 +34,9 @@ function ShowHide() {
     </>
   );
 }
-
 export function ShowMeApp(_props: any): JSX.Element {
   const [ secondsLeft, setSeconds ] = React.useState(-1);
+
   const playFocus = () => {
     setSeconds(3);
     setTimeout(() => setSeconds(2), 1000);
@@ -112,7 +113,7 @@ export function ShowMeApp(_props: any): JSX.Element {
           text={`Get special directory paths`}
           onClick={playPaths}
         />
-        <pre>
+        <pre id='special-paths-content'>
           {paths}
         </pre>
       </Callout>
@@ -131,7 +132,7 @@ export function ShowMeApp(_props: any): JSX.Element {
           text={`Get process metrics`}
           onClick={playMetrics}
         />
-        <pre>
+        <pre id='process-metrics-content'>
           {metrics}
         </pre>
       </Callout>

--- a/src/renderer/components/show-me/default.tsx
+++ b/src/renderer/components/show-me/default.tsx
@@ -2,11 +2,11 @@ import { Button, Icon } from '@blueprintjs/core';
 import * as React from 'react';
 
 import { DocsDemoPage } from '../../../interfaces';
-import { AppState, appState } from '../../state';
+import { AppState } from '../../state';
 import { DOCS_DEMO_COMPONENTS, DOCS_DEMO_NAMES } from './index';
 import { renderMoreDocumentation } from './more-information';
 
-export function ShowMeDefault(_props: { appState: AppState }): JSX.Element {
+export function ShowMeDefault(props: { appState: AppState }): JSX.Element {
   const showMeMenu: Array<JSX.Element> = Object.keys(DOCS_DEMO_COMPONENTS)
     .filter((key) => key !== DocsDemoPage.DEFAULT)
     .map((key) => {
@@ -16,7 +16,7 @@ export function ShowMeDefault(_props: { appState: AppState }): JSX.Element {
             minimal={true}
             icon='play'
             text={DOCS_DEMO_NAMES[key]}
-            onClick={() => (appState.currentDocsDemoPage = key as DocsDemoPage)}
+            onClick={() => (props.appState.currentDocsDemoPage = key as DocsDemoPage)}
           />
         </li>
       );

--- a/src/renderer/components/show-me/default.tsx
+++ b/src/renderer/components/show-me/default.tsx
@@ -1,0 +1,43 @@
+import { Button, Icon } from '@blueprintjs/core';
+import * as React from 'react';
+
+import { DocsDemoPage } from '../../../interfaces';
+import { AppState, appState } from '../../state';
+import { DOCS_DEMO_COMPONENTS, DOCS_DEMO_NAMES } from './index';
+import { renderMoreDocumentation } from './more-information';
+
+export function ShowMeDefault(_props: { appState: AppState }): JSX.Element {
+  const showMeMenu: Array<JSX.Element> = Object.keys(DOCS_DEMO_COMPONENTS)
+    .filter((key) => key !== DocsDemoPage.DEFAULT)
+    .map((key) => {
+      return (
+        <li key={key}>
+          <Button
+            minimal={true}
+            icon='play'
+            text={DOCS_DEMO_NAMES[key]}
+            onClick={() => (appState.currentDocsDemoPage = key as DocsDemoPage)}
+          />
+        </li>
+      );
+  });
+
+  return (
+    <>
+      <Icon icon='help' iconSize={40} style={{ float: 'left', margin: '0 10px 0 0' }} />
+      <p className='bp3r-running-text'>
+        This panel offers useful information about Electron APIs – and
+        easy way to try some of the methods it offers. Fiddle has an example fiddle
+        for every module available in Electron.
+      </p>
+      <p>
+        Clicking on any of the modules below will open up a fiddle showcasing
+        that particular module.
+      </p>
+      <ul className='show-me-list'>
+        {...showMeMenu}
+      </ul>
+      {renderMoreDocumentation()}
+    </>
+  );
+}

--- a/src/renderer/components/show-me/index.tsx
+++ b/src/renderer/components/show-me/index.tsx
@@ -1,0 +1,14 @@
+import { DocsDemoPage } from '../../../interfaces';
+
+import { ShowMeApp } from './app';
+import { ShowMeDefault } from './default';
+
+export const DOCS_DEMO_COMPONENTS: Record<DocsDemoPage, any> = {
+  DEFAULT: ShowMeDefault,
+  DEMO_APP: ShowMeApp
+};
+
+export const DOCS_DEMO_NAMES: Record<DocsDemoPage, string> = {
+  DEFAULT: 'Home',
+  DEMO_APP: 'App Demos'
+};

--- a/src/renderer/components/show-me/more-information.tsx
+++ b/src/renderer/components/show-me/more-information.tsx
@@ -19,13 +19,13 @@ export function renderMoreDocumentation(
     <>
       <br />
       <p className='b3-running-text'>
-        For more documentation, visit <a onClick={() => shell.openExternal(fullUrl)}>{url}</a>, where
+        For more documentation, visit <a id='open-url' onClick={() => shell.openExternal(fullUrl)}>{url}</a>, where
         you can find the full documentation for Electron.
       </p>
       <p className='bp3-text-muted'>
         By the way, Electron Fiddle and the documentation you see here is entirely open source. If you
         have ideas on how to improve it, we'd love to have your contributions! You can find the
-        repository on <a onClick={() => shell.openExternal(gitHubUrl)}>GitHub</a>.
+        repository on <a id='open-github' onClick={() => shell.openExternal(gitHubUrl)}>GitHub</a>.
       </p>
     </>
   );

--- a/src/renderer/components/show-me/more-information.tsx
+++ b/src/renderer/components/show-me/more-information.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import { shell } from 'electron';
+
+/**
+ * Renders a "more documentation" block, typically used at the end of a "show me" documentation piece.
+ *
+ * @export
+ * @param {string} [url='electronjs.org/docs']
+ * @returns {JSX.Element}
+ */
+export function renderMoreDocumentation(
+  url: string = 'electronjs.org/docs'
+): JSX.Element {
+  const fullUrl = `https://${url}`;
+  const gitHubUrl = `https://github.com/electron/fiddle`;
+
+  return (
+    <>
+      <br />
+      <p className='b3-running-text'>
+        For more documentation, visit <a onClick={() => shell.openExternal(fullUrl)}>{url}</a>, where
+        you can find the full documentation for Electron.
+      </p>
+      <p className='bp3-text-muted'>
+        By the way, Electron Fiddle and the documentation you see here is entirely open source. If you
+        have ideas on how to improve it, we'd love to have your contributions! You can find the
+        repository on <a onClick={() => shell.openExternal(gitHubUrl)}>GitHub</a>.
+      </p>
+    </>
+  );
+}

--- a/src/renderer/components/show-me/subset-only.tsx
+++ b/src/renderer/components/show-me/subset-only.tsx
@@ -1,0 +1,26 @@
+import * as React from 'React';
+
+import { shell } from 'electron';
+
+import { getDocsUrlForModule } from '../../../utils/docs-urls';
+
+/**
+ * Returns a common string we use as a disclaimer to explain that this set of demos
+ * is only meant to be a short demonstration, not displaying all of the modules
+ * abilities.
+ *
+ * @export
+ * @param {string} moduleName
+ * @returns {JSX.Element}
+ */
+export function getSubsetOnly(moduleName: string): JSX.Element {
+  const { full, short } = getDocsUrlForModule(moduleName);
+
+  return (
+    <p className='bp3-running-text'>
+      The following demos display only a subset of what the <code>{moduleName}</code>
+      module is capable of. If you want to see its full abilities, check out the
+      documentation on <a onClick={() => shell.openExternal(full)}>{short}</a>.
+    </p>
+  );
+}

--- a/src/renderer/components/show-me/subset-only.tsx
+++ b/src/renderer/components/show-me/subset-only.tsx
@@ -20,7 +20,7 @@ export function getSubsetOnly(moduleName: string): JSX.Element {
     <p className='bp3-running-text'>
       The following demos display only a subset of what the <code>{moduleName}</code>
       module is capable of. If you want to see its full abilities, check out the
-      documentation on <a onClick={() => shell.openExternal(full)}>{short}</a>.
+      documentation on <a id='open-url' onClick={() => shell.openExternal(full)}>{short}</a>.
     </p>
   );
 }

--- a/src/renderer/components/show-me/subset-only.tsx
+++ b/src/renderer/components/show-me/subset-only.tsx
@@ -1,4 +1,4 @@
-import * as React from 'React';
+import * as React from 'react';
 
 import { shell } from 'electron';
 

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -2,14 +2,14 @@ import { remote } from 'electron';
 import * as path from 'path';
 import { MosaicNode } from 'react-mosaic-component';
 
-import { EditorId } from '../interfaces';
+import { EditorId, MosaicId } from '../interfaces';
 
 // Reminder: When testing, this file is mocked in tests/setup.js
 
 export const USER_DATA_PATH = remote.app.getPath('userData');
 export const CONFIG_PATH = path.join(remote.app.getPath('home'), '.electron-fiddle');
 
-export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<EditorId> = {
+export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<MosaicId> = {
   direction: 'row',
   first: EditorId.main,
   second: {

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -1,7 +1,7 @@
 import * as fsType from 'fs-extra';
 import * as path from 'path';
 
-import { EditorValues, Files, FileTransform } from '../interfaces';
+import { EditorValues, Files, FileTransform, SetFiddleOptions } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { INDEX_HTML_NAME, MAIN_JS_NAME, PACKAGE_NAME, RENDERER_JS_NAME } from '../shared-constants';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
@@ -43,7 +43,8 @@ export class FileManager {
    */
   public async openTemplate(name: string) {
     const values = await getTemplateValues(name);
-    this.setFiddle(values);
+
+    this.setFiddle({ values, templateName: name });
   }
 
   /**
@@ -65,19 +66,20 @@ export class FileManager {
       renderer: await this.readFile(path.join(filePath, RENDERER_JS_NAME)),
     };
 
-    this.setFiddle(values);
+    this.setFiddle({ values, filePath });
   }
 
   /**
    * Got values? This method will load them.
    *
-   * @param {EditorValues} values
+   * @param {SetFiddleOptions} options
    * @memberof FileManager
    */
-  public async setFiddle(values: EditorValues, filePath?: string) {
+  public async setFiddle({ values, filePath, templateName }: SetFiddleOptions) {
     this.appState.gistId = '';
     this.appState.isMyGist = false;
-    this.appState.localPath = filePath || null;
+    this.appState.localPath = filePath;
+    this.appState.templateName = templateName;
 
     this.appState.setWarningDialogTexts({
       label: `Opening this fiddle will replace your unsaved changes. Do you want to proceed?`,

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -3,6 +3,7 @@ import { MosaicNode } from 'react-mosaic-component';
 
 import {
   ALL_MOSAICS,
+  DocsDemoPage,
   EditorId,
   ElectronVersion,
   ElectronVersionSource,
@@ -11,8 +12,7 @@ import {
   NpmVersion,
   OutputEntry,
   OutputOptions,
-  WarningDialogTexts,
-  ALL_PANELS
+  WarningDialogTexts
 } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { arrayToStringMap } from '../utils/array-to-stringmap';
@@ -91,6 +91,7 @@ export class AppState {
   @observable public isRunning = false;
   @observable public mosaicArrangement: MosaicNode<MosaicId> | null = DEFAULT_MOSAIC_ARRANGEMENT;
   @observable public templateName: string | undefined;
+  @observable public currentDocsDemoPage: DocsDemoPage = DocsDemoPage.DEFAULT;
 
   // -- Various "isShowing" settings ------------------
   @observable public isConsoleShowing: boolean = false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -83,12 +83,13 @@ export class AppState {
   @observable public isMyGist: boolean = false;
   @observable public versions: Record<string, ElectronVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
-  @observable public localPath: string | null = null;
+  @observable public localPath: string | undefined;
   @observable public isUpdatingElectronVersions = false;
   @observable public warningDialogTexts = { label: '', ok: 'Okay', cancel: 'Cancel' };
   @observable public warningDialogLastResult: boolean | null = null;
   @observable public isRunning = false;
   @observable public mosaicArrangement: MosaicNode<MosaicId> | null = DEFAULT_MOSAIC_ARRANGEMENT;
+  @observable public templateName: string | undefined;
 
   // -- Various "isShowing" settings ------------------
   @observable public isConsoleShowing: boolean = false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -2,10 +2,12 @@ import { action, autorun, computed, observable, when } from 'mobx';
 import { MosaicNode } from 'react-mosaic-component';
 
 import {
+  ALL_MOSAICS,
   EditorId,
   ElectronVersion,
   ElectronVersionSource,
   ElectronVersionState,
+  MosaicId,
   NpmVersion,
   OutputEntry,
   OutputOptions,
@@ -14,9 +16,10 @@ import {
 import { IpcEvents } from '../ipc-events';
 import { arrayToStringMap } from '../utils/array-to-stringmap';
 import { EditorBackup, getEditorBackup } from '../utils/editor-backup';
-import { createMosaicArrangement, getVisibleEditors } from '../utils/editors-mosaic-arrangement';
+import { createMosaicArrangement, getVisibleMosaics } from '../utils/editors-mosaic-arrangement';
 import { getName } from '../utils/get-title';
 import { normalizeVersion } from '../utils/normalize-version';
+import { isEditorBackup, isEditorId } from '../utils/type-checks';
 import { BinaryManager } from './binary';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
 import { getContent, isContentUnchanged } from './content';
@@ -85,7 +88,7 @@ export class AppState {
   @observable public warningDialogTexts = { label: '', ok: 'Okay', cancel: 'Cancel' };
   @observable public warningDialogLastResult: boolean | null = null;
   @observable public isRunning = false;
-  @observable public mosaicArrangement: MosaicNode<EditorId> | null = DEFAULT_MOSAIC_ARRANGEMENT;
+  @observable public mosaicArrangement: MosaicNode<MosaicId> | null = DEFAULT_MOSAIC_ARRANGEMENT;
 
   // -- Various "isShowing" settings ------------------
   @observable public isConsoleShowing: boolean = false;
@@ -97,7 +100,7 @@ export class AppState {
   @observable public isTourShowing: boolean = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
-  @observable public closedEditors: Partial<Record<EditorId, EditorBackup>> = {};
+  @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = {};
 
   private outputBuffer: string = '';
   private name: string;
@@ -466,48 +469,51 @@ export class AppState {
    * @param {EditorId} id
    */
   @action public getAndRemoveEditorValueBackup(id: EditorId): EditorBackup | null {
-    const value = this.closedEditors[id];
+    const value = this.closedPanels[id];
 
-    if (value) {
-      delete this.closedEditors[id];
+    if (isEditorBackup(value)) {
+      delete this.closedPanels[id];
       return value;
     }
 
     return null;
   }
 
-  @action public setVisibleEditors(visible: Array<EditorId>) {
-    const currentlyVisible = getVisibleEditors(this.mosaicArrangement);
+  @action public setVisibleMosaics(visible: Array<MosaicId>) {
+    const currentlyVisible = getVisibleMosaics(this.mosaicArrangement);
 
-    for (const id of [ EditorId.main, EditorId.html, EditorId.renderer ]) {
+    for (const id of ALL_MOSAICS) {
       if (!visible.includes(id) && currentlyVisible.includes(id)) {
-        this.closedEditors[id] = getEditorBackup(id);
+        this.closedPanels[id] = isEditorId(id)
+          ? getEditorBackup(id)
+          : true;
       }
     }
 
-    this.mosaicArrangement = createMosaicArrangement(visible);
+    const updatedArrangement = createMosaicArrangement(visible);
+    console.log(`State: Setting visible mosaic panels`, visible, updatedArrangement);
+
+    this.mosaicArrangement = updatedArrangement;
   }
 
   /**
-   * Hides the editor for a given editor.
+   * Hides the panel for a given MosaicId.
    *
-   * @param {EditorId} id
+   * @param {MosaicId} id
    */
-  @action public hideAndBackupEditor(id: EditorId) {
-    this.closedEditors[id] = getEditorBackup(id);
-
-    const currentlyVisible = getVisibleEditors(this.mosaicArrangement);
-    this.setVisibleEditors(currentlyVisible.filter((v) => v !== id));
+  @action public hideAndBackupMosaic(id: MosaicId) {
+    const currentlyVisible = getVisibleMosaics(this.mosaicArrangement);
+    this.setVisibleMosaics(currentlyVisible.filter((v) => v !== id));
   }
 
   /**
    * Shows the editor value for a given editor.
    *
-   * @param {EditorId} id
+   * @param {MosaicId} id
    */
-  @action public showEditor(id: EditorId) {
-    const currentlyVisible = getVisibleEditors(this.mosaicArrangement);
-    this.setVisibleEditors([ ...currentlyVisible, id ]);
+  @action public showMosaic(id: MosaicId) {
+    const currentlyVisible = getVisibleMosaics(this.mosaicArrangement);
+    this.setVisibleMosaics([ ...currentlyVisible, id ]);
   }
 
   /**

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -104,7 +104,7 @@ export class AppState {
 
   // -- Editor Values stored when we close the editor ------------------
   @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = {
-    showMe: true // Closed by default
+    docsDemo: true // Closed by default
   };
 
   private outputBuffer: string = '';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -11,7 +11,8 @@ import {
   NpmVersion,
   OutputEntry,
   OutputOptions,
-  WarningDialogTexts
+  WarningDialogTexts,
+  ALL_PANELS
 } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { arrayToStringMap } from '../utils/array-to-stringmap';
@@ -19,7 +20,7 @@ import { EditorBackup, getEditorBackup } from '../utils/editor-backup';
 import { createMosaicArrangement, getVisibleMosaics } from '../utils/editors-mosaic-arrangement';
 import { getName } from '../utils/get-title';
 import { normalizeVersion } from '../utils/normalize-version';
-import { isEditorBackup, isEditorId } from '../utils/type-checks';
+import { isEditorBackup, isEditorId, isPanelId } from '../utils/type-checks';
 import { BinaryManager } from './binary';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
 import { getContent, isContentUnchanged } from './content';
@@ -101,7 +102,9 @@ export class AppState {
   @observable public isTourShowing: boolean = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
-  @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = {};
+  @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = {
+    showMe: true // Closed by default
+  };
 
   private outputBuffer: string = '';
   private name: string;
@@ -488,6 +491,12 @@ export class AppState {
         this.closedPanels[id] = isEditorId(id)
           ? getEditorBackup(id)
           : true;
+      }
+
+      // Remove the backup for panels now. Editors will remove their
+      // backup once the data has been loaded.
+      if (isPanelId(id) && visible.includes(id) && !currentlyVisible.includes(id)) {
+        delete this.closedPanels[id];
       }
     }
 

--- a/src/utils/docs-urls.ts
+++ b/src/utils/docs-urls.ts
@@ -1,0 +1,13 @@
+/**
+ * Get all the documentation urls for a given module name.
+ *
+ * @export
+ * @param {string} moduleName
+ */
+export function getDocsUrlForModule(moduleName: string) {
+  return {
+    full: `https://electronjs.org/docs/api/${moduleName}`,
+    repo: `https://github.com/electron/electron/blob/master/docs/api/${moduleName}.md`,
+    short: `electronjs.org/docs/api/${moduleName}`
+  };
+}

--- a/src/utils/editors-mosaic-arrangement.ts
+++ b/src/utils/editors-mosaic-arrangement.ts
@@ -17,12 +17,13 @@ export function createMosaicArrangement(
   }
 
   // This cuts out the first half of input. Input becomes the second half.
-  const firstHalf = input.splice(0, Math.floor(input.length / 2));
+  const secondHalf = [ ...input ];
+  const firstHalf = secondHalf.splice(0, Math.floor(secondHalf.length / 2));
 
   return {
     direction,
     first: createMosaicArrangement(firstHalf, 'column'),
-    second: createMosaicArrangement(input, 'column')
+    second: createMosaicArrangement(secondHalf, 'column')
   };
 }
 

--- a/src/utils/editors-mosaic-arrangement.ts
+++ b/src/utils/editors-mosaic-arrangement.ts
@@ -1,39 +1,39 @@
-import { MosaicNode } from 'react-mosaic-component';
+import { MosaicDirection, MosaicNode } from 'react-mosaic-component';
 
-import { EditorId } from '../interfaces';
-import { DEFAULT_MOSAIC_ARRANGEMENT } from '../renderer/constants';
+import { MosaicId } from '../interfaces';
 
 /**
  * Create a mosaic arrangement given an array of editor ids.
  *
  * @export
- * @param {Array<EditorId>} input
- * @returns {MosaicNode<EditorId>}
+ * @param {Array<MosaicId>} input
+ * @returns {MosaicNode<MosaicId>}
  */
-export function createMosaicArrangement(input: Array<EditorId>): MosaicNode<EditorId> {
-  if (input.length === 2) {
-    return {
-      direction: 'column',
-      first: input[0],
-      second: input[1]
-    };
+export function createMosaicArrangement(
+  input: Array<MosaicId>, direction: MosaicDirection = 'row'
+): MosaicNode<MosaicId> {
+  if (input.length === 1) {
+    return input[0];
   }
 
-  if (input.length === 3) {
-    return DEFAULT_MOSAIC_ARRANGEMENT;
-  }
+  // This cuts out the first half of input. Input becomes the second half.
+  const firstHalf = input.splice(0, Math.floor(input.length / 2));
 
-  return input[0];
+  return {
+    direction,
+    first: createMosaicArrangement(firstHalf, 'column'),
+    second: createMosaicArrangement(input, 'column')
+  };
 }
 
 /**
  * Returns an array of visible editors given a mosaic arrangement.
  *
  * @export
- * @param {MosaicNode<EditorId> | null} input
- * @returns {Array<EditorId>}
+ * @param {MosaicNode<MosaicId> | null} input
+ * @returns {Array<MosaicId>}
  */
-export function getVisibleEditors(input: MosaicNode<EditorId> | null): Array<EditorId> {
+export function getVisibleMosaics(input: MosaicNode<MosaicId> | null): Array<MosaicId> {
   // Handle the unlikely null case
   if (!input) return [];
 
@@ -42,13 +42,13 @@ export function getVisibleEditors(input: MosaicNode<EditorId> | null): Array<Edi
     return [ input ];
   }
 
-  // Handle the other cases (2 or 3)
+  // Handle the other cases (2 - 4)
   const result = [];
   for (const node of [ input.first, input.second ]) {
     if (typeof node === 'string') {
       result.push(node);
     } else {
-      result.push(...getVisibleEditors(node));
+      result.push(...getVisibleMosaics(node));
     }
   }
 

--- a/src/utils/type-checks.ts
+++ b/src/utils/type-checks.ts
@@ -1,4 +1,5 @@
 import { ALL_EDITORS, EditorId, MosaicId, PanelId } from '../interfaces';
+import { EditorBackup } from './editor-backup';
 
 /**
  * Is the given string of type `EditorId`?
@@ -20,4 +21,15 @@ export function isEditorId(input: EditorId | PanelId | MosaicId): input is Edito
  */
 export function isMosaicId(input: EditorId | PanelId | MosaicId): input is MosaicId {
   return !(ALL_EDITORS as any).includes(input);
+}
+
+/**
+ * Is the given input of type `EditorBackup`?
+ *
+ * @export
+ * @param {(EditorBackup | true)} input
+ * @returns {input is EditorBackup}
+ */
+export function isEditorBackup(input?: EditorBackup | true | null): input is EditorBackup {
+  return !!(input && input !== true);
 }

--- a/src/utils/type-checks.ts
+++ b/src/utils/type-checks.ts
@@ -19,7 +19,7 @@ export function isEditorId(input: EditorId | PanelId | MosaicId): input is Edito
  * @param {(EditorId | PanelId | MosaicId)} input
  * @returns {input is MosaicId}
  */
-export function isMosaicId(input: EditorId | PanelId | MosaicId): input is MosaicId {
+export function isPanelId(input: EditorId | PanelId | MosaicId): input is MosaicId {
   return !(ALL_EDITORS as any).includes(input);
 }
 

--- a/src/utils/type-checks.ts
+++ b/src/utils/type-checks.ts
@@ -1,0 +1,23 @@
+import { ALL_EDITORS, EditorId, MosaicId, PanelId } from '../interfaces';
+
+/**
+ * Is the given string of type `EditorId`?
+ *
+ * @export
+ * @param {(EditorId | PanelId | MosaicId)} input
+ * @returns {input is EditorId}
+ */
+export function isEditorId(input: EditorId | PanelId | MosaicId): input is EditorId {
+  return (ALL_EDITORS as any).includes(input);
+}
+
+/**
+ * Is the given string of type `MosaicId`?
+ *
+ * @export
+ * @param {(EditorId | PanelId | MosaicId)} input
+ * @returns {input is MosaicId}
+ */
+export function isMosaicId(input: EditorId | PanelId | MosaicId): input is MosaicId {
+  return !(ALL_EDITORS as any).includes(input);
+}

--- a/src/utils/type-checks.ts
+++ b/src/utils/type-checks.ts
@@ -13,13 +13,13 @@ export function isEditorId(input: EditorId | PanelId | MosaicId): input is Edito
 }
 
 /**
- * Is the given string of type `MosaicId`?
+ * Is the given string of type `isPanelId`?
  *
  * @export
  * @param {(EditorId | PanelId | MosaicId)} input
  * @returns {input is MosaicId}
  */
-export function isPanelId(input: EditorId | PanelId | MosaicId): input is MosaicId {
+export function isPanelId(input: EditorId | PanelId | MosaicId): input is PanelId {
   return !(ALL_EDITORS as any).includes(input);
 }
 

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -102,6 +102,7 @@ const app = {
     if (name === 'home') return `~`;
     return '/test-path';
   },
+  focus: jest.fn(),
   quit: jest.fn(),
   relaunch: jest.fn(),
   setJumpList: jest.fn(),

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -86,12 +86,14 @@ function CreateWindowStub() {
 const app = {
   getName: jest.fn().mockReturnValue('Electron Fiddle'),
   exit: jest.fn(),
+  hide: jest.fn(),
+  show: jest.fn(),
   isDefaultProtocolClient: jest.fn().mockReturnValue(true),
   setAsDefaultProtocolClient: jest.fn(),
   isReady: jest.fn().mockReturnValue(true),
   isInApplicationsFolder: jest.fn().mockReturnValue(true),
   moveToApplicationsFolder: jest.fn(),
-  getAppMetrics: jest.fn(),
+  getAppMetrics: jest.fn().mockReturnValue({ metrics: 123 }),
   getGPUFeatureStatus: jest.fn(),
   getJumpListSettings: jest.fn(() => ({
     removedItems: []

--- a/tests/mocks/file-manager.ts
+++ b/tests/mocks/file-manager.ts
@@ -1,4 +1,5 @@
 export class FileManager {
   public saveToTemp = jest.fn(() => '/mock/temp/dir');
+  public setFiddle = jest.fn();
   public cleanup = jest.fn();
 }

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -3,5 +3,5 @@ import { observable } from 'mobx';
 export class MockState {
   @observable public isWarningDialogShowing = false;
   @observable public gistId = '';
-  @observable public closedEditors = {};
+  @observable public closedPanels = {};
 }

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -1,4 +1,5 @@
 import { App } from '../../src/renderer/app';
+import { EditorBackup } from '../../src/utils/editor-backup';
 import { ElectronFiddleMock } from '../mocks/electron-fiddle';
 import { MockState } from '../mocks/state';
 
@@ -113,7 +114,7 @@ describe('Editors component', () => {
         renderer: 'renderer-value'
       });
 
-      expect(app.state.closedPanels.main!.model!.setValue)
+      expect((app.state.closedPanels.main as EditorBackup)!.model!.setValue)
         .toHaveBeenCalledWith('main-value');
 
       window.ElectronFiddle.editors.main = oldMainEditor;

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -7,7 +7,7 @@ jest.mock('../../src/renderer/state', () => ({
   appState: {
     theme: 'defaultDark',
     getName: () => 'Test',
-    closedEditors: {}
+    closedPanels: {}
   }
 }));
 jest.mock('../../src/renderer/components/header', () => ({
@@ -106,14 +106,14 @@ describe('Editors component', () => {
       delete window.ElectronFiddle.editors.main;
 
       const app = new App();
-      (app.state.closedEditors as any).main = { model: { setValue: jest.fn() } };
+      (app.state.closedPanels as any).main = { model: { setValue: jest.fn() } };
       app.setValues({
         html: 'html-value',
         main: 'main-value',
         renderer: 'renderer-value'
       });
 
-      expect(app.state.closedEditors.main!.model!.setValue)
+      expect(app.state.closedPanels.main!.model!.setValue)
         .toHaveBeenCalledWith('main-value');
 
       window.ElectronFiddle.editors.main = oldMainEditor;

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`EditorDropdown component renders 1`] = `
           onClick={[Function]}
           popoverProps={Object {}}
           shouldDismissPopover={true}
-          text="Main Process"
+          text="Main Process (main.js)"
         />
         <Blueprint3.MenuItem
           disabled={false}
@@ -25,7 +25,7 @@ exports[`EditorDropdown component renders 1`] = `
           onClick={[Function]}
           popoverProps={Object {}}
           shouldDismissPopover={true}
-          text="Renderer Process"
+          text="Renderer Process (renderer.js)"
         />
         <Blueprint3.MenuItem
           disabled={false}
@@ -35,7 +35,7 @@ exports[`EditorDropdown component renders 1`] = `
           onClick={[Function]}
           popoverProps={Object {}}
           shouldDismissPopover={true}
-          text="HTML"
+          text="HTML (index.html)"
         />
       </Blueprint3.Menu>
     }

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -60,12 +60,5 @@ exports[`EditorDropdown component renders 1`] = `
       text="Editors"
     />
   </Blueprint3.Popover>
-  <Blueprint3.Button
-    active={true}
-    icon="help"
-    id="docsDemo"
-    onClick={[Function]}
-    text="Docs & Demos"
-  />
 </Fragment>
 `;

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -63,9 +63,9 @@ exports[`EditorDropdown component renders 1`] = `
   <Blueprint3.Button
     active={true}
     icon="help"
-    id="showMe"
+    id="docsDemo"
     onClick={[Function]}
-    text="Docs & Info"
+    text="Docs & Demos"
   />
 </Fragment>
 `;

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -1,72 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditorDropdown component renders 1`] = `
-<Blueprint3.Popover
-  boundary="scrollParent"
-  captureDismiss={false}
-  content={
-    <Blueprint3.Menu>
-      <Blueprint3.MenuItem
-        disabled={false}
-        icon="eye-off"
-        id="main"
-        multiline={false}
-        onClick={[Function]}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="Main Process"
-      />
-      <Blueprint3.MenuItem
-        disabled={false}
-        icon="eye-open"
-        id="renderer"
-        multiline={false}
-        onClick={[Function]}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="Renderer Process"
-      />
-      <Blueprint3.MenuItem
-        disabled={false}
-        icon="eye-open"
-        id="html"
-        multiline={false}
-        onClick={[Function]}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="HTML"
-      />
-      <Blueprint3.MenuItem
-        disabled={false}
-        icon="eye-off"
-        id="showMe"
-        multiline={false}
-        onClick={[Function]}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="Docs & Info"
-      />
-    </Blueprint3.Menu>
-  }
-  defaultIsOpen={false}
-  disabled={false}
-  hasBackdrop={false}
-  hoverCloseDelay={300}
-  hoverOpenDelay={150}
-  inheritDarkTheme={true}
-  interactionKind="click"
-  minimal={false}
-  modifiers={Object {}}
-  openOnTargetFocus={true}
-  position="bottom"
-  targetTagName="span"
-  transitionDuration={300}
-  usePortal={true}
-  wrapperTagName="span"
->
+<Fragment>
+  <Blueprint3.Popover
+    boundary="scrollParent"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Menu>
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-off"
+          id="main"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Main Process"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-open"
+          id="renderer"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Renderer Process"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-open"
+          id="html"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="HTML"
+        />
+      </Blueprint3.Menu>
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    modifiers={Object {}}
+    openOnTargetFocus={true}
+    position="bottom"
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+    wrapperTagName="span"
+  >
+    <Blueprint3.Button
+      icon="applications"
+      text="Editors"
+    />
+  </Blueprint3.Popover>
   <Blueprint3.Button
-    icon="applications"
-    text="Editors"
+    active={true}
+    icon="help"
+    id="showMe"
+    onClick={[Function]}
+    text="Docs & Info"
   />
-</Blueprint3.Popover>
+</Fragment>
 `;

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -36,6 +36,16 @@ exports[`EditorDropdown component renders 1`] = `
         shouldDismissPopover={true}
         text="HTML"
       />
+      <Blueprint3.MenuItem
+        disabled={false}
+        icon="eye-off"
+        id="showMe"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Docs & Info"
+      />
     </Blueprint3.Menu>
   }
   defaultIsOpen={false}

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -60,5 +60,82 @@ exports[`EditorDropdown component renders 1`] = `
       text="Editors"
     />
   </Blueprint3.Popover>
+  <Blueprint3.Button
+    active={true}
+    icon="help"
+    id="docsDemo"
+    onClick={[Function]}
+    text="Docs & Demos"
+  />
+</Fragment>
+`;
+
+exports[`EditorDropdown component renders the extra button if the FIDDLE_DOCS_DEMOS is set 1`] = `
+<Fragment>
+  <Blueprint3.Popover
+    boundary="scrollParent"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Menu>
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-off"
+          id="main"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Main Process (main.js)"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-open"
+          id="renderer"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Renderer Process (renderer.js)"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-open"
+          id="html"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="HTML (index.html)"
+        />
+      </Blueprint3.Menu>
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    modifiers={Object {}}
+    openOnTargetFocus={true}
+    position="bottom"
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+    wrapperTagName="span"
+  >
+    <Blueprint3.Button
+      icon="applications"
+      text="Editors"
+    />
+  </Blueprint3.Popover>
+  <Blueprint3.Button
+    active={true}
+    icon="help"
+    id="docsDemo"
+    onClick={[Function]}
+    text="Docs & Demos"
+  />
 </Fragment>
 `;

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Editors component renders 1`] = `
       key="main"
       style={
         Object {
-          "bottom": "0%",
+          "bottom": "50%",
           "left": "0%",
           "right": "50%",
           "top": "0%",
@@ -165,14 +165,14 @@ exports[`Editors component renders 1`] = `
       </div>
     </div>
     <div
-      className="mosaic-split -row"
+      className="mosaic-split -column"
       onMouseDown={[Function]}
       style={
         Object {
           "bottom": "0%",
-          "left": "50%",
-          "right": "0%",
-          "top": "0%",
+          "left": "0%",
+          "right": "50%",
+          "top": "50%",
         }
       }
     >
@@ -185,10 +185,10 @@ exports[`Editors component renders 1`] = `
       key="renderer"
       style={
         Object {
-          "bottom": "50%",
-          "left": "50%",
-          "right": "0%",
-          "top": "0%",
+          "bottom": "0%",
+          "left": "0%",
+          "right": "50%",
+          "top": "50%",
         }
       }
     >
@@ -338,14 +338,14 @@ exports[`Editors component renders 1`] = `
       </div>
     </div>
     <div
-      className="mosaic-split -column"
+      className="mosaic-split -row"
       onMouseDown={[Function]}
       style={
         Object {
           "bottom": "0%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "0%",
         }
       }
     >
@@ -358,10 +358,10 @@ exports[`Editors component renders 1`] = `
       key="html"
       style={
         Object {
-          "bottom": "0%",
+          "bottom": "50%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "0%",
         }
       }
     >
@@ -510,6 +510,179 @@ exports[`Editors component renders 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="mosaic-split -column"
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "bottom": "0%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
+        }
+      }
+    >
+      <div
+        className="mosaic-split-line"
+      />
+    </div>
+    <div
+      className="mosaic-tile"
+      key="showMe"
+      style={
+        Object {
+          "bottom": "0%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
+        }
+      }
+    >
+      <div
+        className="mosaic-window mosaic-drop-target showMe"
+      >
+        <div
+          className="mosaic-window-toolbar draggable"
+        >
+          <div>
+            <div>
+              <h5>
+                Docs & Info
+              </h5>
+            </div>
+            <div />
+            <div
+              className="mosaic-controls"
+            >
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-maximize"
+                  icon="maximize"
+                >
+                  <svg
+                    data-icon="maximize"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      maximize
+                    </desc>
+                    <path
+                      d="M5.99 8.99c-.28 0-.53.11-.71.29l-3.29 3.29v-1.59c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1H3.41L6.7 10.7a1.003 1.003 0 0 0-.71-1.71zm9-9h-4c-.55 0-1 .45-1 1s.45 1 1 1h1.59l-3.3 3.3a.99.99 0 0 0-.29.7 1.003 1.003 0 0 0 1.71.71l3.29-3.29V5c0 .55.45 1 1 1s1-.45 1-1V1c0-.56-.45-1.01-1-1.01z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-cross"
+                  icon="cross"
+                >
+                  <svg
+                    data-icon="cross"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      cross
+                    </desc>
+                    <path
+                      d="M9.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 0 0-1.71-.71L8 6.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42L6.59 8 3.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71L8 9.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71L9.41 8z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="mosaic-window-body"
+        >
+          <div />
+        </div>
+        <div
+          className="mosaic-window-body-overlay"
+          onClick={[Function]}
+        />
+        <div
+          className="mosaic-window-additional-actions-bar"
+        />
+        <div
+          className="mosaic-preview"
+        >
+          <div
+            className="mosaic-window-toolbar"
+          >
+            <div
+              className="mosaic-window-title"
+            >
+              Docs & Info
+            </div>
+          </div>
+          <div
+            className="mosaic-window-body"
+          >
+            <h4>
+              Docs & Info
+            </h4>
+            <span
+              className="bp3-icon bp3-icon-application"
+              icon="application"
+            >
+              <svg
+                data-icon="application"
+                height={72}
+                viewBox="0 0 20 20"
+                width={72}
+              >
+                <desc>
+                  application
+                </desc>
+                <path
+                  d="M3.5 9h9c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-9c-.28 0-.5.22-.5.5s.22.5.5.5zm0 2h5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-5c-.28 0-.5.22-.5.5s.22.5.5.5zM19 1H1c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm-1 16H2V6h16v11zM3.5 13h7c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-7c-.28 0-.5.22-.5.5s.22.5.5.5z"
+                  fillRule="evenodd"
+                  key="0"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          className="drop-target-container"
+        >
+          <div
+            className="drop-target top"
+          />
+          <div
+            className="drop-target bottom"
+          />
+          <div
+            className="drop-target left"
+          />
+          <div
+            className="drop-target right"
+          />
+        </div>
+      </div>
+    </div>
   </div>
   <div
     className="drop-target-container"
@@ -548,11 +721,15 @@ exports[`Editors component renders a toolbar 1`] = `
           "isTokenDialogShowing": false,
           "mosaicArrangement": Object {
             "direction": "row",
-            "first": "main",
+            "first": Object {
+              "direction": "column",
+              "first": "main",
+              "second": "renderer",
+            },
             "second": Object {
               "direction": "column",
-              "first": "renderer",
-              "second": "html",
+              "first": "html",
+              "second": "showMe",
             },
           },
           "setWarningDialogTexts": [Function],
@@ -567,11 +744,15 @@ exports[`Editors component renders a toolbar 1`] = `
           "isTokenDialogShowing": false,
           "mosaicArrangement": Object {
             "direction": "row",
-            "first": "main",
+            "first": Object {
+              "direction": "column",
+              "first": "main",
+              "second": "renderer",
+            },
             "second": Object {
               "direction": "column",
-              "first": "renderer",
-              "second": "html",
+              "first": "html",
+              "second": "showMe",
             },
           },
           "setWarningDialogTexts": [Function],

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -528,7 +528,7 @@ exports[`Editors component renders 1`] = `
     </div>
     <div
       className="mosaic-tile"
-      key="showMe"
+      key="docsDemo"
       style={
         Object {
           "bottom": "0%",
@@ -539,7 +539,7 @@ exports[`Editors component renders 1`] = `
       }
     >
       <div
-        className="mosaic-window mosaic-drop-target showMe"
+        className="mosaic-window mosaic-drop-target docsDemo"
       >
         <div
           className="mosaic-window-toolbar draggable"
@@ -547,13 +547,47 @@ exports[`Editors component renders 1`] = `
           <div>
             <div>
               <h5>
-                Docs & Info
+                Docs & Demos
               </h5>
             </div>
             <div />
             <div
               className="mosaic-controls"
             >
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-home"
+                  icon="home"
+                >
+                  <svg
+                    data-icon="home"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      home
+                    </desc>
+                    <path
+                      d="M2 10v5c0 .55.45 1 1 1h3v-5h4v5h3c.55 0 1-.45 1-1v-5L8 4l-6 6zm13.71-2.71L14 5.59V2c0-.55-.45-1-1-1s-1 .45-1 1v1.59L8.71.29C8.53.11 8.28 0 8 0s-.53.11-.71.29l-7 7a1.003 1.003 0 0 0 1.42 1.42L8 2.41l6.29 6.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="bp3-button-text"
+                  key="text"
+                >
+                  Overview
+                </span>
+              </button>
               <button
                 className="bp3-button bp3-small"
                 onClick={[Function]}
@@ -658,7 +692,7 @@ exports[`Editors component renders 1`] = `
                 className="show-me-list"
               >
                 <li
-                  key="App"
+                  key="DEMO_APP"
                 >
                   <button
                     className="bp3-button bp3-minimal"
@@ -691,1033 +725,7 @@ exports[`Editors component renders 1`] = `
                       className="bp3-button-text"
                       key="text"
                     >
-                      App
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="AutoUpdater"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      AutoUpdater
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="BrowserView"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      BrowserView
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="BrowserWindow"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      BrowserWindow
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Clipboard"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Clipboard
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="ContentTracing"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      ContentTracing
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Cookies"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Cookies
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="CrashReporter"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      CrashReporter
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Debugger"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Debugger
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="DesktopCapturer"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      DesktopCapturer
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Dialog"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Dialog
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="GlobalShortcut"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      GlobalShortcut
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="IPC"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      IPC
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Menu"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Menu
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="NativeImage"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      NativeImage
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Net"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Notification"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Notification
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="PowerMonitor"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      PowerMonitor
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="PowerSaveBlocker"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      PowerSaveBlocker
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Remote"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Remote
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Screen"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Screen
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Session"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Session
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Shell"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Shell
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="SystemPreferences"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      SystemPreferences
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="TouchBar"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      TouchBar
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="Tray"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      Tray
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="WebContents"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      WebContents
-                    </span>
-                  </button>
-                </li>
-                <li
-                  key="WebFrame"
-                >
-                  <button
-                    className="bp3-button bp3-minimal"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="bp3-icon bp3-icon-play"
-                      icon="play"
-                    >
-                      <svg
-                        data-icon="play"
-                        height={16}
-                        viewBox="0 0 16 16"
-                        width={16}
-                      >
-                        <desc>
-                          play
-                        </desc>
-                        <path
-                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
-                          fillRule="evenodd"
-                          key="0"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="bp3-button-text"
-                      key="text"
-                    >
-                      WebFrame
+                      App Demos
                     </span>
                   </button>
                 </li>
@@ -1728,6 +736,7 @@ exports[`Editors component renders 1`] = `
               >
                 For more documentation, visit 
                 <a
+                  id="open-url"
                   onClick={[Function]}
                 >
                   electronjs.org/docs
@@ -1739,6 +748,7 @@ exports[`Editors component renders 1`] = `
               >
                 By the way, Electron Fiddle and the documentation you see here is entirely open source. If you have ideas on how to improve it, we'd love to have your contributions! You can find the repository on 
                 <a
+                  id="open-github"
                   onClick={[Function]}
                 >
                   GitHub
@@ -1764,14 +774,14 @@ exports[`Editors component renders 1`] = `
             <div
               className="mosaic-window-title"
             >
-              Docs & Info
+              Docs & Demos
             </div>
           </div>
           <div
             className="mosaic-window-body"
           >
             <h4>
-              Docs & Info
+              Docs & Demos
             </h4>
             <span
               className="bp3-icon bp3-icon-application"
@@ -1847,6 +857,7 @@ exports[`Editors component renders a toolbar 1`] = `
     <MaximizeButton
       appState={
         Object {
+          "currentDocsDemoPage": "DEFAULT",
           "isSettingsShowing": false,
           "isTokenDialogShowing": false,
           "mosaicArrangement": Object {
@@ -1859,7 +870,7 @@ exports[`Editors component renders a toolbar 1`] = `
             "second": Object {
               "direction": "column",
               "first": "html",
-              "second": "showMe",
+              "second": "docsDemo",
             },
           },
           "setWarningDialogTexts": [Function],
@@ -1870,6 +881,7 @@ exports[`Editors component renders a toolbar 1`] = `
     <RemoveButton
       appState={
         Object {
+          "currentDocsDemoPage": "DEFAULT",
           "isSettingsShowing": false,
           "isTokenDialogShowing": false,
           "mosaicArrangement": Object {
@@ -1882,7 +894,7 @@ exports[`Editors component renders a toolbar 1`] = `
             "second": Object {
               "direction": "column",
               "first": "html",
-              "second": "showMe",
+              "second": "docsDemo",
             },
           },
           "setWarningDialogTexts": [Function],

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -619,15 +619,1133 @@ exports[`Editors component renders 1`] = `
           <div
             className="show-me-panel"
           >
-            <h2>
-              What's 
-              ?
-            </h2>
-            <p
-              className="bp3r-running-text"
-            >
-              We're just trying to help.
-            </p>
+            Array [
+              <span
+                className="bp3-icon bp3-icon-help"
+                icon="help"
+                style={
+                  Object {
+                    "float": "left",
+                    "margin": "0 10px 0 0",
+                  }
+                }
+              >
+                <svg
+                  data-icon="help"
+                  height={40}
+                  viewBox="0 0 20 20"
+                  width={40}
+                >
+                  <desc>
+                    help
+                  </desc>
+                  <path
+                    d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zM7.41 4.62c.65-.54 1.51-.82 2.56-.82.54 0 1.03.08 1.48.25.44.17.83.39 1.14.68.32.29.56.63.74 1.02.17.39.26.82.26 1.27s-.08.87-.24 1.23c-.16.37-.4.73-.71 1.11l-1.21 1.58c-.14.17-.28.33-.32.48-.05.15-.11.35-.11.6v.97H9v-2s.06-.58.24-.81l1.21-1.64c.25-.3.41-.56.51-.77s.14-.44.14-.67c0-.35-.11-.63-.32-.85s-.5-.33-.88-.33c-.37 0-.67.11-.89.33-.22.23-.37.54-.46.94-.03.12-.11.17-.23.16l-1.95-.29c-.12-.01-.16-.08-.14-.22.13-.93.52-1.67 1.18-2.22zM9 14h2.02L11 16H9v-2z"
+                    fillRule="evenodd"
+                    key="0"
+                  />
+                </svg>
+              </span>,
+              <p
+                className="bp3r-running-text"
+              >
+                This panel offers useful information about Electron APIs – and easy way to try some of the methods it offers. Fiddle has an example fiddle for every module available in Electron.
+              </p>,
+              <p>
+                Clicking on any of the modules below will open up a fiddle showcasing that particular module.
+              </p>,
+              <ul
+                className="show-me-list"
+              >
+                <li
+                  key="App"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      App
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="AutoUpdater"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      AutoUpdater
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="BrowserView"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      BrowserView
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="BrowserWindow"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      BrowserWindow
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Clipboard"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Clipboard
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="ContentTracing"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      ContentTracing
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Cookies"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Cookies
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="CrashReporter"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      CrashReporter
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Debugger"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Debugger
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="DesktopCapturer"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      DesktopCapturer
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Dialog"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Dialog
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="GlobalShortcut"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      GlobalShortcut
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="IPC"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      IPC
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Menu"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Menu
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="NativeImage"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      NativeImage
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Net"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Net
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Notification"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Notification
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="PowerMonitor"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      PowerMonitor
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="PowerSaveBlocker"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      PowerSaveBlocker
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Remote"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Remote
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Screen"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Screen
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Session"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Session
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Shell"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Shell
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="SystemPreferences"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      SystemPreferences
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="TouchBar"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      TouchBar
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="Tray"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      Tray
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="WebContents"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      WebContents
+                    </span>
+                  </button>
+                </li>
+                <li
+                  key="WebFrame"
+                >
+                  <button
+                    className="bp3-button bp3-minimal"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="bp3-icon bp3-icon-play"
+                      icon="play"
+                    >
+                      <svg
+                        data-icon="play"
+                        height={16}
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <desc>
+                          play
+                        </desc>
+                        <path
+                          d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+                          fillRule="evenodd"
+                          key="0"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="bp3-button-text"
+                      key="text"
+                    >
+                      WebFrame
+                    </span>
+                  </button>
+                </li>
+              </ul>,
+              <br />,
+              <p
+                className="b3-running-text"
+              >
+                For more documentation, visit 
+                <a
+                  onClick={[Function]}
+                >
+                  electronjs.org/docs
+                </a>
+                , where you can find the full documentation for Electron.
+              </p>,
+              <p
+                className="bp3-text-muted"
+              >
+                By the way, Electron Fiddle and the documentation you see here is entirely open source. If you have ideas on how to improve it, we'd love to have your contributions! You can find the repository on 
+                <a
+                  onClick={[Function]}
+                >
+                  GitHub
+                </a>
+                .
+              </p>,
+            ]
           </div>
         </div>
         <div

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -616,7 +616,19 @@ exports[`Editors component renders 1`] = `
         <div
           className="mosaic-window-body"
         >
-          <div />
+          <div
+            className="show-me-panel"
+          >
+            <h2>
+              What's 
+              ?
+            </h2>
+            <p
+              className="bp3r-running-text"
+            >
+              We're just trying to help.
+            </p>
+          </div>
         </div>
         <div
           className="mosaic-window-body-overlay"

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`Editors component renders 1`] = `
           <div>
             <div>
               <h5>
-                Main Process
+                Main Process (main.js)
               </h5>
             </div>
             <div />
@@ -115,14 +115,14 @@ exports[`Editors component renders 1`] = `
             <div
               className="mosaic-window-title"
             >
-              Main Process
+              Main Process (main.js)
             </div>
           </div>
           <div
             className="mosaic-window-body"
           >
             <h4>
-              Main Process
+              Main Process (main.js)
             </h4>
             <span
               className="bp3-icon bp3-icon-application"
@@ -201,7 +201,7 @@ exports[`Editors component renders 1`] = `
           <div>
             <div>
               <h5>
-                Renderer Process
+                Renderer Process (renderer.js)
               </h5>
             </div>
             <div />
@@ -288,14 +288,14 @@ exports[`Editors component renders 1`] = `
             <div
               className="mosaic-window-title"
             >
-              Renderer Process
+              Renderer Process (renderer.js)
             </div>
           </div>
           <div
             className="mosaic-window-body"
           >
             <h4>
-              Renderer Process
+              Renderer Process (renderer.js)
             </h4>
             <span
               className="bp3-icon bp3-icon-application"
@@ -374,7 +374,7 @@ exports[`Editors component renders 1`] = `
           <div>
             <div>
               <h5>
-                HTML
+                HTML (index.html)
               </h5>
             </div>
             <div />
@@ -461,14 +461,14 @@ exports[`Editors component renders 1`] = `
             <div
               className="mosaic-window-title"
             >
-              HTML
+              HTML (index.html)
             </div>
           </div>
           <div
             className="mosaic-window-body"
           >
             <h4>
-              HTML
+              HTML (index.html)
             </h4>
             <span
               className="bp3-icon bp3-icon-application"
@@ -847,7 +847,7 @@ exports[`Editors component renders a toolbar 1`] = `
 <div>
   <div>
     <h5>
-      Main Process
+      Main Process (main.js)
     </h5>
   </div>
   <div />

--- a/tests/renderer/components/__snapshots__/show-me-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/show-me-spec.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShowMe component renders 1`] = `
+<div
+  className="show-me-panel"
+>
+  <ShowMeDefault
+    appState={Object {}}
+  />
+</div>
+`;
+
+exports[`ShowMe component renders 2`] = `
+<div
+  className="show-me-panel"
+>
+  <ShowMeDefault
+    appState={Object {}}
+  />
+</div>
+`;
+
+exports[`ShowMe component renders a template spec 1`] = `
+<div
+  className="show-me-panel"
+>
+  <ShowMeApp
+    appState={
+      Object {
+        "templateName": "app",
+      }
+    }
+  />
+</div>
+`;

--- a/tests/renderer/components/__snapshots__/show-me-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/show-me-spec.tsx.snap
@@ -10,21 +10,11 @@ exports[`ShowMe component renders 1`] = `
 </div>
 `;
 
-exports[`ShowMe component renders 2`] = `
-<div
-  className="show-me-panel"
->
-  <ShowMeDefault
-    appState={Object {}}
-  />
-</div>
-`;
-
 exports[`ShowMe component renders a template spec 1`] = `
 <div
   className="show-me-panel"
 >
-  <ShowMeApp
+  <ShowMeDefault
     appState={
       Object {
         "templateName": "app",

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { EditorId } from '../../../src/interfaces';
 import { EditorDropdown } from '../../../src/renderer/components/commands-editors';
-import { getVisibleEditors } from '../../../src/utils/editors-mosaic-arrangement';
+import { getVisibleMosaics } from '../../../src/utils/editors-mosaic-arrangement';
 
 jest.mock('../../../src/utils/editors-mosaic-arrangement');
 
@@ -12,11 +12,11 @@ describe('EditorDropdown component', () => {
 
   beforeEach(() => {
     store = {
-      hideAndBackupEditor: jest.fn(),
-      showEditor: jest.fn()
+      hideAndBackupMosaic: jest.fn(),
+      showMosaic: jest.fn()
     };
 
-    (getVisibleEditors as jest.Mock).mockReturnValue([ EditorId.html, EditorId.renderer ]);
+    (getVisibleMosaics as jest.Mock).mockReturnValue([ EditorId.html, EditorId.renderer ]);
   });
 
   it('renders', () => {
@@ -29,11 +29,11 @@ describe('EditorDropdown component', () => {
     const dropdown = wrapper.instance() as EditorDropdown;
 
     dropdown.onItemClick({ currentTarget: { id: EditorId.html } } as any);
-    expect(store.hideAndBackupEditor).toHaveBeenCalledTimes(1);
-    expect(store.showEditor).toHaveBeenCalledTimes(0);
+    expect(store.hideAndBackupMosaic).toHaveBeenCalledTimes(1);
+    expect(store.showMosaic).toHaveBeenCalledTimes(0);
 
     dropdown.onItemClick({ currentTarget: { id: EditorId.main } } as any);
-    expect(store.hideAndBackupEditor).toHaveBeenCalledTimes(1);
-    expect(store.showEditor).toHaveBeenCalledTimes(1);
+    expect(store.hideAndBackupMosaic).toHaveBeenCalledTimes(1);
+    expect(store.showMosaic).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -13,7 +13,8 @@ describe('EditorDropdown component', () => {
   beforeEach(() => {
     store = {
       hideAndBackupMosaic: jest.fn(),
-      showMosaic: jest.fn()
+      showMosaic: jest.fn(),
+      closedPanels: {}
     };
 
     (getVisibleMosaics as jest.Mock).mockReturnValue([ EditorId.html, EditorId.renderer ]);

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -11,6 +11,8 @@ describe('EditorDropdown component', () => {
   let store: any;
 
   beforeEach(() => {
+    (process.env as any).FIDDLE_DOCS_DEMOS = false;
+
     store = {
       hideAndBackupMosaic: jest.fn(),
       showMosaic: jest.fn(),
@@ -21,6 +23,13 @@ describe('EditorDropdown component', () => {
   });
 
   it('renders', () => {
+    const wrapper = shallow(<EditorDropdown appState={store} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders the extra button if the FIDDLE_DOCS_DEMOS is set', () => {
+    (process.env as any).FIDDLE_DOCS_DEMOS = true;
+
     const wrapper = shallow(<EditorDropdown appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -13,7 +13,7 @@ describe('Editor component', () => {
     store = {
       isTokenDialogShowing: false,
       isSettingsShowing: false,
-      closedEditors: {},
+      closedPanels: {},
       getAndRemoveEditorValueBackup: jest.fn()
     };
 

--- a/tests/renderer/components/editors-non-ideal-state-spec.tsx
+++ b/tests/renderer/components/editors-non-ideal-state-spec.tsx
@@ -8,11 +8,11 @@ describe('renderNonIdealState()', () => {
   });
 
   it('handles a click', () => {
-    const mockState = { setVisibleEditors: jest.fn() };
+    const mockState = { setVisibleMosaics: jest.fn() };
     const wrapper = mount(renderNonIdealState(mockState as any));
     wrapper.find('button').simulate('click');
 
-    expect(mockState.setVisibleEditors).toHaveBeenCalledTimes(1);
+    expect(mockState.setVisibleMosaics).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -161,7 +161,7 @@ describe('Editors component', () => {
 
       ipcRendererManager.emit(IpcEvents.FS_NEW_FIDDLE, null);
       process.nextTick(() => {
-        expect(window.ElectronFiddle.app.setValues).toHaveBeenCalled();
+        expect(window.ElectronFiddle.app.fileManager.setFiddle).toHaveBeenCalled();
         done();
       });
     });

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -2,7 +2,7 @@ import { mount, shallow } from 'enzyme';
 import { observable } from 'mobx';
 import * as React from 'react';
 
-import { ALL_MOSAICS, EditorId } from '../../../src/interfaces';
+import { ALL_MOSAICS, DocsDemoPage, EditorId } from '../../../src/interfaces';
 import { IpcEvents } from '../../../src/ipc-events';
 import { Editors, TITLE_MAP } from '../../../src/renderer/components/editors';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
@@ -35,7 +35,8 @@ describe('Editors component', () => {
       isTokenDialogShowing: false,
       isSettingsShowing: false,
       setWarningDialogTexts: () => ({}),
-      mosaicArrangement: createMosaicArrangement(ALL_MOSAICS)
+      mosaicArrangement: createMosaicArrangement(ALL_MOSAICS),
+      currentDocsDemoPage: DocsDemoPage.DEFAULT
     };
 
     monaco = {

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -2,12 +2,12 @@ import { mount, shallow } from 'enzyme';
 import { observable } from 'mobx';
 import * as React from 'react';
 
-import { EditorId } from '../../../src/interfaces';
+import { ALL_MOSAICS, EditorId } from '../../../src/interfaces';
 import { IpcEvents } from '../../../src/ipc-events';
 import { Editors, TITLE_MAP } from '../../../src/renderer/components/editors';
-import { DEFAULT_MOSAIC_ARRANGEMENT } from '../../../src/renderer/constants';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { updateEditorLayout } from '../../../src/utils/editor-layout';
+import { createMosaicArrangement } from '../../../src/utils/editors-mosaic-arrangement';
 import { getFocusedEditor } from '../../../src/utils/focused-editor';
 
 jest.mock('monaco-loader', () => jest.fn(async () => {
@@ -35,7 +35,7 @@ describe('Editors component', () => {
       isTokenDialogShowing: false,
       isSettingsShowing: false,
       setWarningDialogTexts: () => ({}),
-      mosaicArrangement: DEFAULT_MOSAIC_ARRANGEMENT
+      mosaicArrangement: createMosaicArrangement(ALL_MOSAICS)
     };
 
     monaco = {

--- a/tests/renderer/components/editors-toolbar-button-spec.tsx
+++ b/tests/renderer/components/editors-toolbar-button-spec.tsx
@@ -30,7 +30,7 @@ describe('Editor toolbar button component', () => {
     };
 
     store = {
-      hideAndBackupEditor: jest.fn()
+      hideAndBackupMosaic: jest.fn()
     };
   });
 
@@ -67,7 +67,7 @@ describe('Editor toolbar button component', () => {
       });      const instance: RemoveButton = wrapper.instance() as any;
 
       instance.remove();
-      expect(store.hideAndBackupEditor).toHaveBeenCalledTimes(1);
+      expect(store.hideAndBackupMosaic).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/renderer/components/show-me-spec.tsx
+++ b/tests/renderer/components/show-me-spec.tsx
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { ShowMe } from '../../../src/renderer/components/show-me';
+
+describe('ShowMe component', () => {
+  let mockState: any = {};
+
+  beforeAll(() => {
+    mockState = {};
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<ShowMe appState={mockState} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a template spec', () => {
+    mockState.templateName = 'app';
+    const wrapper = shallow(<ShowMe appState={mockState} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/renderer/components/show-me/__snapshots__/app-spec.tsx.snap
+++ b/tests/renderer/components/show-me/__snapshots__/app-spec.tsx.snap
@@ -1,0 +1,331 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSubsetOnly() renders 1`] = `
+Array [
+  <span
+    className="bp3-icon bp3-icon-help"
+    icon="help"
+    style={
+      Object {
+        "float": "left",
+        "margin": "0 10px 0 0",
+      }
+    }
+  >
+    <svg
+      data-icon="help"
+      height={40}
+      viewBox="0 0 20 20"
+      width={40}
+    >
+      <desc>
+        help
+      </desc>
+      <path
+        d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zM7.41 4.62c.65-.54 1.51-.82 2.56-.82.54 0 1.03.08 1.48.25.44.17.83.39 1.14.68.32.29.56.63.74 1.02.17.39.26.82.26 1.27s-.08.87-.24 1.23c-.16.37-.4.73-.71 1.11l-1.21 1.58c-.14.17-.28.33-.32.48-.05.15-.11.35-.11.6v.97H9v-2s.06-.58.24-.81l1.21-1.64c.25-.3.41-.56.51-.77s.14-.44.14-.67c0-.35-.11-.63-.32-.85s-.5-.33-.88-.33c-.37 0-.67.11-.89.33-.22.23-.37.54-.46.94-.03.12-.11.17-.23.16l-1.95-.29c-.12-.01-.16-.08-.14-.22.13-.93.52-1.67 1.18-2.22zM9 14h2.02L11 16H9v-2z"
+        fillRule="evenodd"
+        key="0"
+      />
+    </svg>
+  </span>,
+  <p
+    className="bp3r-running-text"
+  >
+    The 
+    <code>
+      app
+    </code>
+     module controls the app's application life-cycle. Most of the events and methods available on this module are responsible for handling how your interacts with the operating system or to set application-wide settings.
+  </p>,
+  <h3>
+    API Demos
+  </h3>,
+  <p
+    className="bp3-running-text"
+  >
+    The following demos display only a subset of what the 
+    <code>
+      app
+    </code>
+    module is capable of. If you want to see its full abilities, check out the documentation on 
+    <a
+      id="open-url"
+      onClick={[Function]}
+    >
+      electronjs.org/docs/api/app
+    </a>
+    .
+  </p>,
+  <div
+    className="bp3-callout bp3-callout-icon"
+  >
+    <span
+      className="bp3-icon bp3-icon-eye-open"
+      icon="eye-open"
+    >
+      <svg
+        data-icon="eye-open"
+        height={20}
+        viewBox="0 0 20 20"
+        width={20}
+      >
+        <desc>
+          eye-open
+        </desc>
+        <path
+          d="M10.01 7.984A2.008 2.008 0 0 0 8.012 9.99c0 1.103.9 2.006 1.998 2.006a2.008 2.008 0 0 0 1.998-2.006c0-1.103-.9-2.006-1.998-2.006zM20 9.96v-.03-.01-.02-.02a.827.827 0 0 0-.21-.442c-.64-.802-1.398-1.514-2.168-2.166-1.658-1.404-3.566-2.587-5.664-3.058a8.982 8.982 0 0 0-3.656-.05c-1.11.2-2.178.641-3.177 1.183-1.569.852-2.997 2.016-4.246 3.33-.23.25-.46.49-.67.761-.279.351-.279.773 0 1.124.64.802 1.4 1.514 2.169 2.166 1.658 1.404 3.566 2.577 5.664 3.058 1.209.271 2.438.281 3.656.05 1.11-.21 2.178-.651 3.177-1.193 1.569-.852 2.997-2.016 4.246-3.33.23-.24.46-.49.67-.751.11-.12.179-.271.209-.442v-.02-.02-.01-.03V10v-.04zM10.01 14A4.003 4.003 0 0 1 6.014 9.99a4.003 4.003 0 0 1 3.996-4.011 4.003 4.003 0 0 1 3.996 4.011 4.003 4.003 0 0 1-3.996 4.011z"
+          fillRule="evenodd"
+          key="0"
+        />
+      </svg>
+    </span>
+    <h4
+      className="bp3-heading"
+    >
+      Hiding, Showing, Focussing
+    </h4>
+    <p>
+      The app can ask the operating system for window focus. On macOS, it can additionally request that the app be hidden or shown. Give it a try: Click on the button below, focus another app, and wait for two seconds to see Electron Fiddle become the focused app again.
+    </p>
+    <button
+      className="bp3-button"
+      id="focus"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      type="button"
+    >
+      <span
+        className="bp3-icon bp3-icon-lightbulb"
+        icon="lightbulb"
+      >
+        <svg
+          data-icon="lightbulb"
+          height={16}
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <desc>
+            lightbulb
+          </desc>
+          <path
+            d="M9.01 14h-2c-.55 0-1 .45-1 1s.45 1 1 1h2c.55 0 1-.45 1-1s-.44-1-1-1zm1-3h-4c-.55 0-1 .45-1 1s.45 1 1 1h4c.55 0 1-.45 1-1s-.44-1-1-1zm-2-11C5.26 0 3.03 1.95 3.03 4.35c0 2.37 1.63 2.64 1.94 5.22 0 .24.22.44.5.44h5.09c.28 0 .5-.19.5-.44C11.37 6.99 13 6.72 13 4.35 13 1.95 10.77 0 8.01 0z"
+            fillRule="evenodd"
+            key="0"
+          />
+        </svg>
+      </span>
+      <span
+        className="bp3-button-text"
+        key="text"
+      >
+        Focus Electron Fiddle
+      </span>
+    </button>
+    Array [
+      <p>
+        This button hides Electron Fiddle right away, showing it again in two seconds.
+      </p>,
+      <button
+        className="bp3-button"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        type="button"
+      >
+        <span
+          className="bp3-icon bp3-icon-eye-off"
+          icon="eye-off"
+        >
+          <svg
+            data-icon="eye-off"
+            height={16}
+            viewBox="0 0 16 16"
+            width={16}
+          >
+            <desc>
+              eye-off
+            </desc>
+            <path
+              d="M16 7.97v-.02-.01-.02-.02a.672.672 0 0 0-.17-.36c-.49-.63-1.07-1.2-1.65-1.72l-3.16 2.26a2.978 2.978 0 0 1-2.98 2.9c-.31 0-.6-.06-.88-.15L5.09 12.3c.44.19.9.36 1.37.47.97.23 1.94.24 2.92.05.88-.17 1.74-.54 2.53-.98 1.25-.7 2.39-1.67 3.38-2.75.18-.2.37-.41.53-.62.09-.1.15-.22.17-.36v-.02-.02-.01-.02-.03c.01-.02.01-.03.01-.04zm-.43-4.17c.25-.18.43-.46.43-.8 0-.55-.45-1-1-1-.22 0-.41.08-.57.2l-.01-.01-2.67 1.91c-.69-.38-1.41-.69-2.17-.87a6.8 6.8 0 0 0-2.91-.05c-.88.18-1.74.54-2.53.99-1.25.7-2.39 1.67-3.38 2.75-.18.2-.37.41-.53.62-.23.29-.23.63-.01.92.51.66 1.11 1.25 1.73 1.79.18.16.38.29.56.44l-2.09 1.5.01.01c-.25.18-.43.46-.43.8 0 .55.45 1 1 1 .22 0 .41-.08.57-.2l.01.01 14-10-.01-.01zm-10.41 5a3.03 3.03 0 0 1-.11-.8 2.99 2.99 0 0 1 2.99-2.98c.62 0 1.19.21 1.66.53L5.16 8.8z"
+              fillRule="evenodd"
+              key="0"
+            />
+          </svg>
+        </span>
+        <span
+          className="bp3-button-text"
+          key="text"
+        >
+          Hide Electron Fiddle
+        </span>
+      </button>,
+    ]
+  </div>,
+  <div
+    className="bp3-callout bp3-callout-icon"
+  >
+    <span
+      className="bp3-icon bp3-icon-folder-open"
+      icon="folder-open"
+    >
+      <svg
+        data-icon="folder-open"
+        height={20}
+        viewBox="0 0 20 20"
+        width={20}
+      >
+        <desc>
+          folder-open
+        </desc>
+        <path
+          d="M20 9c0-.55-.45-1-1-1H5c-.43 0-.79.27-.93.65h-.01l-3 8h.01c-.04.11-.07.23-.07.35 0 .55.45 1 1 1h14c.43 0 .79-.27.93-.65h.01l3-8h-.01c.04-.11.07-.23.07-.35zM3.07 7.63C3.22 7.26 3.58 7 4 7h14V5c0-.55-.45-1-1-1H8.41l-1.7-1.71A.997.997 0 0 0 6 2H1c-.55 0-1 .45-1 1v12.31l3.07-7.68z"
+          fillRule="evenodd"
+          key="0"
+        />
+      </svg>
+    </span>
+    <h4
+      className="bp3-heading"
+    >
+      Paths
+    </h4>
+    <p>
+      Need to query information about various paths in a cross-platform manner? Electron can help. The button queries the operating system for some of them.
+    </p>
+    <button
+      className="bp3-button"
+      id="special-paths"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      type="button"
+    >
+      <span
+        className="bp3-icon bp3-icon-play"
+        icon="play"
+      >
+        <svg
+          data-icon="play"
+          height={16}
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <desc>
+            play
+          </desc>
+          <path
+            d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+            fillRule="evenodd"
+            key="0"
+          />
+        </svg>
+      </span>
+      <span
+        className="bp3-button-text"
+        key="text"
+      >
+        Get special directory paths
+      </span>
+    </button>
+    <pre />
+  </div>,
+  <div
+    className="bp3-callout bp3-callout-icon"
+  >
+    <span
+      className="bp3-icon bp3-icon-pulse"
+      icon="pulse"
+    >
+      <svg
+        data-icon="pulse"
+        height={20}
+        viewBox="0 0 20 20"
+        width={20}
+      >
+        <desc>
+          pulse
+        </desc>
+        <path
+          d="M19 10h-2.38L14.9 6.55h-.01c-.17-.32-.5-.55-.89-.55-.43 0-.79.28-.93.66h-.01l-2.75 7.57L7.98 1.82h-.02A.978.978 0 0 0 7 1c-.44 0-.8.29-.94.69h-.01L3.28 10H1c-.55 0-1 .45-1 1s.45 1 1 1h3c.44 0 .8-.29.94-.69h.01l1.78-5.34 2.29 12.21h.02c.08.46.47.82.96.82.43 0 .79-.28.93-.66h.01l3.21-8.82.96 1.92h.01c.16.33.49.56.88.56h3c.55 0 1-.45 1-1s-.45-1-1-1z"
+          fillRule="evenodd"
+          key="0"
+        />
+      </svg>
+    </span>
+    <h4
+      className="bp3-heading"
+    >
+      Process & Device Information
+    </h4>
+    <p>
+      Need to query information about the process or system? The 
+      <code>
+        app
+      </code>
+       module lets developers query for information about the running app, hardware, and operating system. A good example are process metrics.
+    </p>
+    <button
+      className="bp3-button"
+      id="process-metrics"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      type="button"
+    >
+      <span
+        className="bp3-icon bp3-icon-play"
+        icon="play"
+      >
+        <svg
+          data-icon="play"
+          height={16}
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <desc>
+            play
+          </desc>
+          <path
+            d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+            fillRule="evenodd"
+            key="0"
+          />
+        </svg>
+      </span>
+      <span
+        className="bp3-button-text"
+        key="text"
+      >
+        Get process metrics
+      </span>
+    </button>
+    <pre />
+  </div>,
+  <br />,
+  <p
+    className="b3-running-text"
+  >
+    For more documentation, visit 
+    <a
+      id="open-url"
+      onClick={[Function]}
+    >
+      electronjs.org/docs
+    </a>
+    , where you can find the full documentation for Electron.
+  </p>,
+  <p
+    className="bp3-text-muted"
+  >
+    By the way, Electron Fiddle and the documentation you see here is entirely open source. If you have ideas on how to improve it, we'd love to have your contributions! You can find the repository on 
+    <a
+      id="open-github"
+      onClick={[Function]}
+    >
+      GitHub
+    </a>
+    .
+  </p>,
+]
+`;

--- a/tests/renderer/components/show-me/__snapshots__/app-spec.tsx.snap
+++ b/tests/renderer/components/show-me/__snapshots__/app-spec.tsx.snap
@@ -128,6 +128,7 @@ Array [
       </p>,
       <button
         className="bp3-button"
+        id="show-hide"
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
@@ -228,7 +229,9 @@ Array [
         Get special directory paths
       </span>
     </button>
-    <pre />
+    <pre
+      id="special-paths-content"
+    />
   </div>,
   <div
     className="bp3-callout bp3-callout-icon"
@@ -300,7 +303,9 @@ Array [
         Get process metrics
       </span>
     </button>
-    <pre />
+    <pre
+      id="process-metrics-content"
+    />
   </div>,
   <br />,
   <p

--- a/tests/renderer/components/show-me/__snapshots__/default-spec.tsx.snap
+++ b/tests/renderer/components/show-me/__snapshots__/default-spec.tsx.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSubsetOnly() renders 1`] = `
+Array [
+  <span
+    className="bp3-icon bp3-icon-help"
+    icon="help"
+    style={
+      Object {
+        "float": "left",
+        "margin": "0 10px 0 0",
+      }
+    }
+  >
+    <svg
+      data-icon="help"
+      height={40}
+      viewBox="0 0 20 20"
+      width={40}
+    >
+      <desc>
+        help
+      </desc>
+      <path
+        d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zM7.41 4.62c.65-.54 1.51-.82 2.56-.82.54 0 1.03.08 1.48.25.44.17.83.39 1.14.68.32.29.56.63.74 1.02.17.39.26.82.26 1.27s-.08.87-.24 1.23c-.16.37-.4.73-.71 1.11l-1.21 1.58c-.14.17-.28.33-.32.48-.05.15-.11.35-.11.6v.97H9v-2s.06-.58.24-.81l1.21-1.64c.25-.3.41-.56.51-.77s.14-.44.14-.67c0-.35-.11-.63-.32-.85s-.5-.33-.88-.33c-.37 0-.67.11-.89.33-.22.23-.37.54-.46.94-.03.12-.11.17-.23.16l-1.95-.29c-.12-.01-.16-.08-.14-.22.13-.93.52-1.67 1.18-2.22zM9 14h2.02L11 16H9v-2z"
+        fillRule="evenodd"
+        key="0"
+      />
+    </svg>
+  </span>,
+  <p
+    className="bp3r-running-text"
+  >
+    This panel offers useful information about Electron APIs – and easy way to try some of the methods it offers. Fiddle has an example fiddle for every module available in Electron.
+  </p>,
+  <p>
+    Clicking on any of the modules below will open up a fiddle showcasing that particular module.
+  </p>,
+  <ul
+    className="show-me-list"
+  >
+    <li
+      key="DEMO_APP"
+    >
+      <button
+        className="bp3-button bp3-minimal"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        type="button"
+      >
+        <span
+          className="bp3-icon bp3-icon-play"
+          icon="play"
+        >
+          <svg
+            data-icon="play"
+            height={16}
+            viewBox="0 0 16 16"
+            width={16}
+          >
+            <desc>
+              play
+            </desc>
+            <path
+              d="M12 8c0-.35-.19-.64-.46-.82l.01-.02-6-4-.01.02A.969.969 0 0 0 5 3c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1 .21 0 .39-.08.54-.18l.01.02 6-4-.01-.02c.27-.18.46-.47.46-.82z"
+              fillRule="evenodd"
+              key="0"
+            />
+          </svg>
+        </span>
+        <span
+          className="bp3-button-text"
+          key="text"
+        >
+          App Demos
+        </span>
+      </button>
+    </li>
+  </ul>,
+  <br />,
+  <p
+    className="b3-running-text"
+  >
+    For more documentation, visit 
+    <a
+      id="open-url"
+      onClick={[Function]}
+    >
+      electronjs.org/docs
+    </a>
+    , where you can find the full documentation for Electron.
+  </p>,
+  <p
+    className="bp3-text-muted"
+  >
+    By the way, Electron Fiddle and the documentation you see here is entirely open source. If you have ideas on how to improve it, we'd love to have your contributions! You can find the repository on 
+    <a
+      id="open-github"
+      onClick={[Function]}
+    >
+      GitHub
+    </a>
+    .
+  </p>,
+]
+`;

--- a/tests/renderer/components/show-me/__snapshots__/more-information-spec.tsx.snap
+++ b/tests/renderer/components/show-me/__snapshots__/more-information-spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderMoreDocumentation() renders 1`] = `
+Array [
+  <br />,
+  <p
+    className="b3-running-text"
+  >
+    For more documentation, visit 
+    <a
+      id="open-url"
+      onClick={[Function]}
+    >
+      electronjs.org/docs
+    </a>
+    , where you can find the full documentation for Electron.
+  </p>,
+  <p
+    className="bp3-text-muted"
+  >
+    By the way, Electron Fiddle and the documentation you see here is entirely open source. If you have ideas on how to improve it, we'd love to have your contributions! You can find the repository on 
+    <a
+      id="open-github"
+      onClick={[Function]}
+    >
+      GitHub
+    </a>
+    .
+  </p>,
+]
+`;

--- a/tests/renderer/components/show-me/__snapshots__/subset-only-spec.tsx.snap
+++ b/tests/renderer/components/show-me/__snapshots__/subset-only-spec.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSubsetOnly() renders 1`] = `
+<p
+  className="bp3-running-text"
+>
+  The following demos display only a subset of what the 
+  <code>
+    app
+  </code>
+  module is capable of. If you want to see its full abilities, check out the documentation on 
+  <a
+    id="open-url"
+    onClick={[Function]}
+  >
+    electronjs.org/docs/api/app
+  </a>
+  .
+</p>
+`;

--- a/tests/renderer/components/show-me/app-spec.tsx
+++ b/tests/renderer/components/show-me/app-spec.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { mount } from 'enzyme';
+
+import { ShowMeApp as ShowMeAppType } from '../../../../src/renderer/components/show-me/app';
+
+describe('getSubsetOnly()', () => {
+  let ShowMeApp: typeof ShowMeAppType;
+
+  beforeAll(async () => {
+    jest.useFakeTimers();
+
+    ({ ShowMeApp } = await import('../../../../src/renderer/components/show-me/app'));
+  });
+  afterAll(() => jest.useRealTimers());
+
+  it('renders', () => {
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('handles the focus example', async () => {
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+
+    wrapper.find('button#focus').simulate('click');
+    jest.runAllTimers();
+    jest.advanceTimersByTime(10000);
+  });
+});

--- a/tests/renderer/components/show-me/app-spec.tsx
+++ b/tests/renderer/components/show-me/app-spec.tsx
@@ -1,18 +1,26 @@
+import * as electron from 'electron';
 import * as React from 'react';
+import { act } from 'react-dom/test-utils';
 
 import { mount } from 'enzyme';
 
 import { ShowMeApp as ShowMeAppType } from '../../../../src/renderer/components/show-me/app';
+import { overridePlatform, resetPlatform } from '../../../utils';
 
 describe('getSubsetOnly()', () => {
   let ShowMeApp: typeof ShowMeAppType;
 
   beforeAll(async () => {
     jest.useFakeTimers();
+    overridePlatform('darwin');
 
-    ({ ShowMeApp } = await import('../../../../src/renderer/components/show-me/app'));
+    ({ ShowMeApp } = require('../../../../src/renderer/components/show-me/app'));
   });
-  afterAll(() => jest.useRealTimers());
+
+  afterAll(() => {
+    jest.useRealTimers();
+    resetPlatform();
+  });
 
   it('renders', () => {
     const mockState = {};
@@ -20,12 +28,77 @@ describe('getSubsetOnly()', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('does not render the show/hide on non-darwin', async () => {
+    overridePlatform('win32');
+
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+    const element = wrapper.find('button#show-hide');
+
+    expect(element.length).toBe(0);
+
+    overridePlatform('darwin');
+  });
+
+  it('handles the show/hide example', async () => {
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+
+    wrapper.find('button#show-hide').simulate('click');
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+
+    for (const [ method ] of (setTimeout as any).mock.calls) {
+      act(method);
+    }
+
+    expect(electron.remote.app.show).toHaveBeenCalled();
+    expect(electron.remote.app.hide).toHaveBeenCalled();
+  });
+
   it('handles the focus example', async () => {
     const mockState = {};
     const wrapper = mount(<ShowMeApp appState={mockState} />);
 
     wrapper.find('button#focus').simulate('click');
-    jest.runAllTimers();
-    jest.advanceTimersByTime(10000);
+
+    expect(setTimeout).toHaveBeenCalledTimes(3);
+
+    for (const [ method ] of (setTimeout as any).mock.calls) {
+      act(method);
+    }
+
+    expect(electron.remote.app.focus).toHaveBeenCalled();
+  });
+
+  it('handles the paths example', () => {
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+
+    wrapper.find('button#special-paths').simulate('click');
+    const specialPaths = wrapper.find('pre#special-paths-content').text().trim();
+
+    expect(specialPaths).toEqual(`
+home: ~
+appData: /test-path
+userData: /Users/fake-user
+temp: /test-path
+downloads: /test-path
+desktop: /test-path`.trim()
+    );
+  });
+
+  it('handles the metrics example', () => {
+    (electron.remote.app.getAppMetrics as jest.Mock).mockReturnValue(
+      { metrics: 123 }
+    );
+
+    const mockState = {};
+    const wrapper = mount(<ShowMeApp appState={mockState} />);
+
+    wrapper.find('button#process-metrics').simulate('click');
+    const specialPaths = wrapper.find('pre#process-metrics-content').text().trim();
+
+    expect(JSON.parse(specialPaths)).toEqual({ metrics: 123 });
   });
 });

--- a/tests/renderer/components/show-me/app-spec.tsx
+++ b/tests/renderer/components/show-me/app-spec.tsx
@@ -1,5 +1,7 @@
 import * as electron from 'electron';
 import * as React from 'react';
+
+// tslint:disable-next-line:no-submodule-imports
 import { act } from 'react-dom/test-utils';
 
 import { mount } from 'enzyme';

--- a/tests/renderer/components/show-me/default-spec.tsx
+++ b/tests/renderer/components/show-me/default-spec.tsx
@@ -1,0 +1,16 @@
+import { mount } from 'enzyme';
+
+import { DocsDemoPage } from '../../../../src/interfaces';
+import { ShowMeDefault } from '../../../../src/renderer/components/show-me/default';
+
+describe('getSubsetOnly()', () => {
+  it('renders', () => {
+    const mockState = { currentDocsDemoPage: undefined };
+    const wrapper = mount(ShowMeDefault({ appState: mockState } as any));
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.find('button').simulate('click');
+
+    expect(mockState.currentDocsDemoPage).toBe(DocsDemoPage.DEMO_APP);
+  });
+});

--- a/tests/renderer/components/show-me/more-information-spec.tsx
+++ b/tests/renderer/components/show-me/more-information-spec.tsx
@@ -1,6 +1,5 @@
 import * as electron from 'electron';
-import { mount, shallow } from 'enzyme';
-import * as React from 'react';
+import { mount } from 'enzyme';
 
 import { renderMoreDocumentation } from '../../../../src/renderer/components/show-me/more-information';
 

--- a/tests/renderer/components/show-me/more-information-spec.tsx
+++ b/tests/renderer/components/show-me/more-information-spec.tsx
@@ -1,0 +1,18 @@
+import * as electron from 'electron';
+import { mount, shallow } from 'enzyme';
+import * as React from 'react';
+
+import { renderMoreDocumentation } from '../../../../src/renderer/components/show-me/more-information';
+
+describe('renderMoreDocumentation()', () => {
+  it('renders', () => {
+    const wrapper = mount(renderMoreDocumentation());
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.find('a#open-url').simulate('click');
+    expect(electron.shell.openExternal).toHaveBeenCalledTimes(1);
+
+    wrapper.find('a#open-github').simulate('click');
+    expect(electron.shell.openExternal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/renderer/components/show-me/subset-only-spec.tsx
+++ b/tests/renderer/components/show-me/subset-only-spec.tsx
@@ -1,0 +1,14 @@
+import * as electron from 'electron';
+import { mount } from 'enzyme';
+
+import { getSubsetOnly } from '../../../../src/renderer/components/show-me/subset-only';
+
+describe('getSubsetOnly()', () => {
+  it('renders', () => {
+    const wrapper = mount(getSubsetOnly('app'));
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.find('a#open-url').simulate('click');
+    expect(electron.shell.openExternal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/renderer/fetch-types-spec.ts
+++ b/tests/renderer/fetch-types-spec.ts
@@ -180,7 +180,7 @@ describe('fetch-types', () => {
 
       setTimeout(() => {
         window.ElectronFiddle.app = app;
-      }, 200);
+      }, 300);
 
       await updateEditorTypeDefinitions('3.0.0');
 

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -152,9 +152,12 @@ describe('FileManager', () => {
       fm.setFiddle = jest.fn();
       await fm.openTemplate('test');
       expect(fm.setFiddle).toHaveBeenCalledWith({
-        html: '',
-        main: '',
-        renderer: ''
+        templateName: 'test',
+        values: {
+          html: '',
+          main: '',
+          renderer: ''
+        }
       });
     });
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,9 +1,10 @@
-import { EditorId, ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
+import { ALL_MOSAICS, EditorId, ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from '../../src/renderer/constants';
 import { getContent, isContentUnchanged } from '../../src/renderer/content';
 import { ipcRendererManager } from '../../src/renderer/ipc';
 import { AppState } from '../../src/renderer/state';
 import { getUpdatedElectronVersions, saveLocalVersions } from '../../src/renderer/versions';
+import { createMosaicArrangement } from '../../src/utils/editors-mosaic-arrangement';
 import { getName } from '../../src/utils/get-title';
 import { mockVersions } from '../mocks/electron-versions';
 import { overridePlatform, resetPlatform } from '../utils';
@@ -415,7 +416,7 @@ describe('AppState', () => {
 
   describe('setVisibleMosaics()', () => {
     it('updates the visible editors and creates a backup', () => {
-      appState.mosaicArrangement = DEFAULT_MOSAIC_ARRANGEMENT;
+      appState.mosaicArrangement = createMosaicArrangement(ALL_MOSAICS);
       appState.closedPanels = {};
       appState.setVisibleMosaics([ EditorId.main ]);
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -406,50 +406,50 @@ describe('AppState', () => {
     });
 
     it('returns and deletes a backup if there is one', () => {
-      appState.closedEditors[EditorId.main] = { testBackup: true } as any;
+      appState.closedPanels[EditorId.main] = { testBackup: true } as any;
       const result = appState.getAndRemoveEditorValueBackup(EditorId.main);
       expect(result).toEqual({ testBackup: true });
-      expect(appState.closedEditors[EditorId.main]).toBeUndefined();
+      expect(appState.closedPanels[EditorId.main]).toBeUndefined();
     });
   });
 
-  describe('setVisibleEditors()', () => {
+  describe('setVisibleMosaics()', () => {
     it('updates the visible editors and creates a backup', () => {
       appState.mosaicArrangement = DEFAULT_MOSAIC_ARRANGEMENT;
-      appState.closedEditors = {};
-      appState.setVisibleEditors([ EditorId.main ]);
+      appState.closedPanels = {};
+      appState.setVisibleMosaics([ EditorId.main ]);
 
       expect(appState.mosaicArrangement).toEqual(EditorId.main);
-      expect(appState.closedEditors[EditorId.renderer]).toBeTruthy();
-      expect(appState.closedEditors[EditorId.html]).toBeTruthy();
-      expect(appState.closedEditors[EditorId.main]).toBeUndefined();
+      expect(appState.closedPanels[EditorId.renderer]).toBeTruthy();
+      expect(appState.closedPanels[EditorId.html]).toBeTruthy();
+      expect(appState.closedPanels[EditorId.main]).toBeUndefined();
     });
   });
 
-  describe('hideAndBackupEditor()', () => {
+  describe('hideAndBackupMosaic()', () => {
     it('hides a given editor and creates a backup', () => {
       appState.mosaicArrangement = DEFAULT_MOSAIC_ARRANGEMENT;
-      appState.closedEditors = {};
-      appState.hideAndBackupEditor(EditorId.main);
+      appState.closedPanels = {};
+      appState.hideAndBackupMosaic(EditorId.main);
 
       expect(appState.mosaicArrangement).toEqual({
-        direction: 'column',
+        direction: 'row',
         first: EditorId.renderer,
         second: EditorId.html
       });
-      expect(appState.closedEditors[EditorId.main]).toBeTruthy();
-      expect(appState.closedEditors[EditorId.renderer]).toBeUndefined();
-      expect(appState.closedEditors[EditorId.html]).toBeUndefined();
+      expect(appState.closedPanels[EditorId.main]).toBeTruthy();
+      expect(appState.closedPanels[EditorId.renderer]).toBeUndefined();
+      expect(appState.closedPanels[EditorId.html]).toBeUndefined();
     });
   });
 
-  describe('showEditor()', () => {
+  describe('showMosaic()', () => {
     it('shows a given editor', () => {
       appState.mosaicArrangement = EditorId.main;
-      appState.showEditor(EditorId.html);
+      appState.showMosaic(EditorId.html);
 
       expect(appState.mosaicArrangement).toEqual({
-        direction: 'column',
+        direction: 'row',
         first: EditorId.main,
         second: EditorId.html
       });

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,4 +1,4 @@
-import { ALL_MOSAICS, EditorId, ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
+import { ALL_MOSAICS, EditorId, ElectronVersionSource, ElectronVersionState, PanelId } from '../../src/interfaces';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from '../../src/renderer/constants';
 import { getContent, isContentUnchanged } from '../../src/renderer/content';
 import { ipcRendererManager } from '../../src/renderer/ipc';
@@ -424,6 +424,14 @@ describe('AppState', () => {
       expect(appState.closedPanels[EditorId.renderer]).toBeTruthy();
       expect(appState.closedPanels[EditorId.html]).toBeTruthy();
       expect(appState.closedPanels[EditorId.main]).toBeUndefined();
+    });
+
+    it('removes the backup for a non-editor right away', () => {
+      appState.closedPanels = {};
+      appState.closedPanels[PanelId.showMe] = true;
+      appState.setVisibleMosaics(ALL_MOSAICS);
+
+      expect(appState.closedPanels[PanelId.showMe]).toBeUndefined();
     });
   });
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -428,10 +428,10 @@ describe('AppState', () => {
 
     it('removes the backup for a non-editor right away', () => {
       appState.closedPanels = {};
-      appState.closedPanels[PanelId.showMe] = true;
+      appState.closedPanels[PanelId.docsDemo] = true;
       appState.setVisibleMosaics(ALL_MOSAICS);
 
-      expect(appState.closedPanels[PanelId.showMe]).toBeUndefined();
+      expect(appState.closedPanels[PanelId.docsDemo]).toBeUndefined();
     });
   });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,6 +12,7 @@ global.fetch = require('jest-fetch-mock');
 jest.spyOn(global.console, 'log').mockImplementation(() => jest.fn());
 jest.spyOn(global.console, 'warn').mockImplementation(() => jest.fn());
 jest.mock('electron', () => require('./mocks/electron'));
+jest.mock('fs-extra');
 
 delete window.localStorage;
 // We'll do this twice.

--- a/tests/utils/docs-urls-spec.ts
+++ b/tests/utils/docs-urls-spec.ts
@@ -1,0 +1,13 @@
+import { getDocsUrlForModule } from '../../src/utils/docs-urls';
+
+describe('getDocsUrlForModule()', () => {
+  it('works', () => {
+    const result = getDocsUrlForModule('app');
+
+    expect(result).toEqual({
+      full: `https://electronjs.org/docs/api/app`,
+      repo: `https://github.com/electron/electron/blob/master/docs/api/app.md`,
+      short: `electronjs.org/docs/api/app`
+    });
+  });
+});

--- a/tests/utils/editors-mosaic-arrangement-spec.ts
+++ b/tests/utils/editors-mosaic-arrangement-spec.ts
@@ -1,6 +1,6 @@
 import { ALL_EDITORS, EditorId } from '../../src/interfaces';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from '../../src/renderer/constants';
-import { createMosaicArrangement, getVisibleEditors } from '../../src/utils/editors-mosaic-arrangement';
+import { createMosaicArrangement, getVisibleMosaics } from '../../src/utils/editors-mosaic-arrangement';
 
 describe('Mosaic Arrangement Utilities', () => {
   describe('createMosaicArrangement()', () => {
@@ -14,7 +14,7 @@ describe('Mosaic Arrangement Utilities', () => {
       const result = createMosaicArrangement([ EditorId.main, EditorId.renderer ]);
 
       expect(result).toEqual({
-        direction: 'column',
+        direction: 'row',
         first: EditorId.main,
         second: EditorId.renderer
       });
@@ -27,21 +27,21 @@ describe('Mosaic Arrangement Utilities', () => {
     });
   });
 
-  describe('getVisibleEditors()', () => {
+  describe('getVisibleMosaics()', () => {
     it('returns the correct array for no panels', () => {
-      const result = getVisibleEditors(null);
+      const result = getVisibleMosaics(null);
 
       expect(result).toEqual([]);
     });
 
     it('returns the correct array for one visible panel', () => {
-      const result = getVisibleEditors(EditorId.main);
+      const result = getVisibleMosaics(EditorId.main);
 
       expect(result).toEqual([ EditorId.main ]);
     });
 
     it('returns the correct array for two visible panels', () => {
-      const result = getVisibleEditors({
+      const result = getVisibleMosaics({
         direction: 'column',
         first: EditorId.main,
         second: EditorId.renderer
@@ -51,7 +51,7 @@ describe('Mosaic Arrangement Utilities', () => {
     });
 
     it('returns the correct array for three visible panels', () => {
-      const result = getVisibleEditors(DEFAULT_MOSAIC_ARRANGEMENT);
+      const result = getVisibleMosaics(DEFAULT_MOSAIC_ARRANGEMENT);
 
       expect(result).toEqual(ALL_EDITORS);
     });

--- a/tests/utils/type-checks-spec.ts
+++ b/tests/utils/type-checks-spec.ts
@@ -5,14 +5,14 @@ describe('Type checks', () => {
   describe('isEditorId()', () => {
     it('works', () => {
       expect(isEditorId(EditorId.html)).toBe(true);
-      expect(isEditorId(PanelId.showMe)).toBe(false);
+      expect(isEditorId(PanelId.docsDemo)).toBe(false);
     });
   });
 
   describe('isPanelId()', () => {
     it('works', () => {
       expect(isPanelId(EditorId.html)).toBe(false);
-      expect(isPanelId(PanelId.showMe)).toBe(true);
+      expect(isPanelId(PanelId.docsDemo)).toBe(true);
     });
   });
 

--- a/tests/utils/type-checks-spec.ts
+++ b/tests/utils/type-checks-spec.ts
@@ -1,0 +1,25 @@
+import { EditorId, PanelId } from '../../src/interfaces';
+import { isEditorBackup, isEditorId, isPanelId } from '../../src/utils/type-checks';
+
+describe('Type checks', () => {
+  describe('isEditorId()', () => {
+    it('works', () => {
+      expect(isEditorId(EditorId.html)).toBe(true);
+      expect(isEditorId(PanelId.showMe)).toBe(false);
+    });
+  });
+
+  describe('isPanelId()', () => {
+    it('works', () => {
+      expect(isPanelId(EditorId.html)).toBe(false);
+      expect(isPanelId(PanelId.showMe)).toBe(true);
+    });
+  });
+
+  describe('isEditorBackup()', () => {
+    it('works', () => {
+      expect(isEditorBackup(true)).toBe(false);
+      expect(isEditorBackup({} as any)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This is a big PR with a big feature – it introduces _panels_ to Electron Fiddle. In the short-term, this means that one can toggle individual editors and move them around, arranging them in any way you see fit.

In the long term, this opens the door for more panels: For documentation, API demos, and other pieces of assistance.