### PR TITLE
feat: Enable support for a `preload.js`

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,7 @@ export interface EditorValues {
   main: string;
   renderer: string;
   html: string;
+  preload: string;
   package?: string;
 }
 
@@ -63,7 +64,8 @@ export interface Templates {
 export const enum EditorId {
   'main' = 'main',
   'renderer' = 'renderer',
-  'html' = 'html'
+  'html' = 'html',
+  'preload' = 'preload'
 }
 
 // Panels that can show up as a mosaic
@@ -73,7 +75,7 @@ export const enum PanelId {
 
 export type MosaicId = EditorId | PanelId;
 
-export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.html ];
+export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.preload, EditorId.html ];
 export const ALL_PANELS = [ PanelId.docsDemo ];
 export const ALL_MOSAICS = [ ...ALL_EDITORS, ...ALL_PANELS ];
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -124,6 +124,7 @@ export class App {
     const values: EditorValues = {
       html: getEditorValue(EditorId.html),
       main: getEditorValue(EditorId.main),
+      preload: getEditorValue(EditorId.preload),
       renderer: getEditorValue(EditorId.renderer)
     };
 

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -30,8 +30,9 @@ const defaultMonacoOptions: MonacoType.editor.IEditorOptions = {
 export const TITLE_MAP: Record<MosaicId, string> = {
   main: 'Main Process (main.js)',
   renderer: 'Renderer Process (renderer.js)',
+  preload: 'Preload (preload.js)',
   html: 'HTML (index.html)',
-  docsDemo: 'Docs & Demos'
+  docsDemo: 'Docs & Demos',
 };
 
 export interface EditorsProps {

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { EditorValues, Files, FileTransform } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, PACKAGE_NAME, RENDERER_JS_NAME } from '../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PACKAGE_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
 import { fancyImport } from '../utils/import';
 import { ipcRendererManager } from './ipc';
@@ -62,6 +62,7 @@ export class FileManager {
       html: await this.readFile(path.join(filePath, INDEX_HTML_NAME)),
       main: await this.readFile(path.join(filePath, MAIN_JS_NAME)),
       renderer: await this.readFile(path.join(filePath, RENDERER_JS_NAME)),
+      preload: await this.readFile(path.join(filePath, PRELOAD_JS_NAME)),
     };
 
 
@@ -87,7 +88,9 @@ export class FileManager {
       const files = await this.getFiles(undefined, ...transforms);
 
       for (const [fileName, content] of files) {
-        await this.saveFile(path.join(pathToSave, fileName), content);
+        if (content) {
+          await this.saveFile(path.join(pathToSave, fileName), content);
+        }
       }
 
       if (pathToSave !== localPath) {
@@ -116,6 +119,7 @@ export class FileManager {
     output.set(RENDERER_JS_NAME, values.renderer);
     output.set(MAIN_JS_NAME, values.main);
     output.set(INDEX_HTML_NAME, values.html);
+    output.set(PRELOAD_JS_NAME, values.preload);
     output.set(PACKAGE_NAME, values.package!);
 
     for (const transform of transforms) {

--- a/src/renderer/templates.ts
+++ b/src/renderer/templates.ts
@@ -2,12 +2,11 @@ import * as fsExtraType from 'fs-extra';
 import * as pathType from 'path';
 
 import { EditorValues } from '../interfaces';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
 import { fancyImport } from '../utils/import';
 
 /**
- * Returns expected content for a given name. Currently synchronous,
- * but probably shouldn't be.
+ * Returns expected content for a given name.
  *
  * @param {string} name
  * @returns {Promise<EditorValues>}
@@ -41,6 +40,7 @@ export async function getTemplateValues(name: string): Promise<EditorValues> {
   return {
     renderer: await getFile(RENDERER_JS_NAME),
     main: await getFile(MAIN_JS_NAME),
-    html: await getFile(INDEX_HTML_NAME)
+    html: await getFile(INDEX_HTML_NAME),
+    preload: await getFile(PRELOAD_JS_NAME)
   };
 }

--- a/src/shared-constants.ts
+++ b/src/shared-constants.ts
@@ -1,4 +1,5 @@
 export const INDEX_HTML_NAME = 'index.html';
 export const MAIN_JS_NAME = 'main.js';
 export const RENDERER_JS_NAME = 'renderer.js';
+export const PRELOAD_JS_NAME = 'preload.js';
 export const PACKAGE_NAME = 'package.json';

--- a/src/utils/editor-layout.ts
+++ b/src/utils/editor-layout.ts
@@ -3,11 +3,11 @@
  * a debounced version below.
  */
 function _updateEditorLayout() {
-  const { main, renderer, html } = window.ElectronFiddle.editors;
-
-  if (main) main.layout();
-  if (renderer) renderer.layout();
-  if (html) html.layout();
+  Object.keys(window.ElectronFiddle.editors).forEach((key) => {
+    if (window.ElectronFiddle.editors[key]) {
+      window.ElectronFiddle.editors[key].layout();
+    }
+  });
 }
 
 let handle: number;

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -118,7 +118,8 @@ describe('Editors component', () => {
       const editorValues = {
         html: 'html-value',
         main: 'main-value',
-        renderer: 'renderer-value'
+        renderer: 'renderer-value',
+        preload: ''
       };
 
       app.replaceFiddle(editorValues, {
@@ -286,7 +287,7 @@ describe('Editors component', () => {
       app.setEditorValues({
         html: 'html-value',
         main: 'main-value',
-        renderer: 'renderer-value'
+        renderer: 'renderer-value',
       });
 
       expect(

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -29,6 +29,16 @@ exports[`EditorDropdown component renders 1`] = `
         />
         <Blueprint3.MenuItem
           disabled={false}
+          icon="eye-off"
+          id="preload"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Preload (preload.js)"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
           icon="eye-open"
           id="html"
           multiline={false}
@@ -97,6 +107,16 @@ exports[`EditorDropdown component renders the extra button if the FIDDLE_DOCS_DE
           popoverProps={Object {}}
           shouldDismissPopover={true}
           text="Renderer Process (renderer.js)"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-off"
+          id="preload"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Preload (preload.js)"
         />
         <Blueprint3.MenuItem
           disabled={false}

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -355,13 +355,186 @@ exports[`Editors component renders 1`] = `
     </div>
     <div
       className="mosaic-tile"
-      key="html"
+      key="preload"
       style={
         Object {
           "bottom": "50%",
           "left": "50%",
           "right": "0%",
           "top": "0%",
+        }
+      }
+    >
+      <div
+        className="mosaic-window mosaic-drop-target preload"
+      >
+        <div
+          className="mosaic-window-toolbar draggable"
+        >
+          <div>
+            <div>
+              <h5>
+                Preload (preload.js)
+              </h5>
+            </div>
+            <div />
+            <div
+              className="mosaic-controls"
+            >
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-maximize"
+                  icon="maximize"
+                >
+                  <svg
+                    data-icon="maximize"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      maximize
+                    </desc>
+                    <path
+                      d="M5.99 8.99c-.28 0-.53.11-.71.29l-3.29 3.29v-1.59c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1H3.41L6.7 10.7a1.003 1.003 0 00-.71-1.71zm9-9h-4c-.55 0-1 .45-1 1s.45 1 1 1h1.59l-3.3 3.3a.99.99 0 00-.29.7 1.003 1.003 0 001.71.71l3.29-3.29V5c0 .55.45 1 1 1s1-.45 1-1V1c0-.56-.45-1.01-1-1.01z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-cross"
+                  icon="cross"
+                >
+                  <svg
+                    data-icon="cross"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      cross
+                    </desc>
+                    <path
+                      d="M9.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42L6.59 8 3.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="mosaic-window-body"
+        >
+          Editor
+        </div>
+        <div
+          className="mosaic-window-body-overlay"
+          onClick={[Function]}
+        />
+        <div
+          className="mosaic-window-additional-actions-bar"
+        />
+        <div
+          className="mosaic-preview"
+        >
+          <div
+            className="mosaic-window-toolbar"
+          >
+            <div
+              className="mosaic-window-title"
+            >
+              Preload (preload.js)
+            </div>
+          </div>
+          <div
+            className="mosaic-window-body"
+          >
+            <h4>
+              Preload (preload.js)
+            </h4>
+            <span
+              className="bp3-icon bp3-icon-application"
+              icon="application"
+            >
+              <svg
+                data-icon="application"
+                height={72}
+                viewBox="0 0 20 20"
+                width={72}
+              >
+                <desc>
+                  application
+                </desc>
+                <path
+                  d="M3.5 9h9c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-9c-.28 0-.5.22-.5.5s.22.5.5.5zm0 2h5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-5c-.28 0-.5.22-.5.5s.22.5.5.5zM19 1H1c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm-1 16H2V6h16v11zM3.5 13h7c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-7c-.28 0-.5.22-.5.5s.22.5.5.5z"
+                  fillRule="evenodd"
+                  key="0"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          className="drop-target-container"
+        >
+          <div
+            className="drop-target top"
+          />
+          <div
+            className="drop-target bottom"
+          />
+          <div
+            className="drop-target left"
+          />
+          <div
+            className="drop-target right"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="mosaic-split -column"
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "bottom": "0%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
+        }
+      }
+    >
+      <div
+        className="mosaic-split-line"
+      />
+    </div>
+    <div
+      className="mosaic-tile"
+      key="html"
+      style={
+        Object {
+          "bottom": "25%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
         }
       }
     >
@@ -518,7 +691,7 @@ exports[`Editors component renders 1`] = `
           "bottom": "0%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "75%",
         }
       }
     >
@@ -534,7 +707,7 @@ exports[`Editors component renders 1`] = `
           "bottom": "0%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "75%",
         }
       }
     >
@@ -869,8 +1042,12 @@ exports[`Editors component renders a toolbar 1`] = `
             },
             "second": Object {
               "direction": "column",
-              "first": "html",
-              "second": "docsDemo",
+              "first": "preload",
+              "second": Object {
+                "direction": "column",
+                "first": "html",
+                "second": "docsDemo",
+              },
             },
           },
           "setWarningDialogTexts": [Function],
@@ -893,8 +1070,12 @@ exports[`Editors component renders a toolbar 1`] = `
             },
             "second": Object {
               "direction": "column",
-              "first": "html",
-              "second": "docsDemo",
+              "first": "preload",
+              "second": Object {
+                "direction": "column",
+                "first": "html",
+                "second": "docsDemo",
+              },
             },
           },
           "setWarningDialogTexts": [Function],

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -90,7 +90,15 @@ describe('FileManager', () => {
       expect(fs.outputFile).toHaveBeenCalledTimes(3);
     });
 
-    it('handles an error', async () => {
+    it('removes a file that is newly empty', async () => {
+      const fs = require('fs-extra');
+
+      await fm.saveFiddle('/fake/path');
+
+      expect(fs.remove).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles an error (output)', async () => {
       const fs = require('fs-extra');
       (fs.outputFile as jest.Mock).mockImplementation(() => {
         throw new Error('bwap');
@@ -100,6 +108,18 @@ describe('FileManager', () => {
 
       expect(fs.outputFile).toHaveBeenCalledTimes(3);
       expect(ipcRendererManager.send).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles an error (remove)', async () => {
+      const fs = require('fs-extra');
+      (fs.remove as jest.Mock).mockImplementation(() => {
+        throw new Error('bwap');
+      });
+
+      await fm.saveFiddle('/fake/path');
+
+      expect(fs.remove).toHaveBeenCalledTimes(2);
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(2);
     });
 
     it('runs saveFiddle (normal) on IPC event', () => {

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -59,6 +59,7 @@ describe('FileManager', () => {
       expect(window.ElectronFiddle.app.replaceFiddle).toHaveBeenCalledWith({
         html: '',
         renderer: '',
+        preload: '',
         main: '',
       }, {filePath: fakePath});
     });
@@ -86,7 +87,7 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(4);
+      expect(fs.outputFile).toHaveBeenCalledTimes(3);
     });
 
     it('handles an error', async () => {
@@ -97,8 +98,8 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(4);
-      expect(ipcRendererManager.send).toHaveBeenCalledTimes(4);
+      expect(fs.outputFile).toHaveBeenCalledTimes(3);
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(3);
     });
 
     it('runs saveFiddle (normal) on IPC event', () => {
@@ -129,7 +130,7 @@ describe('FileManager', () => {
 
       await fm.saveToTemp({ includeDependencies: false, includeElectron: false });
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(4);
+      expect(fs.outputFile).toHaveBeenCalledTimes(5);
       expect(tmp.setGracefulCleanup).toHaveBeenCalled();
     });
 

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -85,7 +85,8 @@ describe('npm', () => {
       const result = await findModulesInEditors({
         html: '',
         main: mockMain,
-        renderer: ''
+        renderer: '',
+        preload: ''
       });
 
       expect(result).toEqual(['say']);

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -2,7 +2,7 @@ import { observable } from 'mobx';
 import { ipcRendererManager } from '../../src/renderer/ipc';
 import { RemoteLoader } from '../../src/renderer/remote-loader';
 import { ElectronReleaseChannel } from '../../src/renderer/versions';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME } from '../../src/shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME, PRELOAD_JS_NAME } from '../../src/shared-constants';
 import { getOctokit } from '../../src/utils/octokit';
 import { ElectronFiddleMock } from '../mocks/electron-fiddle';
 
@@ -17,6 +17,9 @@ const mockGistFiles = {
     },
     [INDEX_HTML_NAME]: {
       content: 'html'
+    },
+    [PRELOAD_JS_NAME]: {
+      content: 'preload'
     }
 };
 
@@ -97,6 +100,7 @@ describe('RemoteLoader', () => {
         html: mockGistFiles[INDEX_HTML_NAME].content,
         main: mockGistFiles[MAIN_JS_NAME].content,
         renderer: mockGistFiles[RENDERER_JS_NAME].content,
+        preload: mockGistFiles[PRELOAD_JS_NAME].content,
       }, {gistId: 'abcdtestid'});
     });
 
@@ -136,7 +140,8 @@ describe('RemoteLoader', () => {
       expect(calls[0]).toMatchObject(expect.arrayContaining([{
         html: 'index',
         main: 'main',
-        renderer: 'renderer'
+        renderer: 'renderer',
+        preload: ''
       }]));
     });
 

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -261,7 +261,8 @@ describe('Runner component', () => {
       await instance.installModulesForEditor({
         html: '',
         main: `const a = require('say')`,
-        renderer: ''
+        renderer: '',
+        preload: ''
       }, '/fake/path');
 
       expect(installModules).toHaveBeenCalledTimes(0);
@@ -274,7 +275,8 @@ describe('Runner component', () => {
       await instance.installModulesForEditor({
         html: '',
         main: `const a = require('say')`,
-        renderer: ''
+        renderer: '',
+        preload: ''
       }, '/fake/path');
 
       expect(installModules).toHaveBeenCalledTimes(1);

--- a/tests/renderer/templates-spec.ts
+++ b/tests/renderer/templates-spec.ts
@@ -44,8 +44,8 @@ describe('templates', () => {
       fs.existsSync.mockReturnValue(true);
 
       await getTemplateValues('test');
-      expect(fs.existsSync).toHaveBeenCalledTimes(3);
-      expect(fs.readdirSync).toHaveBeenCalledTimes(3);
+      expect(fs.existsSync).toHaveBeenCalledTimes(4);
+      expect(fs.readdirSync).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/tests/utils/editors-mosaic-arrangement-spec.ts
+++ b/tests/utils/editors-mosaic-arrangement-spec.ts
@@ -1,4 +1,4 @@
-import { ALL_EDITORS, EditorId } from '../../src/interfaces';
+import {  EditorId } from '../../src/interfaces';
 import { DEFAULT_MOSAIC_ARRANGEMENT } from '../../src/renderer/constants';
 import { createMosaicArrangement, getVisibleMosaics } from '../../src/utils/editors-mosaic-arrangement';
 

--- a/tests/utils/editors-mosaic-arrangement-spec.ts
+++ b/tests/utils/editors-mosaic-arrangement-spec.ts
@@ -53,7 +53,7 @@ describe('Mosaic Arrangement Utilities', () => {
     it('returns the correct array for three visible panels', () => {
       const result = getVisibleMosaics(DEFAULT_MOSAIC_ARRANGEMENT);
 
-      expect(result).toEqual(ALL_EDITORS);
+      expect(result).toEqual([ 'main', 'renderer', 'html' ]);
     });
   });
 });

--- a/tests/utils/get-package-spec.ts
+++ b/tests/utils/get-package-spec.ts
@@ -15,7 +15,8 @@ describe('get-package', () => {
     } as any, {
       main: 'app.goDoTheThing()',
       renderer: `const say = require('say')`,
-      html: '<html />'
+      html: '<html />',
+      preload: 'preload'
     });
 
     expect(result).toEqual(JSON.stringify({
@@ -43,7 +44,8 @@ describe('get-package', () => {
     } as any, {
       main: 'app.goDoTheThing()',
       renderer: `const say = require('say')`,
-      html: '<html />'
+      html: '<html />',
+      preload: 'preload'
     }, {
       includeElectron: true,
       includeDependencies: true


### PR DESCRIPTION
This PR enables support for a `preload.js` file. The panel isn't open by default, but if you click on the `Editors` button, you can enable it. 

To make things smoother, I've also added one more change:  If a file is empty, we don't write it to disk or upload to gist. Accordingly, if a gist doesn't contain a file, we assume that it's empty.