### PR TITLE
fix: enforce 2-space indents in all editors

### DIFF
--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -121,6 +121,9 @@ export class Editor extends React.Component<EditorProps> {
     } else {
       const value = await getContent(id, version);
       const model = monaco.editor.createModel(value, this.language);
+      model.updateOptions({
+        tabSize: 2
+      });
 
       this.editor.setModel(model);
     }


### PR DESCRIPTION
Fixes #161.

Previously, when instantiating the Monaco Editor's language model, we did not set any explicit parameters. It just determined them based on the initial values of the editor contents and the language.

My guess is that since `renderer.js` didn't have any 2-indented code, it defaulted to 4-tab.

https://github.com/electron/fiddle/blob/7d19ad91a66c6f40daf0a1277b3c9cfcbb71fe80/src/renderer/components/editor.tsx#L122-L124

This PR just sets it to 2 spaces.