### PR TITLE
feat: add more information to about panel

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 
 import { isDevMode } from '../utils/devmode';
+import { setupAboutPanel } from '../utils/set-about-panel';
 import { setupDevTools } from './devtools';
 import { setupDialogs } from './dialogs';
 import { onFirstRunMaybe } from './first-run';
@@ -18,6 +19,7 @@ export async function onReady() {
   if (!isDevMode()) process.env.NODE_ENV = 'production';
 
   getOrCreateMainWindow();
+  setupAboutPanel();
 
   const { setupMenu } = await import('./menu');
   const { setupFileListeners } = await import('./files');

--- a/src/utils/set-about-panel.ts
+++ b/src/utils/set-about-panel.ts
@@ -1,0 +1,26 @@
+import { AboutPanelOptionsOptions, app } from 'electron';
+
+/**
+ * Sets Fiddle's About panel options on Linux and macOS
+ *
+ * @returns
+ */
+export function setupAboutPanel(): void {
+  const options: AboutPanelOptionsOptions = {
+    applicationName: 'Electron Fiddle',
+    applicationVersion: app.getVersion(),
+    version: process.versions.electron,
+    copyright: '© Electron Authors',
+  };
+
+  switch (process.platform) {
+    case 'linux':
+      options.website = 'https://electronjs.org/fiddle';
+    case 'darwin':
+      options.credits = 'https://github.com/electron/fiddle/graphs/contributors';
+    default:
+      // fallthrough
+  }
+
+  app.setAboutPanelOptions(options);
+}

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -4,9 +4,14 @@ import { main, onBeforeQuit, onReady, onWindowsAllClosed } from '../../src/main/
 import { shouldQuit } from '../../src/main/squirrel';
 import { setupUpdates } from '../../src/main/update';
 import { getOrCreateMainWindow } from '../../src/main/windows';
+import { setupAboutPanel } from '../../src/utils/set-about-panel';
 
 jest.mock('../../src/main/windows', () => ({
   getOrCreateMainWindow: jest.fn()
+}));
+
+jest.mock('../../src/utils/set-about-panel', () => ({
+  setupAboutPanel: jest.fn()
 }));
 
 jest.mock('../../src/main/update', () => ({
@@ -65,6 +70,7 @@ describe('main', () => {
     it('opens a BrowserWindow, sets up updates', async () => {
       await onReady();
 
+      expect(setupAboutPanel).toHaveBeenCalledTimes(1);
       expect(getOrCreateMainWindow).toHaveBeenCalledTimes(1);
       expect(setupUpdates).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
Resolves https://github.com/electron/fiddle/issues/188.

Adds more information to the About panel on macOS and Linux, including the Electron version being used. @felixrieseberg I wasn't sure what you'd like to put for copyright, so i put `Electron Authors` for now but if there's something else you'd prefer I can use that instead!

new panel on macOS:

<img width="302" alt="Screen Shot 2019-05-31 at 10 29 58 PM" src="https://user-images.githubusercontent.com/2036040/58744177-a9c40c00-83f3-11e9-8ddd-486715fc833b.png">


