### PR TITLE
feat: allow users to specify cli flags

### DIFF
--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -1,4 +1,4 @@
-import { Callout, Checkbox, FormGroup } from '@blueprintjs/core';
+import { Callout, Checkbox, FormGroup, InputGroup } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -21,6 +21,7 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
 
     this.handleDeleteDataChange = this.handleDeleteDataChange.bind(this);
     this.handleElectronLoggingChange = this.handleElectronLoggingChange.bind(this);
+    this.handleExecutionFlagChange = this.handleExecutionFlagChange.bind(this);
   }
 
   /**
@@ -48,8 +49,25 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
     this.props.appState.isEnablingElectronLogging = checked;
   }
 
+  /**
+   * Handles a change in the execution flags run with the Electron executable
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  public handleExecutionFlagChange(
+    event: React.FormEvent<HTMLInputElement>
+  ) {
+    const { value } = event.currentTarget;
+    const flags = value.split(',');
+    this.props.appState.executionFlags = flags;
+  }
+
   public render() {
-    const { isKeepingUserDataDirs, isEnablingElectronLogging } = this.props.appState;
+    const {
+      isKeepingUserDataDirs,
+      isEnablingElectronLogging,
+      executionFlags
+    } = this.props.appState;
 
     const deleteUserDirLabel = `
       Whenever Electron runs, it creates a user data directory for cookies, the cache,
@@ -84,6 +102,26 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
               checked={isEnablingElectronLogging}
               label='Enable advanced Electron logging.'
               onChange={this.handleElectronLoggingChange}
+            />
+          </FormGroup>
+        </Callout>
+        <br />
+        <Callout>
+          <FormGroup>
+          <p>
+            Electron allows starting the executable with <a
+              href='https://electronjs.org/docs/api/chrome-command-line-switches'
+            >
+              user-provided flags
+            </a>
+            , such as '--js-flags=--expose-gc'. Those can be added here as bar-separated (|)
+            flags to run when you start your Fiddles.
+          </p>
+            <br />
+            <InputGroup
+              placeholder='--js-flags=--expose-gc|--lang=es'
+              value={executionFlags.join('|')}
+              onChange={this.handleExecutionFlagChange}
             />
           </FormGroup>
         </Callout>

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -66,7 +66,7 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
     const {
       isKeepingUserDataDirs,
       isEnablingElectronLogging,
-      executionFlags
+      executionFlags = []
     } = this.props.appState;
 
     const deleteUserDirLabel = `

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -58,7 +58,7 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
     event: React.FormEvent<HTMLInputElement>
   ) {
     const { value } = event.currentTarget;
-    const flags = value.split(',');
+    const flags = value.split('|');
     this.props.appState.executionFlags = flags;
   }
 

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -193,10 +193,10 @@ export class Runner {
       delete env.ELECTRON_ENABLE_STACK_DUMPING;
     }
 
-    this.child = spawn(binaryPath, [ dir, '--inspect' ], {
-      cwd: dir,
-      env,
-    });
+    // Add user-specified cli flags if any have been set.
+    const options = [ dir, '--inspect' ].concat(this.appState.executionFlags);
+
+    this.child = spawn(binaryPath, options, { cwd: dir, env });
     this.appState.isRunning = true;
     pushOutput(`Electron v${version} started.`);
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -81,6 +81,9 @@ export class AppState {
   @observable public isKeepingUserDataDirs: boolean = !!this.retrieve('isKeepingUserDataDirs');
   @observable public isEnablingElectronLogging: boolean = !!this.retrieve('isEnablingElectronLogging');
   @observable public isClearingConsoleOnRun: boolean = !!this.retrieve('isClearingConsoleOnRun');
+  @observable public executionFlags: Array<string> =
+    this.retrieve('executionFlags') as Array<string> === null ?
+    [] : this.retrieve('executionFlags') as Array<string>;
 
   // -- Various session-only state ------------------
   @observable public gistId: string = '';
@@ -155,6 +158,7 @@ export class AppState {
     autorun(() => this.save('gitHubPublishAsPublic', this.gitHubPublishAsPublic));
     autorun(() => this.save('isKeepingUserDataDirs', this.isKeepingUserDataDirs));
     autorun(() => this.save('isEnablingElectronLogging', this.isEnablingElectronLogging));
+    autorun(() => this.save('executionFlags', this.executionFlags));
     autorun(() => this.save('version', this.version));
     autorun(() => this.save('versionsToShow', this.versionsToShow));
     autorun(() => this.save('statesToShow', this.statesToShow));

--- a/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
@@ -34,5 +34,25 @@ exports[`ExecutionSettings component renders 1`] = `
       />
     </Blueprint3.FormGroup>
   </Blueprint3.Callout>
+  <br />
+  <Blueprint3.Callout>
+    <Blueprint3.FormGroup>
+      <p>
+        Electron allows starting the executable with 
+        <a
+          href="https://electronjs.org/docs/api/chrome-command-line-switches"
+        >
+          user-provided flags
+        </a>
+        , such as '--js-flags=--expose-gc'. Those can be added here as bar-separated (|) flags to run when you start your Fiddles.
+      </p>
+      <br />
+      <Blueprint3.InputGroup
+        onChange={[Function]}
+        placeholder="--js-flags=--expose-gc|--lang=es"
+        value=""
+      />
+    </Blueprint3.FormGroup>
+  </Blueprint3.Callout>
 </div>
 `;

--- a/tests/renderer/components/settings-execution-spec.tsx
+++ b/tests/renderer/components/settings-execution-spec.tsx
@@ -56,4 +56,27 @@ describe('ExecutionSettings component', () => {
       expect(store.isEnablingElectronLogging).toBe(true);
     });
   });
+
+  describe('handleElectronLoggingChange()', () => {
+    it('handles a new selection', async () => {
+      const wrapper = shallow(
+        <ExecutionSettings appState={store} />
+      );
+      const instance = wrapper.instance() as any;
+      await instance.handleExecutionFlagChange({
+        currentTarget: { value: '--lang=es' }
+      });
+
+      expect(store.executionFlags).toBe(['--lang=es']);
+
+      await instance.handleExecutionFlagChange({
+        currentTarget: { value: '--lang=es|--js-flags=--expose-gc' }
+      });
+
+      expect(store.executionFlags).toBe([
+        '--lang=es',
+        '--js-flags=--expose-gc'
+      ]);
+    });
+  });
 });

--- a/tests/renderer/components/settings-execution-spec.tsx
+++ b/tests/renderer/components/settings-execution-spec.tsx
@@ -57,8 +57,8 @@ describe('ExecutionSettings component', () => {
     });
   });
 
-  describe('handleElectronLoggingChange()', () => {
-    it('handles a new selection', async () => {
+  describe('handleExecutionFlagChange()', () => {
+    it('handles new flags', async () => {
       const wrapper = shallow(
         <ExecutionSettings appState={store} />
       );
@@ -67,13 +67,13 @@ describe('ExecutionSettings component', () => {
         currentTarget: { value: '--lang=es' }
       });
 
-      expect(store.executionFlags).toBe(['--lang=es']);
+      expect(store.executionFlags).toEqual(['--lang=es']);
 
       await instance.handleExecutionFlagChange({
         currentTarget: { value: '--lang=es|--js-flags=--expose-gc' }
       });
 
-      expect(store.executionFlags).toBe([
+      expect(store.executionFlags).toEqual([
         '--lang=es',
         '--js-flags=--expose-gc'
       ]);


### PR DESCRIPTION
This PR allows users to add custom [cli flags](https://electronjs.org/docs/api/chrome-command-line-switches) supported by Electron to settings, where they will be passed to Fiddle execution. This would enable helpful functionality like garbage collection exposure on the global object, so that users could e.g. call `gc()` within their Fiddles.

New UI:

<img width="892" alt="Screen Shot 2020-01-06 at 10 18 48 AM" src="https://user-images.githubusercontent.com/2036040/71827305-f6e51c00-306d-11ea-8b39-41292de5f816.png">