### PR TITLE
fix: update dialog example for promisification

### DIFF
--- a/static/show-me/dialog/main.js
+++ b/static/show-me/dialog/main.js
@@ -16,7 +16,7 @@ app.on('ready', () => {
     properties: ['openFile']
   }).then(result => {
     if (result.canceled) {
-      console.log('Dialog was cancelled')
+      console.log('Dialog was canceled')
     } else {
       const file = result.filePaths[0]
       mainWindow.loadURL(`file://${file}`)

--- a/static/show-me/dialog/main.js
+++ b/static/show-me/dialog/main.js
@@ -12,13 +12,16 @@ app.on('ready', () => {
 
   // Show an "Open File" dialog and attempt to open
   // the chosen file in our window.
-  //
-  // If you provide a callback, the method will be asynchronous,
-  // but in thise case, we'll just use the synchronous variant.
-  const file = dialog.showOpenDialog({
-    title: 'Hello!',
+  dialog.showOpenDialog(mainWindow, {
     properties: ['openFile']
+  }).then(result => {
+    if (result.canceled) {
+      console.log('Dialog was cancelled')
+    } else {
+      const file = result.filePaths[0]
+      mainWindow.loadURL(`file://${file}`)
+    }
+  }).catch(err => {
+    console.log(err)
   })
-
-  mainWindow.loadURL(`file://${file}`)
 })


### PR DESCRIPTION
Fixes the dialog example - `showOpenDialog` now returns a Promise in supported versions so we should likely be using that. The previous example would not properly load the chosen file. 

cc @felixrieseberg 