### PR TITLE
feat: add wiring for protocol launching gists

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -42,3 +42,5 @@ export const ipcRendererEvents = [
   IpcEvents.FS_SAVE_FIDDLE_GIST,
   IpcEvents.SHOW_WELCOME_TOUR
 ];
+
+export const WEBCONTENTS_READY_FOR_IPC_SIGNAL = 'WEBCONTENTS_READY_FOR_IPC_SIGNAL';

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,7 +1,9 @@
 import { when } from 'mobx';
 import * as MonacoType from 'monaco-editor';
 
+import { ipcRenderer } from 'electron';
 import { ALL_EDITORS, EditorId, EditorValues } from '../interfaces';
+import { WEBCONTENTS_READY_FOR_IPC_SIGNAL } from '../ipc-events';
 import { updateEditorLayout } from '../utils/editor-layout';
 import { getEditorValue } from '../utils/editor-value';
 import { getPackageJson, PackageJsonOptions } from '../utils/get-package';
@@ -120,6 +122,8 @@ export class App {
     const rendered = render(app, document.getElementById('app'));
 
     this.setupResizeListener();
+
+    ipcRenderer.send(WEBCONTENTS_READY_FOR_IPC_SIGNAL);
 
     // Todo: A timer here is terrible. Let's fix this
     // and ensure we actually do it once Editors have mounted.

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -55,6 +55,7 @@ describe('files', () => {
       };
 
       (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
 
       await cb('/my/fake/path');
       expect(mockTarget.webContents.send).toHaveBeenCalledTimes(1);
@@ -118,6 +119,7 @@ describe('files', () => {
       (dialog.showMessageBox as jest.Mock<any>).mockImplementation(async () => true);
       (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
       (fs.existsSync as jest.Mock<any>).mockReturnValue(true);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
 
       await cb('/my/fake/path');
       expect(dialog.showMessageBox).toHaveBeenCalled();
@@ -138,6 +140,7 @@ describe('files', () => {
       (dialog.showMessageBox as jest.Mock<any>).mockImplementation(async () => false);
       (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
       (fs.existsSync as jest.Mock<any>).mockReturnValue(true);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
 
       await cb('/my/fake/path');
       expect(dialog.showMessageBox).toHaveBeenCalled();

--- a/tests/main/ipc-spec.ts
+++ b/tests/main/ipc-spec.ts
@@ -30,6 +30,7 @@ describe('IpcMainManager', () => {
       };
 
       (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
 
       ipcMainManager.send(IpcEvents.FIDDLE_RUN);
 
@@ -42,9 +43,23 @@ describe('IpcMainManager', () => {
       };
 
       (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(null);
+      ipcMainManager.readyWebContents.add(mockTarget as any);
+
       ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget as any);
 
       expect(mockTarget.send).toHaveBeenCalledWith(IpcEvents.FIDDLE_RUN);
+    });
+
+    it('does not send an event to a target window if it is not ready', () => {
+      const mockTarget = {
+        send: jest.fn()
+      };
+
+      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(null);
+
+      ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget as any);
+
+      expect(mockTarget.send).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -41,8 +41,20 @@ describe('protocol', () => {
 
       const handler = (app.on as any).mock.calls[0][1];
 
-      handler({}, 'electron-fiddle://hello/hi');
-      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, ['/hi']);
+      handler({}, 'electron-fiddle://gist/hi');
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi' }]);
+    });
+
+    it('handles a Fiddle url with a username (open-url)', () => {
+      overridePlatform('darwin');
+      (app.isReady as any).mockReturnValue(true);
+
+      listenForProtocolHandler();
+
+      const handler = (app.on as any).mock.calls[0][1];
+
+      handler({}, 'electron-fiddle://gist/username/gistID');
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'gistID' }]);
     });
 
     it('handles a non-fiddle url (open-url)', () => {
@@ -54,19 +66,19 @@ describe('protocol', () => {
       const handler = (app.on as any).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://noop');
-      handler({}, 'electron-fiddle://noop/noop/noop');
+      handler({}, 'electron-fiddle://gist/noop/noop/null');
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
     });
 
     it('handles a Fiddle url (argv)', () => {
       overridePlatform('win32');
 
-      process.argv = ['electron-fiddle://hello/hi'];
+      process.argv = ['electron-fiddle://gist/hi-arg'];
       (app.isReady as any).mockReturnValue(true);
 
       listenForProtocolHandler();
 
-      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, ['/hi']);
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi-arg' }]);
     });
 
     it('waits for the app to be ready', () => {
@@ -76,7 +88,7 @@ describe('protocol', () => {
       listenForProtocolHandler();
 
       const handler = (app.on as any).mock.calls[0][1];
-      handler({}, 'electron-fiddle://hello/hi');
+      handler({}, 'electron-fiddle://gist/hi-ready');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
       expect(app.once).toHaveBeenCalled();
@@ -86,7 +98,7 @@ describe('protocol', () => {
 
       cb();
 
-      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, ['/hi']);
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi-ready' }]);
     });
   });
 });


### PR DESCRIPTION
This adds support for actually handling the protocol launch requests we receive on the `electron-fiddle://` protocol.

E.g. 
* electron-fiddle://gist/c89aa0037c3da114d44aa3a2d1a0fc24
* electron-fiddle://gist/MarshallOfSound/c89aa0037c3da114d44aa3a2d1a0fc24

In the future I intend to add support for:
* electron-fiddle://electron/master/docs/fiddles/app-ready

In order to load a "fiddle" from the Electron docs.