### PR TITLE
fix: print correct output in ipcRenderer show-me

### DIFF
--- a/static/show-me/ipc/renderer.js
+++ b/static/show-me/ipc/renderer.js
@@ -4,6 +4,6 @@ const { ipcRenderer } = require('electron')
 console.log(ipcRenderer.sendSync('synchronous-message', 'ping'))
 
 // prints "pong"
-ipcRenderer.on('asynchronous-reply', (...args) => console.log(args))
+ipcRenderer.on('asynchronous-reply', (_, ...args) => console.log(...args))
 
 ipcRenderer.send('asynchronous-message', 'ping')


### PR DESCRIPTION
The event listener in `ipcRenderer.on()` is an arrow function with the parameters `event` and `...args`.

In this show-me, we were supposed to print `"pong"`, but ended up printing `[event, "pong"]` because we were using the rest parameter `...args` at the wrong level.