### PR TITLE
fix: ensure state consistency when loading an external Fiddle

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,9 +33,9 @@ export interface ElectronVersion extends NpmVersion {
 }
 
 export interface SetFiddleOptions {
-  values: EditorValues;
   filePath?: string;
   templateName?: string;
+  gistId?: string;
 }
 
 export interface OutputEntry {

--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -107,7 +107,7 @@ export class BinaryManager {
     } catch (error) {
       console.warn(`Failure while unzipping ${version}`, error);
 
-      // Todo: Handle this case
+      // TODO: Handle this case
     }
 
     this.state[version] = 'ready';

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -71,7 +71,7 @@ export class PublishButton extends React.Component<PublishButtonProps> {
     const octo = await getOctokit(this.props.appState);
     const { gitHubPublishAsPublic } = this.props.appState;
     const options = { includeDependencies: true, includeElectron: true };
-    const values = await window.ElectronFiddle.app.getValues(options);
+    const values = await window.ElectronFiddle.app.getEditorValues(options);
 
     try {
       const gist = await octo.gists.create({

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -79,17 +79,11 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     ipcRendererManager.on(IpcEvents.FS_NEW_FIDDLE, async (_event) => {
       const { version } = this.props.appState;
 
-      this.props.appState.setWarningDialogTexts({
-        label: 'Your current fiddle is unsaved. Do you want to discard it?'
-      });
-
-      window.ElectronFiddle.app.fileManager.setFiddle({
-        values: {
-          html: await getContent(EditorId.html, version),
-          renderer: await getContent(EditorId.renderer, version),
-          main: await getContent(EditorId.main, version),
-        }
-      });
+      await window.ElectronFiddle.app.replaceFiddle({
+        html: await getContent(EditorId.html, version),
+        renderer: await getContent(EditorId.renderer, version),
+        main: await getContent(EditorId.main, version),
+      }, {});
     });
 
     ipcRendererManager.on(IpcEvents.MONACO_TOGGLE_OPTION, (_event, cmd: string) => {

--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -22,7 +22,7 @@ export async function getContent(
 
   if (name === EditorId.main) {
     // We currently only distinguish between loadFile
-    // and loadURL. Todo: Properly version the quick-start.
+    // and loadURL. TODO: Properly version the quick-start.
     if (version && version.startsWith('1.')) {
       return (await import('../content/main-1-x-x')).main;
     }
@@ -42,7 +42,7 @@ export async function getContent(
 export async function isContentUnchanged(name: EditorId): Promise<boolean> {
   if (!window.ElectronFiddle || !window.ElectronFiddle.app) return false;
 
-  const values = await window.ElectronFiddle.app.getValues({ include: false });
+  const values = await window.ElectronFiddle.app.getEditorValues({ include: false });
 
   // Handle main case, which needs to check both possible versions
   if (name === EditorId.main) {

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -1,7 +1,6 @@
 import { when } from 'mobx';
 import { EditorId, EditorValues } from '../interfaces';
 import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
-import { getTitle } from '../utils/get-title';
 import { getOctokit } from '../utils/octokit';
 import { sortedElectronMap } from '../utils/sorted-electron-map';
 import { ELECTRON_ORG, ELECTRON_REPO } from './constants';
@@ -189,17 +188,7 @@ export class RemoteLoader {
    * @returns {boolean}
    */
   private async handleLoadingSuccess(values: Partial<EditorValues>, gistId: string): Promise<boolean> {
-    this.appState.setWarningDialogTexts({
-      label: 'Loading the fiddle will replace your current unsaved changes. Do you want to discard them?'
-    });
-
-    await window.ElectronFiddle.app.setValues(values);
-
-    document.title = getTitle(this.appState);
-    this.appState.gistId = gistId;
-    this.appState.localPath = undefined;
-    this.appState.templateName = undefined;
-
+    await window.ElectronFiddle.app.replaceFiddle(values, {gistId});
     return true;
   }
 

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -37,7 +37,7 @@ export class Runner {
    * @returns {Promise<boolean>}
    */
   public async run(): Promise<boolean> {
-    const { fileManager, getValues } = window.ElectronFiddle.app;
+    const { fileManager, getEditorValues } = window.ElectronFiddle.app;
     const options = { includeDependencies: false, includeElectron: false };
     const { binaryManager, currentElectronVersion } = this.appState;
     const { version, localPath } = currentElectronVersion;
@@ -47,7 +47,7 @@ export class Runner {
     }
     this.appState.isConsoleShowing = true;
 
-    const values = await getValues(options);
+    const values = await getEditorValues(options);
     const dir = await this.saveToTemp(options);
 
     if (!dir) return false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -85,7 +85,6 @@ export class AppState {
 
   // -- Various session-only state ------------------
   @observable public gistId: string = '';
-  @observable public isMyGist: boolean = false;
   @observable public isPublishing: boolean = false;
   @observable public versions: Record<string, ElectronVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
@@ -405,7 +404,7 @@ export class AppState {
     // Should we update the editor?
     if (await isContentUnchanged(EditorId.main)) {
       const main = await getContent(EditorId.main, version);
-      window.ElectronFiddle.app.setValues({ main }, false);
+      window.ElectronFiddle.app.setEditorValues({ main });
     }
 
     // Update TypeScript definitions
@@ -475,7 +474,7 @@ export class AppState {
     let strData = data.toString();
     const { isNotPre, bypassBuffer } = options;
 
-    // Todo: This drops the first part of the buffer... is that fully expected?
+    // TODO: This drops the first part of the buffer... is that fully expected?
     if (process.platform === 'win32' && bypassBuffer === false) {
       this.outputBuffer += strData;
       strData = this.outputBuffer;

--- a/tests/mocks/app.ts
+++ b/tests/mocks/app.ts
@@ -4,8 +4,9 @@ import { RunnerMock } from './runner';
 
 export class AppMock {
   public setupUnsavedOnChangeListener = jest.fn();
-  public setValues = jest.fn();
-  public getValues = jest.fn(() => ({
+  public replaceFiddle = jest.fn();
+  public setEditorValues = jest.fn();
+  public getEditorValues = jest.fn(() => ({
     main: 'main-content',
     renderer: 'renderer-content',
     html: 'html-content'

--- a/tests/mocks/file-manager.ts
+++ b/tests/mocks/file-manager.ts
@@ -1,5 +1,4 @@
 export class FileManager {
   public saveToTemp = jest.fn(() => '/mock/temp/dir');
-  public setFiddle = jest.fn();
   public cleanup = jest.fn();
 }

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,20 +1,20 @@
-import { shallow } from 'enzyme';
-import * as React from 'react';
+import { shallow } from "enzyme";
+import * as React from "react";
 
-import { PublishButton } from '../../../src/renderer/components/commands-publish-button';
-import { getOctokit } from '../../../src/utils/octokit';
+import { PublishButton } from "../../../src/renderer/components/commands-publish-button";
+import { getOctokit } from "../../../src/utils/octokit";
 
-jest.mock('../../../src/utils/octokit');
+jest.mock("../../../src/utils/octokit");
 
-describe('Publish button component', () => {
+describe("Publish button component", () => {
   let store: any;
 
   const expectedGistCreateOpts = {
-    description: 'Electron Fiddle Gist',
+    description: "Electron Fiddle Gist",
     files: {
-      'index.html': { content: 'html-content' },
-      'renderer.js': { content: 'renderer-content' },
-      'main.js': { content: 'main-content' },
+      "index.html": { content: "html-content" },
+      "renderer.js": { content: "renderer-content" },
+      "main.js": { content: "main-content" }
     },
     public: true
   };
@@ -25,12 +25,12 @@ describe('Publish button component', () => {
     };
   });
 
-  it('renders', () => {
+  it("renders", () => {
     const wrapper = shallow(<PublishButton appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('toggles the auth dialog on click if not authed', async () => {
+  it("toggles the auth dialog on click if not authed", async () => {
     store.toggleAuthDialog = jest.fn();
 
     const wrapper = shallow(<PublishButton appState={store} />);
@@ -40,8 +40,8 @@ describe('Publish button component', () => {
     expect(store.toggleAuthDialog).toHaveBeenCalled();
   });
 
-  it('toggles the publish method on click if authed', async () => {
-    store.gitHubToken = 'github-token';
+  it("toggles the publish method on click if authed", async () => {
+    store.gitHubToken = "github-token";
 
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
@@ -51,11 +51,11 @@ describe('Publish button component', () => {
     expect(instance.publishFiddle).toHaveBeenCalled();
   });
 
-  it('attempts to publish to Gist', async () => {
+  it("attempts to publish to Gist", async () => {
     const mockOctokit = {
       authenticate: jest.fn(),
       gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } }))
+        create: jest.fn(async () => ({ data: { id: "123" } }))
       }
     };
 
@@ -67,21 +67,21 @@ describe('Publish button component', () => {
     await instance.publishFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
-      description: 'Electron Fiddle Gist',
+      description: "Electron Fiddle Gist",
       files: {
-        'index.html': { content: 'html-content' },
-        'renderer.js': { content: 'renderer-content' },
-        'main.js': { content: 'main-content' },
+        "index.html": { content: "html-content" },
+        "renderer.js": { content: "renderer-content" },
+        "main.js": { content: "main-content" }
       },
       public: true
     });
   });
 
-  it('handles missing content', async () => {
+  it("handles missing content", async () => {
     const mockOctokit = {
       authenticate: jest.fn(),
       gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } }))
+        create: jest.fn(async () => ({ data: { id: "123" } }))
       }
     };
 
@@ -90,27 +90,27 @@ describe('Publish button component', () => {
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
 
-    (window as any).ElectronFiddle.app.getValues.mockReturnValueOnce({});
+    (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
 
     await instance.publishFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
-      description: 'Electron Fiddle Gist',
+      description: "Electron Fiddle Gist",
       files: {
-        'index.html': { content: '<!-- Empty -->' },
-        'renderer.js': { content: '// Empty' },
-        'main.js': { content: '// Empty' },
+        "index.html": { content: "<!-- Empty -->" },
+        "renderer.js": { content: "// Empty" },
+        "main.js": { content: "// Empty" }
       },
       public: true
     });
   });
 
-  it('handles an error in Gist publishing', async () => {
+  it("handles an error in Gist publishing", async () => {
     const mockOctokit = {
       authenticate: jest.fn(),
       gists: {
         create: jest.fn(() => {
-          throw new Error('bwap bwap');
+          throw new Error("bwap bwap");
         })
       }
     };
@@ -125,12 +125,12 @@ describe('Publish button component', () => {
     expect(store.isPublishing).toBe(false);
   });
 
-  it('uses the privacy setting correctly', async () => {
+  it("uses the privacy setting correctly", async () => {
     const mockOctokit = {
       authenticate: jest.fn(),
       gists: {
         create: jest.fn(() => {
-          throw new Error('bwap bwap');
+          throw new Error("bwap bwap");
         })
       }
     };
@@ -145,7 +145,7 @@ describe('Publish button component', () => {
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       ...expectedGistCreateOpts,
-      public: false,
+      public: false
     });
 
     instance.setPublic();
@@ -153,24 +153,24 @@ describe('Publish button component', () => {
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       ...expectedGistCreateOpts,
-      public: true,
+      public: true
     });
   });
 
-  it('disables during gist publishing', async () => {
+  it("disables during gist publishing", async () => {
     store.isPublishing = false;
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
 
-    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+    expect(wrapper.find("fieldset").prop("disabled")).toBe(false);
 
     instance.publishFiddle = jest.fn().mockImplementationOnce(() => {
-      return new Promise((resolve) => {
-        wrapper.setProps({appState: {store, isPublishing: true}}, () => {
-          expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+      return new Promise(resolve => {
+        wrapper.setProps({ appState: { store, isPublishing: true } }, () => {
+          expect(wrapper.find("fieldset").prop("disabled")).toBe(true);
         });
-        wrapper.setProps({appState: {store, isPublishing: false}}, () => {
-          expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+        wrapper.setProps({ appState: { store, isPublishing: false } }, () => {
+          expect(wrapper.find("fieldset").prop("disabled")).toBe(false);
         });
         resolve();
       });
@@ -179,8 +179,8 @@ describe('Publish button component', () => {
     await instance.publishFiddle();
   });
 
-  describe('privacy menu', () => {
-    it('toggles the privacy setting', () => {
+  describe("privacy menu", () => {
+    it("toggles the privacy setting", () => {
       const wrapper = shallow(<PublishButton appState={store} />);
       const instance: PublishButton = wrapper.instance() as any;
 

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -1,32 +1,34 @@
-import { mount, shallow } from 'enzyme';
-import { observable } from 'mobx';
-import * as React from 'react';
+import { mount, shallow } from "enzyme";
+import { observable } from "mobx";
+import * as React from "react";
 
-import { ALL_MOSAICS, DocsDemoPage, EditorId } from '../../../src/interfaces';
-import { IpcEvents } from '../../../src/ipc-events';
-import { Editors, TITLE_MAP } from '../../../src/renderer/components/editors';
-import { ipcRendererManager } from '../../../src/renderer/ipc';
-import { updateEditorLayout } from '../../../src/utils/editor-layout';
-import { createMosaicArrangement } from '../../../src/utils/editors-mosaic-arrangement';
-import { getFocusedEditor } from '../../../src/utils/focused-editor';
+import { ALL_MOSAICS, DocsDemoPage, EditorId } from "../../../src/interfaces";
+import { IpcEvents } from "../../../src/ipc-events";
+import { Editors, TITLE_MAP } from "../../../src/renderer/components/editors";
+import { ipcRendererManager } from "../../../src/renderer/ipc";
+import { updateEditorLayout } from "../../../src/utils/editor-layout";
+import { createMosaicArrangement } from "../../../src/utils/editors-mosaic-arrangement";
+import { getFocusedEditor } from "../../../src/utils/focused-editor";
 
-jest.mock('monaco-loader', () => jest.fn(async () => {
-  return { monaco: true };
+jest.mock("monaco-loader", () =>
+  jest.fn(async () => {
+    return { monaco: true };
+  })
+);
+
+jest.mock("../../../src/renderer/components/editor", () => ({
+  Editor: () => "Editor"
 }));
 
-jest.mock('../../../src/renderer/components/editor', () => ({
-  Editor: () => 'Editor'
-}));
-
-jest.mock('../../../src/utils/focused-editor', () => ({
+jest.mock("../../../src/utils/focused-editor", () => ({
   getFocusedEditor: jest.fn()
 }));
 
-jest.mock('../../../src/utils/editor-layout', () => ({
+jest.mock("../../../src/utils/editor-layout", () => ({
   updateEditorLayout: jest.fn()
 }));
 
-describe('Editors component', () => {
+describe("Editors component", () => {
   let store: any;
   let monaco: any;
 
@@ -46,13 +48,13 @@ describe('Editors component', () => {
     };
   });
 
-  it('renders', () => {
+  it("renders", () => {
     const wrapper = mount(<Editors appState={store} />);
     wrapper.setState({ monaco });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('does not execute command if not supported', () => {
+  it("does not execute command if not supported", () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;
     const mockAction = {
@@ -65,60 +67,62 @@ describe('Editors component', () => {
 
     (getFocusedEditor as any).mockReturnValueOnce(mockEditor);
 
-    instance.executeCommand('hello');
+    instance.executeCommand("hello");
     expect(mockEditor.getAction).toHaveBeenCalled();
     expect(mockAction.isSupported).toHaveBeenCalled();
     expect(mockAction.run).toHaveBeenCalledTimes(0);
   });
 
-  describe('toggleEditorOption()', () => {
-    it('handles a missing ElectronFiddle global', () => {
+  describe("toggleEditorOption()", () => {
+    it("handles a missing ElectronFiddle global", () => {
       const oldEditors = window.ElectronFiddle.editors;
       window.ElectronFiddle.editors = undefined as any;
 
       const wrapper = shallow(<Editors appState={store} />);
       const instance: Editors = wrapper.instance() as any;
 
-      expect(instance.toggleEditorOption('wordWrap')).toBe(false);
+      expect(instance.toggleEditorOption("wordWrap")).toBe(false);
       window.ElectronFiddle.editors = oldEditors;
     });
 
-    it('handles an error', () => {
-      (window.ElectronFiddle.editors.html!.updateOptions as jest.Mock).mockImplementationOnce(
-        () => {
-          throw new Error('Bwap bwap');
-        }
-      );
+    it("handles an error", () => {
+      (window.ElectronFiddle.editors.html!
+        .updateOptions as jest.Mock).mockImplementationOnce(() => {
+        throw new Error("Bwap bwap");
+      });
 
       const wrapper = shallow(<Editors appState={store} />);
       const instance: Editors = wrapper.instance() as any;
 
-      expect(instance.toggleEditorOption('wordWrap')).toBe(false);
+      expect(instance.toggleEditorOption("wordWrap")).toBe(false);
     });
 
-    it('updates a setting', () => {
+    it("updates a setting", () => {
       const wrapper = shallow(<Editors appState={store} />);
       const instance: Editors = wrapper.instance() as any;
 
-      expect(instance.toggleEditorOption('wordWrap')).toBe(true);
-      expect(window.ElectronFiddle.editors.html!.updateOptions).toHaveBeenCalledWith(
-        {
-          minimap: { enabled: false },
-          wordWrap: 'off'
-        }
-      );
+      expect(instance.toggleEditorOption("wordWrap")).toBe(true);
+      expect(
+        window.ElectronFiddle.editors.html!.updateOptions
+      ).toHaveBeenCalledWith({
+        minimap: { enabled: false },
+        wordWrap: "off"
+      });
     });
   });
 
-  it('renders a toolbar', () => {
+  it("renders a toolbar", () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;
-    const toolbar = instance.renderToolbar({ title: TITLE_MAP[EditorId.main] } as any, EditorId.main);
+    const toolbar = instance.renderToolbar(
+      { title: TITLE_MAP[EditorId.main] } as any,
+      EditorId.main
+    );
 
     expect(toolbar).toMatchSnapshot();
   });
 
-  it('componentWillUnmount() unsubscribes the layout reaction', () => {
+  it("componentWillUnmount() unsubscribes the layout reaction", () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;
     (instance as any).disposeLayoutAutorun = jest.fn();
@@ -128,7 +132,7 @@ describe('Editors component', () => {
     expect(instance.disposeLayoutAutorun).toHaveBeenCalledTimes(1);
   });
 
-  it('onChange() updates the mosaic arrangement in the appState', () => {
+  it("onChange() updates the mosaic arrangement in the appState", () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;
 
@@ -137,8 +141,8 @@ describe('Editors component', () => {
     expect(store.mosaicArrangement).toEqual({ testArrangement: true });
   });
 
-  describe('IPC commands', () => {
-    it('handles an MONACO_EXECUTE_COMMAND command', () => {
+  describe("IPC commands", () => {
+    it("handles an MONACO_EXECUTE_COMMAND command", () => {
       shallow(<Editors appState={store} />);
 
       const mockAction = {
@@ -151,48 +155,54 @@ describe('Editors component', () => {
 
       (getFocusedEditor as any).mockReturnValueOnce(mockEditor);
 
-      ipcRendererManager.emit(IpcEvents.MONACO_EXECUTE_COMMAND, null, 'hello');
+      ipcRendererManager.emit(IpcEvents.MONACO_EXECUTE_COMMAND, null, "hello");
       expect(mockEditor.getAction).toHaveBeenCalled();
       expect(mockAction.isSupported).toHaveBeenCalled();
       expect(mockAction.run).toHaveBeenCalled();
     });
 
-    it('handles an FS_NEW_FIDDLE command', (done) => {
+    it("handles an FS_NEW_FIDDLE command", done => {
       shallow(<Editors appState={store} />);
 
       ipcRendererManager.emit(IpcEvents.FS_NEW_FIDDLE, null);
       process.nextTick(() => {
-        expect(window.ElectronFiddle.app.fileManager.setFiddle).toHaveBeenCalled();
+        expect(window.ElectronFiddle.app.replaceFiddle).toHaveBeenCalled();
         done();
       });
     });
 
-    it('handles the monaco editor option commands', () => {
+    it("handles the monaco editor option commands", () => {
       shallow(<Editors appState={store} />);
 
-      ipcRendererManager.emit(IpcEvents.MONACO_TOGGLE_OPTION, null, 'wordWrap');
+      ipcRendererManager.emit(IpcEvents.MONACO_TOGGLE_OPTION, null, "wordWrap");
 
-      expect(window.ElectronFiddle.editors.html!.updateOptions).toHaveBeenCalled();
-      expect(window.ElectronFiddle.editors.renderer!.updateOptions).toHaveBeenCalled();
-      expect(window.ElectronFiddle.editors.main!.updateOptions).toHaveBeenCalled();
+      expect(
+        window.ElectronFiddle.editors.html!.updateOptions
+      ).toHaveBeenCalled();
+      expect(
+        window.ElectronFiddle.editors.renderer!.updateOptions
+      ).toHaveBeenCalled();
+      expect(
+        window.ElectronFiddle.editors.main!.updateOptions
+      ).toHaveBeenCalled();
     });
   });
 
-  describe('loadMonaco()', () => {
-    it('loads Monaco', (done) => {
+  describe("loadMonaco()", () => {
+    it("loads Monaco", done => {
       window.ElectronFiddle.app.monaco = null;
 
       shallow(<Editors appState={store} />);
 
       process.nextTick(() => {
-        expect(window.ElectronFiddle.app.monaco).toEqual({ monaco: true});
+        expect(window.ElectronFiddle.app.monaco).toEqual({ monaco: true });
         done();
       });
     });
   });
 
-  describe('disposeLayoutAutorun()', () => {
-    it('automatically updates the layout when the mosaic arrangement changes', () => {
+  describe("disposeLayoutAutorun()", () => {
+    it("automatically updates the layout when the mosaic arrangement changes", () => {
       class MockStore {
         @observable public mosaicArrangement: any = {};
       }

--- a/tests/renderer/content-spec.ts
+++ b/tests/renderer/content-spec.ts
@@ -30,7 +30,9 @@ describe('content', () => {
 
     describe(EditorId.main, () => {
       it('returns false if it changed', async () => {
-        (window.ElectronFiddle.app.getValues as jest.Mock<any>).mockReturnValueOnce({
+        (window.ElectronFiddle.app.getEditorValues as jest.Mock<
+          any
+        >).mockReturnValueOnce({
           main: 'hi'
         });
 
@@ -39,7 +41,9 @@ describe('content', () => {
       });
 
       it('returns true if it did not change', async () => {
-        (window.ElectronFiddle.app.getValues as jest.Mock<any>).mockReturnValueOnce({
+        (window.ElectronFiddle.app.getEditorValues as jest.Mock<
+          any
+        >).mockReturnValueOnce({
           main: require('../../src/content/main').main
         });
 
@@ -48,7 +52,9 @@ describe('content', () => {
       });
 
       it('returns true if it did not change (1.0 version)', async () => {
-        (window.ElectronFiddle.app.getValues as jest.Mock<any>).mockReturnValueOnce({
+        (window.ElectronFiddle.app.getEditorValues as jest.Mock<
+          any
+        >).mockReturnValueOnce({
           main: require('../../src/content/main-1-x-x').main
         });
 
@@ -59,7 +65,9 @@ describe('content', () => {
 
     describe(EditorId.renderer, () => {
       it('returns false if it changed', async () => {
-        (window.ElectronFiddle.app.getValues as jest.Mock<any>).mockReturnValueOnce({
+        (window.ElectronFiddle.app.getEditorValues as jest.Mock<
+          any
+        >).mockReturnValueOnce({
           renderer: 'hi'
         });
 
@@ -68,7 +76,9 @@ describe('content', () => {
       });
 
       it('returns true if it did not change', async () => {
-        (window.ElectronFiddle.app.getValues as jest.Mock<any>).mockReturnValueOnce({
+        (window.ElectronFiddle.app.getEditorValues as jest.Mock<
+          any
+        >).mockReturnValueOnce({
           renderer: require('../../src/content/renderer').renderer
         });
 

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -91,13 +91,13 @@ describe('RemoteLoader', () => {
       store.gistId = 'abcdtestid';
 
       const result = await instance.fetchGistAndLoad('abcdtestid');
+
       expect(result).toBe(true);
-      expect(window.ElectronFiddle.app.setValues).toBeCalledWith({
+      expect(window.ElectronFiddle.app.replaceFiddle).toBeCalledWith({
         html: mockGistFiles[INDEX_HTML_NAME].content,
         main: mockGistFiles[MAIN_JS_NAME].content,
         renderer: mockGistFiles[RENDERER_JS_NAME].content,
-      });
-      expect(document.title).toBe(`Electron Fiddle - gist.github.com/${store.gistId}`);
+      }, {gistId: 'abcdtestid'});
     });
 
     it('handles an error', async () => {
@@ -130,15 +130,14 @@ describe('RemoteLoader', () => {
 
       await instance.fetchExampleAndLoad('4.0.0', 'test/path');
 
-      expect(document.title).toBe('Electron Fiddle - Unsaved');
-      const { calls } = (window.ElectronFiddle.app.setValues as any).mock;
+      const { calls } = (window.ElectronFiddle.app.replaceFiddle as jest.Mock).mock;
 
       expect(calls).toHaveLength(1);
-      expect(calls[0]).toEqual([{
+      expect(calls[0]).toMatchObject(expect.arrayContaining([{
         html: 'index',
         main: 'main',
         renderer: 'renderer'
-      }]);
+      }]));
     });
 
     it('handles an error', async () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -296,7 +296,7 @@ describe('AppState', () => {
       await appState.setVersion('v1.0.0');
 
       expect(getContent).toHaveBeenCalledTimes(1);
-      expect(window.ElectronFiddle.app.setValues).toHaveBeenCalledTimes(1);
+    expect(window.ElectronFiddle.app.setEditorValues).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Fixes #251 by refactoring the prompt logic.

### Context
Previously, ancillary state variables for a Fiddle (`gistId`, `filePath`, `templateName`) were being reset even if a user cancelled the loading via a prompt.

### Solution

_Note: The LoC setting these variables simply could have been moved such that they were blocked by a prompt cancellation. However, I noticed that I had to do this many times in the code, so it seemed like a code smell._

* Renamed functions to make purpose clearer:
  * `app.setValues() -> app.setEditorValues()`
  * `app.getValues() -> app.getEditorValues()`

* Added a new `replaceFiddle()` function:
  * **Purpose:** to have a DRY abstraction for replacing the existing Fiddle with a new one.
  * **Motivation:** Previously, local Fiddles, show-mes, Gists, and Fiddle Protocols each had their own loading implementation. This involved code duplication for calling `setEditorValues()`, showing the Unsaved prompt, and setting supporting state variables.
  * The new implementation gets rid of the `warn` boolean parameter, as we always warn when loading an external Fiddle. `setEditorValues()` is called directly if warning is unnecessary (e.g. when switching versions).
  * **The bug is addressed in here because `replaceFiddle` avoids setting the new Fiddle's supporting state variables if the Unsaved prompt is cancelled.**

Example of new API:
```javascript
// local file
await replaceFiddle(editorValues, { localPath: '/some/path' });
```
