### PR TITLE
feat: intellisense for local builds

### DIFF
--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -15,15 +15,25 @@ const definitionPath = path.join(USER_DATA_PATH, 'electron-typedef');
  * @param {string} version
  * @returns {Promise<string>}
  */
-export function fetchTypeDefinitions(version: string): Promise<string> {
+export async function fetchTypeDefinitions(version: string): Promise<string> {
   const url = `https://unpkg.com/electron@${version}/electron.d.ts`;
 
-  return window.fetch(url)
-    .then((response) => response.text())
-    .catch((error) => {
-      console.warn(`Fetch Types: Could not fetch definitions`, error);
-      return '';
-    });
+  let text: string;
+  try {
+    const response = await window.fetch(url);
+    text = await response.text();
+  } catch (error) {
+    console.warn(`Fetch Types: Could not fetch definitions`, error);
+    return '';
+  }
+
+  // for invalid packa
+  if (text.includes('Cannot find package')) {
+    console.warn(`Fetch Types: ${text}`);
+    return '';
+  } else {
+    return text;
+  }
 }
 
 /**

--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -91,10 +91,15 @@ export async function getDownloadedVersionTypeDefs(version: ElectronVersion): Pr
   }
 }
 
-export async function getLocalVersionTypeDefs(version: ElectronVersion) {    // module path is inside out/Debug for local builds.
-  const fs = await fancyImport<typeof fsType>('fs-extra');
-  const typesPath = getLocalTypePathForVersion(version);
-  return fs.readFile(typesPath!, 'utf-8');
+export async function getLocalVersionTypeDefs(version: ElectronVersion) {
+  if (version.source === ElectronVersionSource.local && !!version.localPath) {
+    const fs = await fancyImport<typeof fsType>('fs-extra');
+    const typesPath = getLocalTypePathForVersion(version);
+    if (!!typesPath && fs.existsSync(typesPath)) {
+      return fs.readFile(typesPath, 'utf-8');
+    }
+  }
+  return null;
 }
 
 /**
@@ -149,6 +154,6 @@ export function getLocalTypePathForVersion(version: ElectronVersion) {
       'electron.d.ts'
     );
   } else {
-    return undefined;
+    return null;
   }
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -26,7 +26,7 @@ import { isEditorBackup, isEditorId, isPanelId } from '../utils/type-checks';
 import { BinaryManager } from './binary';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
 import { getContent, isContentUnchanged } from './content';
-import { updateEditorTypeDefinitions, getLocalTypePathForVersion } from './fetch-types';
+import { getLocalTypePathForVersion, updateEditorTypeDefinitions } from './fetch-types';
 import { ipcRendererManager } from './ipc';
 import { activateTheme } from './themes';
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -1,3 +1,4 @@
+import * as fsType from 'fs-extra';
 import { action, autorun, computed, observable, when } from 'mobx';
 import { MosaicNode } from 'react-mosaic-component';
 
@@ -19,14 +20,16 @@ import { arrayToStringMap } from '../utils/array-to-stringmap';
 import { EditorBackup, getEditorBackup } from '../utils/editor-backup';
 import { createMosaicArrangement, getVisibleMosaics } from '../utils/editors-mosaic-arrangement';
 import { getName } from '../utils/get-title';
+import { fancyImport } from '../utils/import';
 import { normalizeVersion } from '../utils/normalize-version';
 import { isEditorBackup, isEditorId, isPanelId } from '../utils/type-checks';
 import { BinaryManager } from './binary';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
 import { getContent, isContentUnchanged } from './content';
-import { updateEditorTypeDefinitions } from './fetch-types';
+import { updateEditorTypeDefinitions, getLocalTypePathForVersion } from './fetch-types';
 import { ipcRendererManager } from './ipc';
 import { activateTheme } from './themes';
+
 import {
   addLocalVersion,
   ElectronReleaseChannel,
@@ -96,6 +99,7 @@ export class AppState {
   @observable public mosaicArrangement: MosaicNode<MosaicId> | null = DEFAULT_MOSAIC_ARRANGEMENT;
   @observable public templateName: string | undefined;
   @observable public currentDocsDemoPage: DocsDemoPage = DocsDemoPage.DEFAULT;
+  @observable public localTypeWatcher: fsType.FSWatcher | undefined;
 
   // -- Various "isShowing" settings ------------------
   @observable public isConsoleShowing: boolean = false;
@@ -405,7 +409,24 @@ export class AppState {
     }
 
     // Update TypeScript definitions
-    updateEditorTypeDefinitions(version);
+    const versionObject = this.versions[version];
+
+    if (versionObject.source === ElectronVersionSource.local) {
+      const fs = await fancyImport<typeof fsType>('fs-extra');
+      const typePath = getLocalTypePathForVersion(versionObject);
+      console.info(`TypeDefs: Watching file for local version ${version} at path ${typePath}`);
+      this.localTypeWatcher = fs.watch(typePath!, async () => {
+        console.info(`TypeDefs: Noticed file change at ${typePath}. Updating editor typedefs.`);
+        await updateEditorTypeDefinitions(versionObject);
+      });
+    } else {
+      if (!!this.localTypeWatcher) {
+        console.info(`TypeDefs: Switched to downloaded version ${version}. Unwatching local typedefs.`);
+        this.localTypeWatcher.close();
+        this.localTypeWatcher = undefined;
+      }
+    }
+    await updateEditorTypeDefinitions(versionObject);
 
     // Fetch new binaries, maybe?
     await this.downloadVersion(version);

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -215,7 +215,7 @@ describe('Editors component', () => {
           html: 'html-value',
           main: 'main-value',
         });
-  
+
         expect((window as any).ElectronFiddle.editors.renderer.setValue)
           .not.toHaveBeenCalled();
     });

--- a/tests/renderer/binary-spec.ts
+++ b/tests/renderer/binary-spec.ts
@@ -1,6 +1,6 @@
 import { BinaryManager } from '../../src/renderer/binary';
-import { overridePlatform, resetPlatform } from '../utils';
 import { USER_DATA_PATH } from '../../src/renderer/constants';
+import { overridePlatform, resetPlatform } from '../utils';
 
 import * as path from 'path';
 
@@ -80,7 +80,7 @@ describe('binary', () => {
 
       await binaryManager.remove('v3.0.0');
       expect(binaryManager.removeTypeDefsForVersion).toHaveBeenCalledTimes(4);
-      
+
     });
   });
 
@@ -103,7 +103,7 @@ describe('binary', () => {
 
       try {
         await binaryManager.removeTypeDefsForVersion('v3.0.0');
-      } catch(e) {
+      } catch (e) {
         expect(e).toEqual(new Error('Bwap bwap'));
       }
     });

--- a/tests/renderer/components/settings-spec.tsx
+++ b/tests/renderer/components/settings-spec.tsx
@@ -87,7 +87,7 @@ describe('Settings component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it.only('closes upon pressing Escape key', () => {
+  it('closes upon pressing Escape key', () => {
     expect(store.isSettingsShowing).toBe(true);
     // mock event listener API
     const map: any = {};


### PR DESCRIPTION
This PR adds IntelliSense for local versions of Electron by loading and watching the `electron.d.ts` file generated by the local build. By using `fs.watch`, the definitions will be renewed whenever they are updated locally.

Since the TypeScript definitions are generated from documentation, changes to the IntelliSense will only be reflected upon modifying the documentation locally and rebuilding.