### PR TITLE
chore: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This project is a part of the Electron ecosystem. As such, all contributions to 
 [Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
 where appropriate.
 
-## Contribution suggestions
+## Contribution Suggestions
 
 We use the label [`good first issue`](https://github.com/electron/fiddle/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the issue tracker to denote fairly-well-scoped-out bugs or feature requests that the community can pick up and work on. If any of those labeled issues do not have enough information, please feel free to ask constructive questions. (This applies to any open issue.)
 
@@ -65,7 +65,7 @@ However, rebasing is encouraged when practical, particularly when there's a merg
 If you are continuing the work of another person's PR and need to rebase/squash, please retain the
 attribution of the original author(s) and continue the work in subsequent commits.
 
-### Running Fiddle from source
+### Running Fiddle From Source
 
 ```sh
 git clone https://github.com/electron/fiddle
@@ -74,12 +74,12 @@ npm install
 npm start
 ```
 
-### Running tests
+### Running Tests
 
 ```sh
 npm test
 ```
 
-## Release process
+## Release Process
 
 <!-- TODO @felix add your release process here 😁 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,34 +36,6 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 * Please **do not** bump the version number in your pull requests, the maintainers will do that.
   Feel free to indicate whether the changes require a major, minor, or patch version bump, as
   prescribed by the [semantic versioning specification](http://semver.org/).
-* Once your pull request is approved, please make sure your commits are rebased onto the latest
-  commit in the master branch, and that you limit/squash the number of commits created to a
-  "feature"-level. For instance:
-
-bad:
-
-```
-commit 1: add foo option
-commit 2: standardize code
-commit 3: add test
-commit 4: add docs
-commit 5: add bar option
-commit 6: add test + docs
-```
-
-good:
-
-```
-commit 1: add foo option
-commit 2: add bar option
-```
-
-Squashing commits during discussion of the pull request is almost always unnecessary, and makes it
-more difficult for both the submitters and reviewers to understand what changed in between comments.
-However, rebasing is encouraged when practical, particularly when there's a merge conflict.
-
-If you are continuing the work of another person's PR and need to rebase/squash, please retain the
-attribution of the original author(s) and continue the work in subsequent commits.
 
 ### Running Fiddle From Source
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Electron Fiddle
+
+Electron Fiddle is a community-driven project, overseen by the [Electron Ecosystem Working
+Group](https://github.com/electron/governance/tree/master/wg-ecosystem#readme). As such, we welcome
+and encourage all sorts of contributions. They include, but are not limited to:
+
+- Constructive feedback
+- Bug reports / technical issues
+- Documentation changes
+- Feature requests
+- [Pull requests](#filing-pull-requests)
+
+We strongly suggest that before filing an issue, you search through the existing issues to see
+if it has already been filed by someone else.
+
+This project is a part of the Electron ecosystem. As such, all contributions to this project follow
+[Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+where appropriate.
+
+## Contribution suggestions
+
+We use the label [`good first issue`](https://github.com/electron/fiddle/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the issue tracker to denote fairly-well-scoped-out bugs or feature requests that the community can pick up and work on. If any of those labeled issues do not have enough information, please feel free to ask constructive questions. (This applies to any open issue.)
+
+## Filing Pull Requests
+
+Here are some things to keep in mind as you file pull requests to fix bugs, add new features, etc.:
+
+* If you're unfamiliar with forking, branching, and pull requests, please see [GitHub's extensive
+  documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests).
+* Travis CI and AppVeyor are used to make sure that any new or changed code meets the project's
+  style guidelines, and that the project's testsuite passes for each new commit.
+* Unless it's impractical, please write tests for your changes. This will help us so that we can
+  spot regressions much easier.
+* When creating commit messages and pull request titles, please adhere to the [conventional
+  commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
+* Please **do not** bump the version number in your pull requests, the maintainers will do that.
+  Feel free to indicate whether the changes require a major, minor, or patch version bump, as
+  prescribed by the [semantic versioning specification](http://semver.org/).
+* Once your pull request is approved, please make sure your commits are rebased onto the latest
+  commit in the master branch, and that you limit/squash the number of commits created to a
+  "feature"-level. For instance:
+
+bad:
+
+```
+commit 1: add foo option
+commit 2: standardize code
+commit 3: add test
+commit 4: add docs
+commit 5: add bar option
+commit 6: add test + docs
+```
+
+good:
+
+```
+commit 1: add foo option
+commit 2: add bar option
+```
+
+Squashing commits during discussion of the pull request is almost always unnecessary, and makes it
+more difficult for both the submitters and reviewers to understand what changed in between comments.
+However, rebasing is encouraged when practical, particularly when there's a merge conflict.
+
+If you are continuing the work of another person's PR and need to rebase/squash, please retain the
+attribution of the original author(s) and continue the work in subsequent commits.
+
+### Running Fiddle from source
+
+```sh
+git clone https://github.com/electron/fiddle
+cd fiddle
+npm install
+npm start
+```
+
+### Running tests
+
+```sh
+npm test
+```
+
+## Release process
+
+<!-- TODO @felix add your release process here 😁 -->


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` to the repository (based on the one I wrote for Electron Packager).