### PR TITLE
chore: 'monoaco' -> 'monaco'

### DIFF
--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -11,7 +11,7 @@ import { AppState } from '../state';
 export interface EditorProps {
   appState: AppState;
   monaco: typeof MonacoType;
-  monoacoOptions: MonacoType.editor.IEditorOptions;
+  monacoOptions: MonacoType.editor.IEditorOptions;
   id: EditorId;
   options?: Partial<MonacoType.editor.IEditorConstructionOptions>;
   editorDidMount?: (editor: MonacoType.editor.IStandaloneCodeEditor) => void;
@@ -68,7 +68,7 @@ export class Editor extends React.Component<EditorProps> {
    * Initialize Monaco.
    */
   public async initMonaco() {
-    const { monaco, monoacoOptions } = this.props;
+    const { monaco, monacoOptions: monacoOptions } = this.props;
     const ref = this.containerRef.current;
 
     if (ref) {
@@ -77,7 +77,7 @@ export class Editor extends React.Component<EditorProps> {
         theme: 'main',
         contextmenu: false,
         model: null,
-        ...monoacoOptions
+        ...monacoOptions
       });
 
       await this.editorDidMount(this.editor);

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -241,7 +241,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
         id={id}
         monaco={monaco!}
         appState={appState}
-        monoacoOptions={defaultMonacoOptions}
+        monacoOptions={defaultMonacoOptions}
       />
     );
   }

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -35,7 +35,7 @@ describe('Editor component', () => {
 
   it('renders the editor container', () => {
     const wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monoacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
     );
 
     expect(wrapper.html()).toBe('<div class="editorContainer"></div>');
@@ -43,13 +43,13 @@ describe('Editor component', () => {
 
   it('correctly sets the language', () => {
     let wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monoacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
     );
 
     expect((wrapper.instance() as any).language).toBe('javascript');
 
     wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monoacoOptions={{}} id={EditorId.html} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.html} />
     );
 
     expect((wrapper.instance() as any).language).toBe('html');
@@ -57,7 +57,7 @@ describe('Editor component', () => {
 
   it('denies updates', () => {
     const wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monoacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
     );
 
     expect((wrapper as any)
@@ -72,7 +72,7 @@ describe('Editor component', () => {
       <Editor
         appState={store}
         monaco={monaco}
-        monoacoOptions={{}}
+        monacoOptions={{}}
         id={EditorId.main}
         editorDidMount={didMount}
       />
@@ -97,7 +97,7 @@ describe('Editor component', () => {
       <Editor
         appState={store}
         monaco={monaco}
-        monoacoOptions={{}}
+        monacoOptions={{}}
         id={EditorId.main}
         editorDidMount={() => undefined}
       />
@@ -117,7 +117,7 @@ describe('Editor component', () => {
       <Editor
         appState={store}
         monaco={monaco}
-        monoacoOptions={{}}
+        monacoOptions={{}}
         id={EditorId.main}
         editorDidMount={didMount}
       />


### PR DESCRIPTION
Fixes a typo so that we can search through the code easier. :)

cc @felixrieseberg @malept 