### PR TITLE
feat: console resizing

### DIFF
--- a/src/less/components/output.less
+++ b/src/less/components/output.less
@@ -14,7 +14,6 @@
   padding-left: 10px;
   height: 100%;
   overflow-y: scroll;
-  transition: height 0.2s linear, padding 0.2s linear;
   -webkit-app-region: no-drag;
 
   p {

--- a/src/less/components/output.less
+++ b/src/less/components/output.less
@@ -7,19 +7,15 @@
   color: var(--text-color-1);
   background: var(--background-2);
   box-shadow: inset 0 0 100px 100px rgba(0, 0, 0, 0.15);
+  border-top: @border;
   top: 10vh;
   padding: 0;
+  padding-top: 10px;
   padding-left: 10px;
-  height: 0;
+  height: 100%;
   overflow-y: scroll;
   transition: height 0.2s linear, padding 0.2s linear;
   -webkit-app-region: no-drag;
-
-  &.showing {
-    border-top: @border;
-    padding-top: 10px;
-    height: 150px;
-  }
 
   p {
     margin-bottom: 0;

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -112,16 +112,16 @@ export class App {
 
     const React = await import('react');
     const { render } = await import('react-dom');
-    const { Header } = await import('./components/header');
     const { Dialogs } = await import('./components/dialogs');
-    const { Editors } = await import('./components/editors');
+    const { OutputEditorsWrapper } = await import('./components/output-editors-wrapper');
+    const { Header } = await import('./components/header');
 
     const className = `${process.platform} container`;
     const app = (
       <div className={className}>
-        <Header appState={this.state} />
         <Dialogs appState={this.state} />
-        <Editors appState={this.state} />
+        <Header appState={this.state} />
+        <OutputEditorsWrapper appState={this.state} />
       </div>
     );
 

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { AppState } from '../state';
 import { ChromeMac } from './chrome-mac';
 import { Commands } from './commands';
-import { Output } from './output';
 import { WelcomeTour } from './tour-welcome';
 
 export interface HeaderProps {
@@ -23,7 +22,6 @@ export class Header extends React.Component<HeaderProps, {}> {
         <ChromeMac appState={this.props.appState} />
         <header id='header'>
           <Commands key='commands' appState={this.props.appState} />
-          <Output key='output' appState={this.props.appState} />
         </header>
         <WelcomeTour appState={this.props.appState} />
       </>

--- a/src/renderer/components/output-editors-wrapper.tsx
+++ b/src/renderer/components/output-editors-wrapper.tsx
@@ -29,7 +29,7 @@ export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperS
     }
   }
 
-  private ELEMENTS = {
+  private MOSAIC_ELEMENTS = {
     output: <Output appState={this.props.appState} />,
     editors: <Editors appState={this.props.appState} />
   }
@@ -38,9 +38,9 @@ export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperS
     return (
       <>
         <Mosaic<WrapperMosaicId>
-          renderTile={(id: string) => this.ELEMENTS[id]}
+          renderTile={(id: string) => this.MOSAIC_ELEMENTS[id]}
           resize={{
-            minimumPaneSizePercentage: 0 // Default: 20
+            minimumPaneSizePercentage: 0
           }}
           value={this.state.mosaicArrangement}
           onChange={this.onChange}

--- a/src/renderer/components/output-editors-wrapper.tsx
+++ b/src/renderer/components/output-editors-wrapper.tsx
@@ -2,20 +2,25 @@ import * as React from 'react';
 import { Mosaic, MosaicNode } from 'react-mosaic-component';
 
 import { AppState } from '../state';
-import { Output } from './output';
 import { Editors } from './editors';
+import { Output } from './output';
 
 export interface WrapperProps {
-  appState: AppState
+  appState: AppState;
 }
 
 export interface WrapperState {
-  mosaicArrangement: MosaicNode<WrapperMosaicId>
+  mosaicArrangement: MosaicNode<WrapperMosaicId>;
 }
 
 export type WrapperMosaicId = 'output' | 'editors';
 
 export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperState> {
+
+  private MOSAIC_ELEMENTS = {
+    output: <Output appState={this.props.appState} />,
+    editors: <Editors appState={this.props.appState} />
+  };
 
   constructor(props: any) {
     super(props);
@@ -26,12 +31,7 @@ export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperS
         second: 'editors',
         splitPercentage: 25,
       }
-    }
-  }
-
-  private MOSAIC_ELEMENTS = {
-    output: <Output appState={this.props.appState} />,
-    editors: <Editors appState={this.props.appState} />
+    };
   }
 
   public render() {
@@ -39,9 +39,7 @@ export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperS
       <>
         <Mosaic<WrapperMosaicId>
           renderTile={(id: string) => this.MOSAIC_ELEMENTS[id]}
-          resize={{
-            minimumPaneSizePercentage: 0
-          }}
+          resize={{minimumPaneSizePercentage: 0}}
           value={this.state.mosaicArrangement}
           onChange={this.onChange}
         />
@@ -50,6 +48,6 @@ export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperS
   }
 
   private onChange = (currentNode: any) => {
-    this.setState({mosaicArrangement: currentNode})
+    this.setState({mosaicArrangement: currentNode});
   }
 }

--- a/src/renderer/components/output-editors-wrapper.tsx
+++ b/src/renderer/components/output-editors-wrapper.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Mosaic, MosaicNode } from 'react-mosaic-component';
+
+import { AppState } from '../state';
+import { Output } from './output';
+import { Editors } from './editors';
+
+export interface WrapperProps {
+  appState: AppState
+}
+
+export interface WrapperState {
+  mosaicArrangement: MosaicNode<WrapperMosaicId>
+}
+
+export type WrapperMosaicId = 'output' | 'editors';
+
+export class OutputEditorsWrapper extends React.Component<WrapperProps, WrapperState> {
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      mosaicArrangement: {
+        direction: 'column',
+        first: 'output',
+        second: 'editors',
+        splitPercentage: 25,
+      }
+    }
+  }
+
+  private ELEMENTS = {
+    output: <Output appState={this.props.appState} />,
+    editors: <Editors appState={this.props.appState} />
+  }
+
+  public render() {
+    return (
+      <>
+        <Mosaic<WrapperMosaicId>
+          renderTile={(id: string) => this.ELEMENTS[id]}
+          resize={{
+            minimumPaneSizePercentage: 0 // Default: 20
+          }}
+          value={this.state.mosaicArrangement}
+          onChange={this.onChange}
+        />
+      </>
+    );
+  }
+
+  private onChange = (currentNode: any) => {
+    this.setState({mosaicArrangement: currentNode})
+  }
+}

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { OutputEntry } from '../../interfaces';
 import { AppState } from '../state';
 import { MosaicContext } from 'react-mosaic-component';
+import { WrapperMosaicId } from './output-editors-wrapper';
 
 export interface CommandsProps {
   appState: AppState;
@@ -22,7 +23,7 @@ export interface CommandsProps {
 export class Output extends React.Component<CommandsProps, {}> {
   private outputRef = React.createRef<HTMLDivElement>();
   static contextType = MosaicContext;
-  public context: MosaicContext<string>;
+  public context: MosaicContext<WrapperMosaicId>;
 
   constructor(props: CommandsProps) {
     super(props);

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { OutputEntry } from '../../interfaces';
 import { AppState } from '../state';
+import { MosaicContext } from 'react-mosaic-component';
 
 export interface CommandsProps {
   appState: AppState;
@@ -20,6 +21,8 @@ export interface CommandsProps {
 @observer
 export class Output extends React.Component<CommandsProps, {}> {
   private outputRef = React.createRef<HTMLDivElement>();
+  static contextType = MosaicContext;
+  public context: MosaicContext<string>;
 
   constructor(props: CommandsProps) {
     super(props);
@@ -73,7 +76,11 @@ export class Output extends React.Component<CommandsProps, {}> {
 
   public render() {
     const { isConsoleShowing, output } = this.props.appState;
-    const className = isConsoleShowing ? 'output showing' : 'output';
+    if (!isConsoleShowing) {
+      this.context.mosaicActions.expand(['first'], 0);
+    } else {
+      this.context.mosaicActions.expand(['first'], 25);
+    }
 
     // The last 1000 lines
     const lines = output
@@ -81,7 +88,7 @@ export class Output extends React.Component<CommandsProps, {}> {
       .map(this.renderEntry);
 
     return (
-      <div className={className} ref={this.outputRef}>
+      <div className="output" ref={this.outputRef}>
         {lines}
       </div>
     );

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -5,6 +5,7 @@ import { OutputEntry } from '../../interfaces';
 import { AppState } from '../state';
 import { MosaicContext } from 'react-mosaic-component';
 import { WrapperMosaicId } from './output-editors-wrapper';
+import { autorun } from 'mobx';
 
 export interface CommandsProps {
   appState: AppState;
@@ -30,6 +31,19 @@ export class Output extends React.Component<CommandsProps, {}> {
 
     this.renderTimestamp = this.renderTimestamp.bind(this);
     this.renderEntry = this.renderEntry.bind(this);
+  }
+
+
+  public componentDidMount() {
+    autorun(() => {
+      const { isConsoleShowing } = this.props.appState;
+
+      if (!isConsoleShowing) {
+        this.context.mosaicActions.expand(['first'], 0);
+      } else {
+        this.context.mosaicActions.expand(['first'], 25);
+      }
+    })
   }
 
   public componentDidUpdate() {
@@ -76,12 +90,7 @@ export class Output extends React.Component<CommandsProps, {}> {
   }
 
   public render() {
-    const { isConsoleShowing, output } = this.props.appState;
-    if (!isConsoleShowing) {
-      this.context.mosaicActions.expand(['first'], 0);
-    } else {
-      this.context.mosaicActions.expand(['first'], 25);
-    }
+    const { output } = this.props.appState;
 
     // The last 1000 lines
     const lines = output

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -1,11 +1,11 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
+import { autorun } from 'mobx';
+import { MosaicContext } from 'react-mosaic-component';
 import { OutputEntry } from '../../interfaces';
 import { AppState } from '../state';
-import { MosaicContext } from 'react-mosaic-component';
 import { WrapperMosaicId } from './output-editors-wrapper';
-import { autorun } from 'mobx';
 
 export interface CommandsProps {
   appState: AppState;
@@ -22,9 +22,9 @@ export interface CommandsProps {
  */
 @observer
 export class Output extends React.Component<CommandsProps, {}> {
-  private outputRef = React.createRef<HTMLDivElement>();
-  static contextType = MosaicContext;
+  public static contextType = MosaicContext;
   public context: MosaicContext<WrapperMosaicId>;
+  private outputRef = React.createRef<HTMLDivElement>();
 
   constructor(props: CommandsProps) {
     super(props);
@@ -40,14 +40,14 @@ export class Output extends React.Component<CommandsProps, {}> {
       // is not fully supported, so this condition makes the tests pass
       if (this.context.mosaicActions && this.context.mosaicActions.expand) {
         const { isConsoleShowing } = this.props.appState;
-  
+
         if (!isConsoleShowing) {
           this.context.mosaicActions.expand(['first'], 0);
         } else {
           this.context.mosaicActions.expand(['first'], 25);
         }
       }
-    })
+    });
   }
 
   public componentDidUpdate() {
@@ -102,7 +102,7 @@ export class Output extends React.Component<CommandsProps, {}> {
       .map(this.renderEntry);
 
     return (
-      <div className="output" ref={this.outputRef}>
+      <div className='output' ref={this.outputRef}>
         {lines}
       </div>
     );

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -36,12 +36,16 @@ export class Output extends React.Component<CommandsProps, {}> {
 
   public componentDidMount() {
     autorun(() => {
-      const { isConsoleShowing } = this.props.appState;
-
-      if (!isConsoleShowing) {
-        this.context.mosaicActions.expand(['first'], 0);
-      } else {
-        this.context.mosaicActions.expand(['first'], 25);
+      // this context should always exist, but mocking context in enzyme
+      // is not fully supported, so this condition makes the tests pass
+      if (this.context.mosaicActions && this.context.mosaicActions.expand) {
+        const { isConsoleShowing } = this.props.appState;
+  
+        if (!isConsoleShowing) {
+          this.context.mosaicActions.expand(['first'], 0);
+        } else {
+          this.context.mosaicActions.expand(['first'], 25);
+        }
       }
     })
   }

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -4,4 +4,6 @@ export class MockState {
   @observable public isWarningDialogShowing = false;
   @observable public gistId = '';
   @observable public closedPanels = {};
+  @observable public isConsoleShowing = true;
+  @observable public output = [];
 }

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -18,8 +18,8 @@ jest.mock('../../src/renderer/components/header', () => ({
 jest.mock('../../src/renderer/components/dialogs', () => ({
   Dialogs: () => 'Dialogs;'
 }));
-jest.mock('../../src/renderer/components/editors', () => ({
-  Editors: () => 'Editors;'
+jest.mock('../../src/renderer/components/output-editors-wrapper', () => ({
+  OutputEditorsWrapper: () => 'OutputEditorsWrapper;'
 }));
 
 describe('Editors component', () => {
@@ -37,7 +37,7 @@ describe('Editors component', () => {
       app.setupUnsavedOnChangeListener = jest.fn();
       jest.runAllTimers();
 
-      expect(result.innerHTML).toBe('Header;Dialogs;Editors;');
+      expect(result.innerHTML).toBe('Dialogs;Header;OutputEditorsWrapper;');
       expect(app.setupUnsavedOnChangeListener).toHaveBeenCalled();
 
       jest.useRealTimers();

--- a/tests/renderer/components/__snapshots__/header-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/header-spec.tsx.snap
@@ -12,10 +12,6 @@ exports[`Header component renders 1`] = `
       appState={Object {}}
       key="commands"
     />
-    <output
-      appState={Object {}}
-      key="output"
-    />
   </header>
   <welcome-tour
     appState={Object {}}

--- a/tests/renderer/components/__snapshots__/output-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/output-spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Output component renders with output 1`] = `
 <div
-  className="output showing"
+  className="output"
 >
   <p
     key="1532704073130--0--0"

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -38,7 +38,7 @@ describe('Output component', () => {
 
   it('renders', () => {
     const wrapper = shallow(<Output appState={store} />);
-    expect(wrapper.html()).toBe('<div class="output showing"></div>');
+    expect(wrapper.html()).toBe('<div class="output"></div>');
   });
 
   it('renders with output', () => {

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -2,15 +2,38 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { Output } from '../../../src/renderer/components/output';
+import { MockState } from '../../mocks/state';
+
+let mockContext: any = {};
+
+jest.mock('react-mosaic-component', () => {
+  const { MosaicContext, MosaicRootActions } = jest.requireActual('react-mosaic-component');
+
+  return {
+    MosaicContext,
+    MosaicRootActions
+  };
+});
+
+beforeAll(() => {
+  mockContext = {
+    mosaicActions: {
+      expand: jest.fn(),
+      remove: jest.fn(),
+      hide: jest.fn(),
+      replaceWith: jest.fn(),
+      updateTree: jest.fn(),
+      getRoot: jest.fn()
+    },
+    mosaicId: 'output'
+  };
+})
 
 describe('Output component', () => {
   let store: any;
 
   beforeEach(() => {
-    store = {
-      isConsoleShowing: true,
-      output: []
-    };
+    store = new MockState();
   });
 
   it('renders', () => {
@@ -54,14 +77,19 @@ describe('Output component', () => {
     expect(result).toBeTruthy();
   });
 
-  it('hides the console via class', () => {
+  it.only('hides the console with react-mosaic-component', () => {
+    // manually trigger lifecycle methods so that 
+    // context can be set before mounting method
+    const wrapper = shallow(<Output appState={store} />, {
+      context: mockContext,
+      disableLifecycleMethods: true
+    });
+    wrapper.instance().context = mockContext;
+    wrapper.instance().componentDidMount!();
+
+    expect(mockContext.mosaicActions.expand).toHaveBeenCalledWith(['first'], 25);
     store.isConsoleShowing = false;
-
-    const wrapper = shallow(
-      <Output appState={store} />
-    );
-
-    expect(wrapper.html().includes('showing')).toBe(false);
+    expect(mockContext.mosaicActions.expand).toHaveBeenCalledWith(['first'], 0);
   });
 
   it('handles componentDidUpdate', () => {

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -77,7 +77,7 @@ describe('Output component', () => {
     expect(result).toBeTruthy();
   });
 
-  it.only('hides the console with react-mosaic-component', () => {
+  it('hides the console with react-mosaic-component', () => {
     // manually trigger lifecycle methods so that 
     // context can be set before mounting method
     const wrapper = shallow(<Output appState={store} />, {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -153,7 +153,7 @@ describe('AppState', () => {
     });
   });
 
-  describe.only('clearConsole()', () => {
+  describe('clearConsole()', () => {
     it('clears the console', () => {
       expect(appState.output.length).toBe(1);
       appState.clearConsole();

--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -30,7 +30,8 @@ const CONTRIBUTORS_WHITELIST = [
   'hashimotoyt',
   'ada-lovecraft',
   'ajphukan',
-  'deermichel'
+  'deermichel',
+  'erickzhao'
 ]
 
 async function maybeFetchContributors () {


### PR DESCRIPTION
Closes #215.

Adds a `react-mosaic-component` wrapper around the `Editors` and the `Output` components so that you can drag and resize.

Due to this resizing fix, the functionality of the console show/hide button had to be refactored as well. Note that pressing show/hide now does not have an animation. Moreover, showing the hidden console will always revert to its default size.

### TODO
- [x] Rewrite close console test to pass

cc @felixrieseberg @codebytere @DeerMichel 