### PR TITLE
fix: Inserted whitespace in tour

### DIFF
--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -157,7 +157,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
           </p>
           <p>
             By the way: If you want to use an <code>npm</code> module here, just
-            <code>require</code> it. Electron Fiddle will automatically detect that you
+          &nbsp;<code>require</code> it. Electron Fiddle will automatically detect that you
             requested a module and install it as soon as you run your fiddle.
           </p>
         </>

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -115,7 +115,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
             a Node.js application is started. The main script runs in the "main
             process". To display a user interface, the main process creates renderer
             processes – usually in the form of windows, which Electron calls
-             <code>BrowserWindow</code>.
+             &nbsp;<code>BrowserWindow</code>.
           </p>
           <p>
             To get started, pretend that the main process is just like a Node.js
@@ -137,7 +137,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
       content: (
         <p>
           In the default fiddle, this HTML file is loaded in the
-           <code>BrowserWindow</code>. Any HTML, CSS, or JavaScript that works
+          &nbsp;<code>BrowserWindow</code>. Any HTML, CSS, or JavaScript that works
           in a browser will work here, too. In addition, Electron allows you
           to execute Node.js code. Take a close look at the
             <code>&lt;script /&gt;</code> tag and notice how we can call <code>

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -140,7 +140,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
           &nbsp;<code>BrowserWindow</code>. Any HTML, CSS, or JavaScript that works
           in a browser will work here, too. In addition, Electron allows you
           to execute Node.js code. Take a close look at the
-            <code>&lt;script /&gt;</code> tag and notice how we can call <code>
+          &nbsp;<code>&lt;script /&gt;</code> tag and notice how we can call <code>
           require()</code> like we would in Node.js.
         </p>
       )

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -151,7 +151,7 @@ exports[`Header component renders the tour once started 1`] = `
           <code>
             BrowserWindow
           </code>
-          . Any HTML, CSS, or JavaScript that works in a browser will work here, too. In addition, Electron allows you to execute Node.js code. Take a close look at the
+          . Any HTML, CSS, or JavaScript that works in a browser will work here, too. In addition, Electron allows you to execute Node.js code. Take a close look at the  
           <code>
             &lt;script /&gt;
           </code>
@@ -179,7 +179,7 @@ exports[`Header component renders the tour once started 1`] = `
             <code>
               npm
             </code>
-             module here, just
+             module here, just  
             <code>
               require
             </code>

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -120,7 +120,7 @@ exports[`Header component renders the tour once started 1`] = `
       Object {
         "content": <React.Fragment>
           <p>
-            Every Electron app starts with a main script, very similar to how a Node.js application is started. The main script runs in the "main process". To display a user interface, the main process creates renderer processes – usually in the form of windows, which Electron calls
+            Every Electron app starts with a main script, very similar to how a Node.js application is started. The main script runs in the "main process". To display a user interface, the main process creates renderer processes – usually in the form of windows, which Electron calls  
             <code>
               BrowserWindow
             </code>
@@ -147,7 +147,7 @@ exports[`Header component renders the tour once started 1`] = `
       },
       Object {
         "content": <p>
-          In the default fiddle, this HTML file is loaded in the
+          In the default fiddle, this HTML file is loaded in the  
           <code>
             BrowserWindow
           </code>


### PR DESCRIPTION
The fiddle tour had missing spaces in the modal for main window and HTML window. Also, the snapshots are updated to make sure this passes the tests. Fixes #235.