### PR TITLE
build: Don't throw if missing contributors in PR

### DIFF
--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -146,7 +146,9 @@ async function fetchAndWriteContributorsFile () {
           throw new Error('Contributors array is empty')
         }
       } catch (error) {
-        if (process.env.CI) throw error;
+        if (missingContributorsShouldThrow()) {
+          throw error
+        }
 
         console.warn(`Fetching contributors failed!`, error)
         console.log(`We'll continue without.`)
@@ -159,6 +161,20 @@ async function fetchAndWriteContributorsFile () {
       resolve()
     })
   })
+}
+
+function missingContributorsShouldThrow() {
+  // Not in CI?
+  if (!process.env.CI) {
+    return false
+  }
+
+  // A Pull Request? Fine, we can do without
+  if (process.env.TRAVIS_PULL_REQUEST || process.env.APPVEYOR_PULL_REQUEST_NUMBER ) {
+    return false
+  }
+
+  return true
 }
 
 module.exports = {


### PR DESCRIPTION
A PR from non-maintainers would always fail the Travis CI build, since the build is untrusted and the request for contributors would automatically reach the rate limit (Travis CI is always at the rate limit).

This ensures that only trusted builds actually throw.

cc @codebytere @DeerMichel 