### PR TITLE
fix: load empty files upon opening a fiddle

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -65,12 +65,14 @@ export class App {
       const editor = fiddle.editors[name];
       const backup = this.state.closedPanels[name];
 
-      if (isEditorBackup(backup) && backup.model && values[name]) {
-        // The editor does not exist, attempt to set it on the backup
-        backup.model.setValue(values[name]!);
-      } else if (editor && editor.setValue && values[name]) {
-        // The editor exists, set the value directly
-        editor.setValue(values[name]!);
+      if (typeof values[name] !== 'undefined') {
+        if (isEditorBackup(backup) && backup.model) {
+          // The editor does not exist, attempt to set it on the backup
+          backup.model.setValue(values[name]!);
+        } else if (editor && editor.setValue) {
+          // The editor exists, set the value directly
+          editor.setValue(values[name]!);
+        }
       }
     }
 

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -208,6 +208,17 @@ describe('Editors component', () => {
 
       expect(threw).toBe(true);
     });
+
+    it('does not set a value if none passed in', async () => {
+        const app = new App();
+        await app.setValues({
+          html: 'html-value',
+          main: 'main-value',
+        });
+  
+        expect((window as any).ElectronFiddle.editors.renderer.setValue)
+          .not.toHaveBeenCalled();
+    });
   });
 
   describe('setupUnsavedOnChangeListener()', () => {


### PR DESCRIPTION
Fixes #180.

Previously, the code would avoid overwriting the editor file with `editor.setValue()` if `values[name]` was falsy. However, since `Boolean('')` evaluates to false, empty strings would not be set.

This solves an edge case with Saved Fiddles with missing files or Show Me's that didn't require all 3 files.