### PR TITLE
fix: correct touch bar constructor in example

### DIFF
--- a/static/show-me/touchbar/main.js
+++ b/static/show-me/touchbar/main.js
@@ -87,17 +87,19 @@ app.on('ready', () => {
     spinning = false
   }
 
-  const touchBar = new TouchBar([
-    spin,
-    new TouchBarSpacer({ size: 'large' }),
-    reel1,
-    new TouchBarSpacer({ size: 'small' }),
-    reel2,
-    new TouchBarSpacer({ size: 'small' }),
-    reel3,
-    new TouchBarSpacer({ size: 'large' }),
-    result
-  ])
+  const touchBar = new TouchBar({
+    items: [
+      spin,
+      new TouchBarSpacer({ size: 'large' }),
+      reel1,
+      new TouchBarSpacer({ size: 'small' }),
+      reel2,
+      new TouchBarSpacer({ size: 'small' }),
+      reel3,
+      new TouchBarSpacer({ size: 'large' }),
+      result
+    ]
+  })
 
   mainWindow.setTouchBar(touchBar)
 })


### PR DESCRIPTION
Fixes the touch bar Show Me example; the one in play now no longer works in > v5 as a result of a change in the Touch Bar constructor. This thus changes that to use a constructor that works for all supported versions.

cc @MarshallOfSound @felixrieseberg 