### PR TITLE
refactor(show-me): avoid using a global mainWindow variable

### DIFF
--- a/src/content/main-1-x-x.ts
+++ b/src/content/main-1-x-x.ts
@@ -3,13 +3,9 @@ const {app, BrowserWindow} = require('electron')
 const path = require('path')
 const url = require('url')
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
-
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  const mainWindow = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
   mainWindow.loadURL(url.format({
@@ -20,14 +16,6 @@ function createWindow () {
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
-
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null
-  })
 }
 
 // This method will be called when Electron has finished
@@ -47,7 +35,7 @@ app.on('window-all-closed', function () {
 app.on('activate', function () {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
+  if (BrowserWindow.getAllWindows().length === 0) {
     createWindow()
   }
 })

--- a/static/show-me/clipboard/main.js
+++ b/static/show-me/clipboard/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/cookies/main.js
+++ b/static/show-me/cookies/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow, session } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/crashreporter/main.js
+++ b/static/show-me/crashreporter/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/debugger/main.js
+++ b/static/show-me/debugger/main.js
@@ -8,10 +8,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
 
   mainWindow.loadFile('index.html')
 

--- a/static/show-me/desktopcapturer/main.js
+++ b/static/show-me/desktopcapturer/main.js
@@ -6,10 +6,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/dialog/main.js
+++ b/static/show-me/dialog/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow, dialog } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
 
   // Show an "Open File" dialog and attempt to open
   // the chosen file in our window.

--- a/static/show-me/ipc/main.js
+++ b/static/show-me/ipc/main.js
@@ -7,10 +7,8 @@
 
 const { app, BrowserWindow, ipcMain } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/menu/main.js
+++ b/static/show-me/menu/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow, Menu } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
   mainWindow.loadFile('index.html')
 
   const template = [

--- a/static/show-me/notification/main.js
+++ b/static/show-me/notification/main.js
@@ -6,10 +6,8 @@
 
 const { app, BrowserWindow, Notification } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/remote/main.js
+++ b/static/show-me/remote/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {

--- a/static/show-me/screen/main.js
+++ b/static/show-me/screen/main.js
@@ -5,8 +5,6 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
   // We cannot require the screen module until the
   // app is ready
@@ -17,7 +15,7 @@ app.on('ready', () => {
   const primaryDisplay = screen.getPrimaryDisplay()
   const { width, height } = primaryDisplay.workAreaSize
 
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width,
     height,
     webPreferences: {

--- a/static/show-me/shell/main.js
+++ b/static/show-me/shell/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width: 600,
     height: 600,
     webPreferences: {

--- a/static/show-me/touchbar/main.js
+++ b/static/show-me/touchbar/main.js
@@ -7,7 +7,8 @@ const { app, BrowserWindow, TouchBar } = require('electron')
 const { TouchBarLabel, TouchBarButton, TouchBarSpacer } = TouchBar
 
 app.on('ready', () => {
-  const mainWindow.loadFile('index.html')
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  mainWindow.loadFile('index.html')
 
   // This API only works on macOS devices with a TouchBar.
   if (process.platform !== 'darwin') return

--- a/static/show-me/touchbar/main.js
+++ b/static/show-me/touchbar/main.js
@@ -6,11 +6,8 @@
 const { app, BrowserWindow, TouchBar } = require('electron')
 const { TouchBarLabel, TouchBarButton, TouchBarSpacer } = TouchBar
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ height: 600, width: 600 })
-  mainWindow.loadFile('index.html')
+  const mainWindow.loadFile('index.html')
 
   // This API only works on macOS devices with a TouchBar.
   if (process.platform !== 'darwin') return

--- a/static/show-me/webcontents/main.js
+++ b/static/show-me/webcontents/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow, webContents } = require('electron')
 
-let mainWindow
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
   mainWindow.loadFile('index.html')
 
   setTimeout(() => {

--- a/static/show-me/webframe/main.js
+++ b/static/show-me/webframe/main.js
@@ -5,10 +5,8 @@
 
 const { app, BrowserWindow } = require('electron')
 
-let mainWindow = null
-
 app.on('ready', () => {
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width: 600,
     height: 600,
     webPreferences: {


### PR DESCRIPTION
Follow-up to #312 (and https://github.com/electron/electron/pull/21957), updates all the examples in the Fiddle repo I could find.

CC: @nornagon 