### PR TITLE
fix: don't install commented-out requires

### DIFF
--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -16,7 +16,7 @@ const ignoredModules: Array<string> = [
 ];
 
 /* regular expression to both match and extract module names */
-const requiregx = /require\(['"](.*?)['"]\)/gm;
+const requiregx = /^.*require\(['"](.*?)['"]\)/gm;
 
 
 /*
@@ -91,8 +91,11 @@ export function findModules(input: string): Array<string> {
   /* grab all global require matches in the text */
   // tslint:disable-next-line:no-conditional-assignment
   while (match = (requiregx.exec(input) || null)) {
-    const mod = match[1];
-    modules.push(mod);
+    // ensure commented-out requires aren't downloaded
+    if (!match[0].startsWith('//')) {
+      const mod = match[1];
+      modules.push(mod);
+    }
   }
 
   /* map and reduce */


### PR DESCRIPTION
This PR updates the 'require' regex to match the whole line for a module require:
Before:
`const y = require('yargs')` returns:
* `match[0]` = `require('yargs')`
* `match[1]` = `yargs`

After:
`const y = require('yargs')` returns:
* `match[0]` = `const y = require('yargs')`
* `match[1]` = `yargs`

This allows us to add an extra conditional to the loop to ensure that if a given module is commented out:
```js
// const y = require('yargs')
```

that this logic won't install it anyway.

cc @felixrieseberg 
