### PR TITLE
fix: Make example warning more descriptive

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -25,17 +25,20 @@ export class RemoteLoader {
 
   public async loadFiddleFromElectronExample(_: any, exampleInfo: { path: string; ref: string }) {
     console.log(`Loading fiddle from Electron example`, _, exampleInfo);
-    const ok = await this.verifyRemoteLoad('example from the Electron docs', exampleInfo.ref);
+    const {path, ref} = exampleInfo;
+    const prettyName = path.replace('docs/fiddles/', '');
+    const ok = await this.verifyRemoteLoad(`'${prettyName}' example from the Electron docs for version ${ref}`);
     if (!ok) return;
 
-    this.fetchExampleAndLoad(exampleInfo.ref, exampleInfo.path);
+    this.fetchExampleAndLoad(ref, path);
   }
 
   public async loadFiddleFromGist(_: any, gistInfo: { id: string }) {
-    const ok = await this.verifyRemoteLoad('gist');
+    const {id} = gistInfo;
+    const ok = await this.verifyRemoteLoad(`gist`);
     if (!ok) return;
 
-    this.fetchGistAndLoad(gistInfo.id);
+    this.fetchGistAndLoad(id);
   }
 
   public async fetchExampleAndLoad(ref: string, path: string): Promise<boolean> {
@@ -197,9 +200,9 @@ export class RemoteLoader {
    *
    * @param what What are we loading from (gist, example, etc.)
    */
-  public async verifyRemoteLoad(what: string, fiddlePath?: string): Promise<boolean> {
+  public async verifyRemoteLoad(what: string): Promise<boolean> {
     this.appState.setConfirmationPromptTexts({
-      label: `Are you sure you sure you want to load this '${what}' from fiddle path '${fiddlePath}'? Only load and run it if you trust the source.`
+      label: `Are you sure you want to load this ${what}? Only load and run it if you trust the source.`
     });
     this.appState.isConfirmationPromptShowing = true;
     await when(() => !this.appState.isConfirmationPromptShowing);

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -249,7 +249,8 @@ describe('RemoteLoader', () => {
         { path: 'test/path', ref: '4.0.0' }
       );
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalled();
+      expect(instance.verifyRemoteLoad)
+        .toHaveBeenCalledWith(`'test/path' example from the Electron docs for version 4.0.0`);
       expect(instance.fetchExampleAndLoad).toHaveBeenCalledWith('4.0.0', 'test/path');
     });
 
@@ -276,7 +277,7 @@ describe('RemoteLoader', () => {
         { id: 'gist' }
       );
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalled();
+      expect(instance.verifyRemoteLoad).toHaveBeenCalledWith('gist');
       expect(instance.fetchGistAndLoad).toHaveBeenCalledWith('gist');
     });
 


### PR DESCRIPTION
Fixes #262.

Make example warning more descriptive by adding path, remove repeated text. 

## Screenshots
<img width="500" alt="example" src="https://user-images.githubusercontent.com/44379112/73131366-971fc800-3fbe-11ea-8af4-65e2915a6d94.png">

<img width="500" alt="gist" src="https://user-images.githubusercontent.com/44379112/73131365-971fc800-3fbe-11ea-916a-c08cf47edf0f.png">

## Considerations
* We may want to preflight the gist so we can tell the user the author name, at the moment we just say 'gist'
* The string replace to pretty up the example name is a bit weak, but the code is currently written to allow us to point to directories outside the fiddle directory. If we want to ban this all together I'm happy to catch it on the protocol handler side, only sending the pretty name to the app, which reconstructs the path later.
* Words are hard.