### PR TITLE
refactor: update deprecated app.setName API

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,7 +68,7 @@ export function main() {
   }
 
   // Set the app's name
-  app.setName('Electron Fiddle');
+  app.name = 'Electron Fiddle';
 
   // Ensure that there's only ever one Fiddle running
   listenForProtocolHandler();

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -116,7 +116,6 @@ const app = {
   quit: jest.fn(),
   relaunch: jest.fn(),
   setJumpList: jest.fn(),
-  setName: jest.fn(),
   requestSingleInstanceLock: jest.fn(),
   on: jest.fn(),
   once: jest.fn()


### PR DESCRIPTION
Removes the deprecated `app.setName()` API (https://electronjs.org/docs/api/app#appsetnamename).

Instead overwrites app name by setting `app.name` property.