### PR TITLE
fix: Add original-fs to ignored modules

### DIFF
--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -13,6 +13,7 @@ export let isInstalled: boolean | null = null;
 /* perhaps we can expose this to the settings module?*/
 const ignoredModules: Array<string> = [
   'electron',
+  'original-fs',
   ...builtinModules
 ];
 

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -20,6 +20,7 @@ describe('npm', () => {
 
     function hello() {
       const electron = require('electron');
+      const originalFs = require('original-fs');
       const fs = require('fs');
       const privateModule = require('./hi');
     }
@@ -81,7 +82,7 @@ describe('npm', () => {
   });
 
   describe('findModulesInEditors()', () => {
-    it('finds modules', async () => {
+    it('finds modules, ignoring node and electron builtins', async () => {
       const result = await findModulesInEditors({
         html: '',
         main: mockMain,


### PR DESCRIPTION
Fixes #231

This PR adds `original-fs` to this list of ignored modules (as it's exposed by electron).