### PR TITLE
fix: correct button code for BrowserWindow show-me

### DIFF
--- a/static/show-me/browserwindow/index.html
+++ b/static/show-me/browserwindow/index.html
@@ -5,11 +5,10 @@
 </head>
 <body>
   <h1>Hello from your BrowserWindow!</h1>
-  <button></button>
+  <button id="close-btn">Close this window</button>
   <script>
-    document.querySelector('Close this window').onclick = () => {
-      window.close()
-    }
+    const button = document.querySelector('#close-btn')
+    button.addEventListener('click', () => window.close())
   </script>
 </body>
 </html>


### PR DESCRIPTION
Little fix so that the button in the `BrowserWindow` show-me does what the code seemed like it was supposed to do. Upon clicking the `Close this window` button, the window will close! ✨ 
![screencast 2019-07-03 15-54-31](https://user-images.githubusercontent.com/16010076/60629730-b7323480-9dab-11e9-9634-4e9eb0314e1a.gif)


