### PR TITLE
fix: Don't attempt to set about panel on Windows

### DIFF
--- a/src/utils/set-about-panel.ts
+++ b/src/utils/set-about-panel.ts
@@ -6,6 +6,8 @@ import { AboutPanelOptionsOptions, app } from 'electron';
  * @returns
  */
 export function setupAboutPanel(): void {
+  if (process.platform === 'win32') return;
+
   const options: AboutPanelOptionsOptions = {
     applicationName: 'Electron Fiddle',
     applicationVersion: app.getVersion(),


### PR DESCRIPTION
Turns out, `setAboutPanelOptions` doesn't work on Windows, so we're crashing there 🙈 

fixes #210 