### PR TITLE
chore: `toogle` -> `toggle`

### DIFF
--- a/src/renderer/components/dialog-confirm.tsx
+++ b/src/renderer/components/dialog-confirm.tsx
@@ -29,7 +29,7 @@ export class ConfirmDialog extends React.Component<ConfirmDialogProps, ConfirmDi
 
   public onClose(result: boolean) {
     this.props.appState.confirmationPromptLastResult = result;
-    this.props.appState.toogleConfirmationPromptDialog();
+    this.props.appState.toggleConfirmationPromptDialog();
   }
 
   public render() {

--- a/src/renderer/components/dialog-warning.tsx
+++ b/src/renderer/components/dialog-warning.tsx
@@ -29,7 +29,7 @@ export class WarningDialog extends React.Component<WarningDialogProps, WarningDi
 
   public onClose(result: boolean) {
     this.props.appState.warningDialogLastResult = result;
-    this.props.appState.toogleWarningDialog();
+    this.props.appState.toggleWarningDialog();
   }
 
   public render() {

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -223,7 +223,7 @@ export class RemoteLoader {
       });
     }
 
-    this.appState.toogleWarningDialog();
+    this.appState.toggleWarningDialog();
 
     console.warn(`Loading Fiddle failed`, error);
     return false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -246,7 +246,7 @@ export class AppState {
     this.isTokenDialogShowing = !this.isTokenDialogShowing;
   }
 
-  @action public toogleWarningDialog() {
+  @action public toggleWarningDialog() {
     this.isWarningDialogShowing = !this.isWarningDialogShowing;
 
     if (this.isWarningDialogShowing) {
@@ -254,7 +254,7 @@ export class AppState {
     }
   }
 
-  @action public toogleConfirmationPromptDialog() {
+  @action public toggleConfirmationPromptDialog() {
     this.isConfirmationPromptShowing = !this.isConfirmationPromptShowing;
 
     if (this.isConfirmationPromptShowing) {

--- a/tests/renderer/components/commands-address-bar-spec.tsx
+++ b/tests/renderer/components/commands-address-bar-spec.tsx
@@ -19,7 +19,7 @@ describe('AddressBar component', () => {
     public setWarningDialogTexts = jest.fn();
     public setConfirmationDialogTexts = jest.fn();
     public setConfirmationPromptTexts = jest.fn();
-    public toogleWarningDialog = jest.fn();
+    public toggleWarningDialog = jest.fn();
   }
 
   beforeEach(() => {

--- a/tests/renderer/components/dialog-warning-spec.tsx
+++ b/tests/renderer/components/dialog-warning-spec.tsx
@@ -17,7 +17,7 @@ describe('TokenDialog component', () => {
     store = {
       isWarningDialogShowing: false,
       warningDialogTexts: { label: '', ok: '', cancel: '' },
-      toogleWarningDialog: jest.fn()
+      toggleWarningDialog: jest.fn()
     };
   });
 
@@ -37,6 +37,6 @@ describe('TokenDialog component', () => {
     const instance: WarningDialog = wrapper.instance() as any;
 
     instance.onClose(true);
-    expect(store.toogleWarningDialog).toHaveBeenCalledTimes(1);
+    expect(store.toggleWarningDialog).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -54,7 +54,7 @@ class MockStore {
   @observable public isWarningDialogShowing: boolean = false;
   @observable public isConfirmationPromptShowing: boolean = false;
   public setWarningDialogTexts = jest.fn();
-  public toogleWarningDialog = jest.fn();
+  public toggleWarningDialog = jest.fn();
   public setConfirmationDialogTexts = jest.fn();
   public setConfirmationPromptTexts = jest.fn();
   public versions = {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -188,15 +188,15 @@ describe('AppState', () => {
     });
   });
 
-  describe('toogleWarningDialog()', () => {
+  describe('toggleWarningDialog()', () => {
     it('toggles the warnign dialog', () => {
       appState.warningDialogLastResult = true;
 
-      appState.toogleWarningDialog();
+      appState.toggleWarningDialog();
       expect(appState.isWarningDialogShowing).toBe(true);
       expect(appState.warningDialogLastResult).toBe(null);
 
-      appState.toogleWarningDialog();
+      appState.toggleWarningDialog();
       expect(appState.isWarningDialogShowing).toBe(false);
     });
   });


### PR DESCRIPTION
Tiny nit where we were calling a bunch of variables `toogle` rather than `toggle` in the code. Will make toggles easier to search for 👀 