### PR TITLE
chore: fix autoUpdater example to remove spurious event. Fixes #283

### DIFF
--- a/static/show-me/autoupdater/main.js
+++ b/static/show-me/autoupdater/main.js
@@ -26,10 +26,6 @@ app.on('ready', () => {
   })
 
   autoUpdater.on('update-available', () => {
-    console.log('The autoUpdater has found an update!')
-  })
-
-  autoUpdater.on('update-available', () => {
     console.log('The autoUpdater has found an update and is now downloading it!')
   })
 


### PR DESCRIPTION
Removes a confusing extra event listener to `update-available` from the `autoUpdater` example