### PR TITLE
chore: add offline notice when loading fiddles

### DIFF
--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -268,10 +268,17 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
    * @returns {boolean}
    */
   private handleLoadingFailed(error: Error): false {
-    this.props.appState.setWarningDialogTexts({
-      label: `Loading the fiddle failed: ${error}`,
-      cancel: undefined
-    });
+    if (navigator.onLine) {
+      this.props.appState.setWarningDialogTexts({
+        label: `Loading the fiddle failed: ${error}`,
+        cancel: undefined
+      });
+    } else {
+      this.props.appState.setWarningDialogTexts({
+        label: `Loading the fiddle failed. Your computer seems to be offline. Error: ${error}`,
+        cancel: undefined
+      });
+    }
 
     this.props.appState.toogleWarningDialog();
 


### PR DESCRIPTION
This PR adds a more verbose warning message when trying to load a fiddle while computer is offline.