### PR TITLE
fix: Create initial backup for preload editor

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -95,9 +95,16 @@ export class App {
       const backup = this.state.closedPanels[name];
 
       if (typeof values[name] !== 'undefined') {
-        if (isEditorBackup(backup) && backup.model) {
-          // The editor does not exist, attempt to set it on the backup
-          backup.model.setValue(values[name]!);
+        if (isEditorBackup(backup)) {
+          // The editor does not exist, attempt to set it on the backup.
+          // If there's a model, we'll do it on the model. Else, we'll
+          // set the value.
+
+          if (backup.model) {
+            backup.model.setValue(values[name]!);
+          } else {
+            backup.value = values[name]!;
+          }
         } else if (editor && editor.setValue) {
           // The editor exists, set the value directly
           editor.setValue(values[name]!);

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -99,33 +99,52 @@ export class Editor extends React.Component<EditorProps> {
   }
 
   /**
+   * Create a model and attach it to the editor
+   *
+   * @private
+   * @param {string} value
+   */
+  private async createModel(value: string) {
+    const { monaco } = this.props;
+
+    const model = monaco.editor.createModel(value, this.language);
+    model.updateOptions({
+      tabSize: 2
+    });
+
+    this.editor.setModel(model);
+  }
+
+  /**
    * Sets the content on the editor, including the model and the view state.
    *
    * @private
    * @memberof Editor
    */
   private async setContent() {
-    const { appState, id, monaco } = this.props;
+    const { appState, id } = this.props;
     const { version } = appState;
 
     const backup = appState.getAndRemoveEditorValueBackup(id);
 
-    if (backup && backup.model) {
+    console.log(id);
+
+    if (backup) {
       console.log(`Editor: Backup found, restoring state`);
 
       if (backup.viewState) {
         this.editor.restoreViewState(backup.viewState);
       }
 
-      this.editor.setModel(backup.model);
+      // If there's a model, use the model. No model? Use the value
+      if (backup.model) {
+        this.editor.setModel(backup.model);
+      } else if (typeof backup.value !== 'undefined') {
+        this.createModel(backup.value);
+      }
     } else {
       const value = await getContent(id, version);
-      const model = monaco.editor.createModel(value, this.language);
-      model.updateOptions({
-        tabSize: 2
-      });
-
-      this.editor.setModel(model);
+      await this.createModel(value);
     }
   }
 }

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { MosaicNode } from 'react-mosaic-component';
 
 import { EditorId, MosaicId } from '../interfaces';
+import { EditorBackup } from '../utils/editor-backup';
 
 // Reminder: When testing, this file is mocked in tests/setup.js
 
@@ -17,6 +18,11 @@ export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<MosaicId> = {
     first: EditorId.renderer,
     second: EditorId.html,
   }
+};
+
+export const DEFAULT_CLOSED_PANELS: Partial<Record<MosaicId, EditorBackup | true>> = {
+  docsDemo: true,
+  preload: {}
 };
 
 export const ELECTRON_ORG = 'electron';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -25,7 +25,7 @@ import { normalizeVersion } from '../utils/normalize-version';
 import { isEditorBackup, isEditorId, isPanelId } from '../utils/type-checks';
 import { BinaryManager } from './binary';
 import { Bisector } from './bisect';
-import { DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
+import { DEFAULT_CLOSED_PANELS, DEFAULT_MOSAIC_ARRANGEMENT } from './constants';
 import { getContent, isContentUnchanged } from './content';
 import { getLocalTypePathForVersion, updateEditorTypeDefinitions } from './fetch-types';
 import { ipcRendererManager } from './ipc';
@@ -119,9 +119,7 @@ export class AppState {
   @observable public isTourShowing: boolean = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
-  @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = {
-    docsDemo: true // Closed by default
-  };
+  @observable public closedPanels: Partial<Record<MosaicId, EditorBackup | true>> = DEFAULT_CLOSED_PANELS;
 
   private outputBuffer: string = '';
   private name: string;

--- a/src/utils/editor-backup.ts
+++ b/src/utils/editor-backup.ts
@@ -6,9 +6,9 @@ import { getEditorValue } from './editor-value';
 import { getEditorViewState } from './editor-viewstate';
 
 export interface EditorBackup {
-  value: string;
-  model: editor.ITextModel | null;
-  viewState: editor.ICodeEditorViewState | null;
+  value?: string;
+  model?: editor.ITextModel | null;
+  viewState?: editor.ICodeEditorViewState | null;
 }
 
 /**

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -283,16 +283,22 @@ describe('Editors component', () => {
       delete window.ElectronFiddle.editors.main;
 
       const app = new App();
-      (app.state.closedPanels as any).main = { model: { setValue: jest.fn() } };
+      (app.state.closedPanels as any).main = {
+        model: { setValue: jest.fn() }
+      };
+      app.state.closedPanels.preload = {};
+
       app.setEditorValues({
         html: 'html-value',
         main: 'main-value',
         renderer: 'renderer-value',
+        preload: 'preload-value'
       });
 
       expect(
         (app.state.closedPanels.main as EditorBackup)!.model!.setValue
       ).toHaveBeenCalledWith('main-value');
+      expect(app.state.closedPanels.preload).toEqual({ value: 'preload-value' });
 
       window.ElectronFiddle.editors.main = oldMainEditor;
     });

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -115,6 +115,30 @@ describe('Editor component', () => {
       expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
     });
 
+    it('attempts to restore a backup value if available', async () => {
+      store.getAndRemoveEditorValueBackup.mockReturnValueOnce({
+        value: 'hello'
+      });
+
+      const wrapper = shallow(
+        <Editor
+          appState={store}
+          monaco={monaco}
+          monacoOptions={{}}
+          id={EditorId.main}
+          editorDidMount={() => undefined}
+        />
+      );
+      const instance: any = wrapper.instance();
+
+      instance.containerRef.current = 'ref';
+      await instance.initMonaco();
+
+      expect(instance.editor.restoreViewState).toHaveBeenCalledTimes(0);
+      expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
+      expect(monaco.editor.createModel).toHaveBeenCalledWith('hello', 'javascript');
+    });
+
     it('initializes with a fixed tab size', async () => {
       const didMount = jest.fn();
       const wrapper = shallow(


### PR DESCRIPTION
When loading a Fiddle that contains a `preload` file, we didn't correctly load that content unless the user has previously opened the preload editor. The underlying cause was that we didn't create an initial text model for that editor, so we didn't have a place to store that value.

Closes #284 