### PR TITLE
fix: prevent other editors from clipping tooltips

### DIFF
--- a/src/less/components/editors.less
+++ b/src/less/components/editors.less
@@ -24,6 +24,21 @@
   }
 }
 
+// update if list of Editor ID changes
+@editor-ids: main, renderer, html, preload;
+
+// takes each editor ID and increase its z-index if the parent Mosiac root
+// has focused__id class for that specific id.
+each(@editor-ids, {
+  .focused__@{value}.mosaic .mosaic-window.@{value} {
+    z-index: 2;
+  }
+});
+
+.mosaic-window {
+  z-index: 1;
+}
+
 @keyframes fadein {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -16,6 +16,7 @@ export interface EditorProps {
   options?: Partial<MonacoType.editor.IEditorConstructionOptions>;
   editorDidMount?: (editor: MonacoType.editor.IStandaloneCodeEditor) => void;
   onChange?: (value: string, event: MonacoType.editor.IModelContentChangedEvent) => void;
+  setFocused: (id: EditorId) => void;
 }
 
 export class Editor extends React.Component<EditorProps> {
@@ -27,7 +28,6 @@ export class Editor extends React.Component<EditorProps> {
 
   constructor(props: EditorProps) {
     super(props);
-
     this.language = props.id === 'html' ? 'html' : 'javascript';
   }
 
@@ -78,6 +78,12 @@ export class Editor extends React.Component<EditorProps> {
         contextmenu: false,
         model: null,
         ...monacoOptions
+      });
+
+      // mark this editor as focused whenever it is
+      this.editor.onDidFocusEditorText(() => {
+        const { id, setFocused } = this.props;
+        setFocused(id);
       });
 
       await this.editorDidMount(this.editor);

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -43,6 +43,7 @@ export interface EditorsState {
   monaco?: typeof MonacoType;
   isMounted?: boolean;
   monacoOptions: MonacoType.editor.IEditorOptions;
+  focused?: EditorId;
 }
 
 @observer
@@ -61,6 +62,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     this.renderEditor = this.renderEditor.bind(this);
     this.renderTile = this.renderTile.bind(this);
     this.renderGenericPanel = this.renderGenericPanel.bind(this);
+    this.setFocused = this.setFocused.bind(this);
 
     this.state = { monacoOptions: defaultMonacoOptions };
 
@@ -237,6 +239,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
         monaco={monaco!}
         appState={appState}
         monacoOptions={defaultMonacoOptions}
+        setFocused={this.setFocused}
       />
     );
   }
@@ -249,6 +252,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
 
     return (
       <Mosaic<EditorId | PanelId>
+        className={`focused__${this.state.focused}`}
         onChange={this.onChange}
         value={appState.mosaicArrangement}
         zeroStateView={renderNonIdealState(appState)}
@@ -290,5 +294,15 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     }
 
     activateTheme(monaco, undefined, this.props.appState.theme);
+  }
+
+  /**
+   * Sets the currently-focused editor. This will impact the editor's
+   * z-index, ensuring that its intellisense menus don't get clipped
+   * by the other editor windows.
+   * @param id Editor ID
+   */
+  public setFocused(id: EditorId): void {
+    this.setState({ focused: id });
   }
 }

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Editors component renders 1`] = `
 <div
-  className="mosaic-blueprint-theme mosaic mosaic-drop-target"
+  className="focused__undefined mosaic mosaic-drop-target"
 >
   <div
     className="mosaic-root"

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -9,6 +9,7 @@ describe('Editor component', () => {
   let monaco: any;
   const editorDispose = jest.fn();
   const updateOptions = jest.fn();
+  const onDidFocusEditorText = jest.fn();
 
   beforeEach(() => {
     store = {
@@ -24,8 +25,9 @@ describe('Editor component', () => {
       editor: {
         create: jest.fn(() => ({
           dispose: editorDispose,
+          onDidFocusEditorText,
           setModel: jest.fn(),
-          restoreViewState: jest.fn()
+          restoreViewState: jest.fn(),
         })),
         createModel: jest.fn(() => ({
           updateOptions
@@ -38,7 +40,7 @@ describe('Editor component', () => {
 
   it('renders the editor container', () => {
     const wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} setFocused={() => undefined} />
     );
 
     expect(wrapper.html()).toBe('<div class="editorContainer"></div>');
@@ -46,13 +48,13 @@ describe('Editor component', () => {
 
   it('correctly sets the language', () => {
     let wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} setFocused={() => undefined} />
     );
 
     expect((wrapper.instance() as any).language).toBe('javascript');
 
     wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.html} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.html} setFocused={() => undefined} />
     );
 
     expect((wrapper.instance() as any).language).toBe('html');
@@ -60,7 +62,7 @@ describe('Editor component', () => {
 
   it('denies updates', () => {
     const wrapper = shallow(
-      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} />
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.main} setFocused={() => undefined} />
     );
 
     expect((wrapper as any)
@@ -79,6 +81,7 @@ describe('Editor component', () => {
           monacoOptions={{}}
           id={EditorId.main}
           editorDidMount={didMount}
+          setFocused={() => undefined}
         />
       );
       const instance: any = wrapper.instance();
@@ -104,6 +107,7 @@ describe('Editor component', () => {
           monacoOptions={{}}
           id={EditorId.main}
           editorDidMount={() => undefined}
+          setFocused={() => undefined}
         />
       );
       const instance: any = wrapper.instance();
@@ -127,6 +131,7 @@ describe('Editor component', () => {
           monacoOptions={{}}
           id={EditorId.main}
           editorDidMount={() => undefined}
+          setFocused={() => undefined}
         />
       );
       const instance: any = wrapper.instance();
@@ -148,6 +153,7 @@ describe('Editor component', () => {
           monacoOptions={{}}
           id={EditorId.main}
           editorDidMount={didMount}
+          setFocused={() => undefined}
         />
       );
       const instance: any = wrapper.instance();
@@ -158,6 +164,24 @@ describe('Editor component', () => {
       expect(updateOptions).toHaveBeenCalledWith(expect.objectContaining({
         tabSize: 2
       }));
+    });
+
+    it('sets up a listener on focused text editor', async () => {
+      const wrapper = shallow(
+        <Editor
+          appState={store}
+          monaco={monaco}
+          monacoOptions={{}}
+          id={EditorId.main}
+          editorDidMount={() => undefined}
+          setFocused={() => undefined}
+        />
+      );
+      const instance: any = wrapper.instance();
+
+      instance.containerRef.current = 'ref';
+      await instance.initMonaco();
+      expect(onDidFocusEditorText).toHaveBeenCalled();
     });
   });
 
@@ -170,6 +194,7 @@ describe('Editor component', () => {
         monacoOptions={{}}
         id={EditorId.main}
         editorDidMount={didMount}
+        setFocused={() => undefined}
       />
     );
     const instance: any = wrapper.instance();


### PR DESCRIPTION
Fixes #289 

Leverages the CSS `z-index` property and Monaco's `onDidFocusEditorText()` event handler to make the latest focused Editor pane higher in stack order than the others.

The Less selectors are a bit complicated because I couldn't add the `focused` class directly on each `<MosaicWindow/>`. This is due to the `<Mosaic/>` element not calling `renderTile()` unless the child `<MosaicWindow/>` elements were re-arranged.