### PR TITLE
fix: Incorrect dropdowns

### DIFF
--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -2,7 +2,6 @@
 
 header {
   box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.4);
-  //border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   background-color: @background-3;
   -webkit-app-region: drag;
 }
@@ -14,12 +13,6 @@ header {
   padding: 10px;
   box-sizing: border-box;
   font-family: @fonts-common;
-  overflow-x: scroll;
-  overflow-y: hidden;
-
-  &::-webkit-scrollbar {
-    height: 5px;
-  }
 
   button,
   input,


### PR DESCRIPTION
This code was introduced in #257 and seems to have broken popovers and dropdowns. I don't believe it's actually required, I ran some bisect operations without it and things worked fine.

### Before

<img width="728" alt="Screen Shot 2019-12-12 at 2 24 53 PM" src="https://user-images.githubusercontent.com/1426799/70742302-3462bd80-1ceb-11ea-87d1-4bcdd5d87e61.png">

### After

<img width="890" alt="Screen Shot 2019-12-12 at 2 24 32 PM" src="https://user-images.githubusercontent.com/1426799/70742313-375dae00-1ceb-11ea-8f70-d1e6cffc64d0.png">
