### PR TITLE
test: Mock electron-download

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -13,6 +13,7 @@ jest.spyOn(global.console, 'log').mockImplementation(() => jest.fn());
 jest.spyOn(global.console, 'warn').mockImplementation(() => jest.fn());
 jest.mock('electron', () => require('./mocks/electron'));
 jest.mock('fs-extra');
+jest.mock('electron-download');
 
 delete window.localStorage;
 // We'll do this twice.


### PR DESCRIPTION
Some of our tests accidentally trigger a version change, thus triggering the automatic download of whatever Electron version was selected.

Sure, we could go in and with hours of work find how exactly that happens, but we can also just mock away `electron-download` 😛 