### PR TITLE
build: Don't mark releases as prereleases

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -90,7 +90,7 @@ module.exports = {
           name: 'fiddle'
         },
         draft: true,
-        prerelease: true
+        prerelease: false
       }
     }
   ]


### PR DESCRIPTION
We released 0.9 as a pre-release, meaning that the auto-update didn't actually go out. This'll fix that 🙈 