### PR TITLE
fix: ensure dev tools only open in dev mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7695,7 +7695,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7738,7 +7739,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -7749,7 +7751,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7866,7 +7869,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7878,6 +7882,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7900,12 +7905,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7924,6 +7931,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8017,6 +8025,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8102,7 +8111,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8138,6 +8148,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8157,6 +8168,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8200,12 +8212,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/main/devtools.ts
+++ b/src/main/devtools.ts
@@ -7,7 +7,7 @@ import { isDevMode } from '../utils/devmode';
  * @returns {Promise<void>}
  */
 export async function setupDevTools(): Promise<void> {
-  if (!isDevMode) return;
+  if (!isDevMode()) return;
 
   const {
     default: installExtension,

--- a/tests/main/devtools-spec.ts
+++ b/tests/main/devtools-spec.ts
@@ -1,13 +1,5 @@
 import { setupDevTools } from '../../src/main/devtools';
 
-let mockIsDevMode = false;
-
-jest.mock('../../src/utils/devmode', () => ({
-  get isDevMode() {
-    return mockIsDevMode;
-  }
-}));
-
 jest.mock('electron-devtools-installer', () => ({
   default: jest.fn(),
   REACT_DEVELOPER_TOOLS: 'REACT_DEVELOPER_TOOLS',
@@ -15,18 +7,30 @@ jest.mock('electron-devtools-installer', () => ({
 }));
 
 describe('devtools', () => {
+  const old = (process as any).defaultApp;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'defaultApp', { value: old });
+  });
+
   it('does not set up developer tools if not in dev mode', () => {
     const devtools = require('electron-devtools-installer');
-
+    Object.defineProperty(process, 'defaultApp', {
+      value: undefined,
+      writable: true
+    });
     setupDevTools();
 
     expect(devtools.default).toHaveBeenCalledTimes(0);
   });
 
-  it('sets up developer tools if not in dev mode', () => {
+  it('sets up developer tools if in dev mode', () => {
     const devtools = require('electron-devtools-installer');
 
-    mockIsDevMode = true;
+    Object.defineProperty(process, 'defaultApp', {
+      value: true,
+      writable: true
+    });
     setupDevTools();
 
     expect(devtools.default).toHaveBeenCalledTimes(1);

--- a/tests/main/devtools-spec.ts
+++ b/tests/main/devtools-spec.ts
@@ -7,7 +7,7 @@ jest.mock('electron-devtools-installer', () => ({
 }));
 
 describe('devtools', () => {
-  const old = (process as any).defaultApp;
+  const old = (process as any).defaultApp; // for tsconfig error
 
   afterEach(() => {
     Object.defineProperty(process, 'defaultApp', { value: old });

--- a/tests/main/devtools-spec.ts
+++ b/tests/main/devtools-spec.ts
@@ -35,4 +35,20 @@ describe('devtools', () => {
 
     expect(devtools.default).toHaveBeenCalledTimes(1);
   });
+
+  it('catch error in setting up developer tools', async (done) => {
+    const devtools = require('electron-devtools-installer');
+    // throw devtool erros
+    devtools.default.mockRejectedValue(new Error('devtool error'));
+    Object.defineProperty(process, 'defaultApp', {
+      value: true,
+      writable: true
+    });
+    try {
+      await setupDevTools();
+      done();
+    } catch (e) {
+      expect(e).toMatch('error');
+    }
+  });
 });

--- a/tests/utils/devmode-spec.ts
+++ b/tests/utils/devmode-spec.ts
@@ -1,7 +1,7 @@
 import { isDevMode } from '../../src/utils/devmode';
 
 describe('devMode', () => {
-  const old = process.defaultApp;
+  const old = (process as any).defaultApp; // for tsconfig error
 
   afterEach(() => {
     Object.defineProperty(process, 'defaultApp', { value: old });


### PR DESCRIPTION
Closes #276 

isDevMode is of function type but used as boolean.

Fix devtools-spec.ts for not calling isDevMode