### PR TITLE
test: avoid transforming JSON files

### DIFF
--- a/jest.json
+++ b/jest.json
@@ -1,6 +1,6 @@
 {
   "transform": {
-    ".(js|jsx|ts|tsx)": "ts-jest"
+    "\\.(js|jsx|ts|tsx)$": "ts-jest"
   },
   "testURL": "http://localhost",
   "testRegex": "(-spec)\\.(ts|tsx)$",


### PR DESCRIPTION
Be more specific for the `ts-jest` transform, to avoid errors [like these](https://travis-ci.org/electron/fiddle/jobs/624313335#L623):

> `ts-jest[jest-transformer]` (WARN) Got a unknown file type to compile (file: `fiddle/static/releases.json`). To fix this, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match this kind of files anymore.