### PR TITLE
fix: adjust styling to avoid hiding IntelliSense popups

### DIFF
--- a/src/less/mosaic-vendor.less
+++ b/src/less/mosaic-vendor.less
@@ -188,7 +188,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
### Problem

Currently, some styling leads to the Monaco editor's IntelliSense being hidden if it would overflow the window.

Screenshot:
![image](https://user-images.githubusercontent.com/16010076/62087160-a68fa580-b215-11e9-896b-265396382bd9.png)

### Fix
I pinpointed the root cause of the problem to `.mosaic-preview` in our own `src/less/mosaic-vendor.less` file, which sets `overflow: hidden`.

Looking at the original vendor styling ([link](https://github.com/nomcopter/react-mosaic/blob/master/styles/mosaic.less)), it seems like they're not setting any `overflow` anywhere, so it seems to be on our end.

Since this vendor `.less` file was originally added in PR #14 to improve FPS, I wanted to test if removing the rule would cause a regression in the scrolling FPS:

1. [Screen capture with `overflow: hidden`](https://youtu.be/3rh7_CAjEfY)
2. [Screen capture without](https://youtu.be/wdrRkNfyU6k)

There doesn't seem to be any sort of meaningful regression here, and it seems that removing the rule solves the IntelliSense problem (see video 2).

