### PR TITLE
feat: publish preload scripts to GitHub gists

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -79,10 +79,9 @@ export class App {
   }
 
   /**
-   * Sets the values on all three editors.
+   * Sets the contents of all editor panes.
    *
    * @param {EditorValues} values
-   * @param {warn} warn - Should we warn before overwriting unsaved data?
    */
   public async setEditorValues(values: Partial<EditorValues>): Promise<void> {
     const { ElectronFiddle: fiddle } = window;
@@ -108,7 +107,7 @@ export class App {
   }
 
   /**
-   * Gets the values on all three editors.
+   * Retrieves the contents of all editor panes.
    *
    * @returns {EditorValues}
    */

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { when } from 'mobx';
 import { IpcEvents } from '../../ipc-events';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, RENDERER_JS_NAME } from '../../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../../shared-constants';
 import { getOctokit } from '../../utils/octokit';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
@@ -86,6 +86,9 @@ export class PublishButton extends React.Component<PublishButtonProps> {
           },
           [RENDERER_JS_NAME]: {
             content: values.renderer || '// Empty',
+          },
+          [PRELOAD_JS_NAME]: {
+            content: values.preload || '// Empty',
           },
         },
       } as any); // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -29,8 +29,8 @@ export function getWelcomeTour(): Set<TourScriptStep> {
         <>
           <p>
             Electron Fiddle allows you to build little experiments and mini-apps with
-            Electron. Each Fiddle has three files: A main script, a renderer script,
-            and an HTML file.
+            Electron. Each Fiddle has at least three of these files: A main script, a
+            renderer script, a preload script, and an HTML file.
           </p>
           <p>
             If you <code>require()</code> a module, Fiddle will install

--- a/tests/mocks/app.ts
+++ b/tests/mocks/app.ts
@@ -8,6 +8,7 @@ export class AppMock {
   public setEditorValues = jest.fn();
   public getEditorValues = jest.fn(() => ({
     main: 'main-content',
+    preload: 'preload-content',
     renderer: 'renderer-content',
     html: 'html-content'
   }));

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`Header component renders the tour once started 1`] = `
       Object {
         "content": <React.Fragment>
           <p>
-            Electron Fiddle allows you to build little experiments and mini-apps with Electron. Each Fiddle has three files: A main script, a renderer script, and an HTML file.
+            Electron Fiddle allows you to build little experiments and mini-apps with Electron. Each Fiddle has at least three of these files: A main script, a renderer script, a preload script, and an HTML file.
           </p>
           <p>
             If you 

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -14,7 +14,8 @@ describe("Publish button component", () => {
     files: {
       "index.html": { content: "html-content" },
       "renderer.js": { content: "renderer-content" },
-      "main.js": { content: "main-content" }
+      "main.js": { content: "main-content" },
+      "preload.js": { content: "preload-content" },
     },
     public: true
   };
@@ -71,7 +72,8 @@ describe("Publish button component", () => {
       files: {
         "index.html": { content: "html-content" },
         "renderer.js": { content: "renderer-content" },
-        "main.js": { content: "main-content" }
+        "main.js": { content: "main-content" },
+        "preload.js": { content: "preload-content" },
       },
       public: true
     });
@@ -99,7 +101,8 @@ describe("Publish button component", () => {
       files: {
         "index.html": { content: "<!-- Empty -->" },
         "renderer.js": { content: "// Empty" },
-        "main.js": { content: "// Empty" }
+        "main.js": { content: "// Empty" },
+        "preload.js": { content: "// Empty" }
       },
       public: true
     });

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -87,7 +87,7 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(3);
+      expect(fs.outputFile).toHaveBeenCalledTimes(4);
     });
 
     it('removes a file that is newly empty', async () => {
@@ -95,7 +95,7 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.remove).toHaveBeenCalledTimes(2);
+      expect(fs.remove).toHaveBeenCalledTimes(1);
     });
 
     it('handles an error (output)', async () => {
@@ -106,8 +106,8 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(3);
-      expect(ipcRendererManager.send).toHaveBeenCalledTimes(3);
+      expect(fs.outputFile).toHaveBeenCalledTimes(4);
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(4);
     });
 
     it('handles an error (remove)', async () => {
@@ -118,8 +118,8 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.remove).toHaveBeenCalledTimes(2);
-      expect(ipcRendererManager.send).toHaveBeenCalledTimes(2);
+      expect(fs.remove).toHaveBeenCalledTimes(1);
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(1);
     });
 
     it('runs saveFiddle (normal) on IPC event', () => {


### PR DESCRIPTION
Addresses #284.

This does not address loading preload scripts - they load, but only if the preload pane is loaded at least once beforehand.

Also updates some docs/help text that don't take into account the new preload editor pane.