### PR TITLE
fix: Reorganize the bisect helper

### DIFF
--- a/src/less/components/version-select.less
+++ b/src/less/components/version-select.less
@@ -1,0 +1,5 @@
+.bp3-fill {
+  .version-chooser  {
+    width: 100%;
+  }
+}

--- a/src/less/root.less
+++ b/src/less/root.less
@@ -17,3 +17,4 @@
 @import "components/editors.less";
 @import "components/tour.less";
 @import "components/show-me.less";
+@import "components/version-select.less";

--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -21,11 +21,14 @@ export class BisectHandler extends React.Component<BisectHandlerProps> {
   public continueBisect(isGood: boolean) {
     const { appState } = this.props;
     const response = appState.Bisector!.continue(isGood);
+
     if (Array.isArray(response)) {
       this.terminateBisect();
+
       const [minRev, maxRev] = response;
       const [minVer, maxVer] = [minRev.version, maxRev.version];
       const message = `Check between versions ${minVer} and ${maxVer}.`;
+
       appState.pushOutput(`[BISECT] Complete: ${message}`);
       appState.setGenericDialogOptions({
         type: GenericDialogType.success,

--- a/src/renderer/components/commands-version-chooser.tsx
+++ b/src/renderer/components/commands-version-chooser.tsx
@@ -1,172 +1,29 @@
-import { Button, ButtonGroup, MenuItem } from '@blueprintjs/core';
-import { ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
+import { ButtonGroup } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../interfaces';
-import { highlightText } from '../../utils/highlight-text';
-import { sortedElectronMap } from '../../utils/sorted-electron-map';
 import { AppState } from '../state';
-import { getReleaseChannel } from '../versions';
-
-const ElectronVersionSelect = Select.ofType<ElectronVersion>();
-
-/**
- * Helper method: Returns the <Select /> label for an Electron
- * version.
- *
- * @param {ElectronVersion} { source, state }
- * @returns {string}
- */
-export function getItemLabel({ source, state, name }: ElectronVersion): string {
-  let label = '';
-
-  if (source === ElectronVersionSource.local) {
-    label = name || 'Local';
-  } else {
-    if (state === ElectronVersionState.unknown) {
-      label = `Not downloaded`;
-    } else if (state === ElectronVersionState.ready) {
-      label = `Downloaded`;
-    } else if (state === ElectronVersionState.downloading) {
-      label = `Downloading`;
-    }
-  }
-
-  return label;
-}
-
-/**
- * Helper method: Returns the <Select /> icon for an Electron
- * version.
- *
- * @param {ElectronVersion} { state }
- * @returns
- */
-export function getItemIcon({ state }: ElectronVersion) {
-  return state === 'ready'
-    ? 'saved'
-    : state === 'downloading' ? 'cloud-download' : 'cloud';
-}
-
-/**
- * Helper method: Returns the <Select /> predicate for an Electron
- * version.
- *
- * @param {string} query
- * @param {ElectronVersion} { version }
- * @returns
- */
-export const filterItem: ItemPredicate<ElectronVersion> = (query, { version }) => {
-  return version.toLowerCase().includes(query.toLowerCase());
-};
-
-/**
- * Helper method: Returns the <Select /> <MenuItem /> for Electron
- * versions.
- *
- * @param {ElectronVersion} item
- * @param {IItemRendererProps} { handleClick, modifiers, query }
- * @returns
- */
-export const renderItem: ItemRenderer<ElectronVersion> = (item, { handleClick, modifiers, query }) => {
-  if (!modifiers.matchesPredicate) {
-    return null;
-  }
-
-  return (
-    <MenuItem
-      active={modifiers.active}
-      disabled={modifiers.disabled}
-      text={highlightText(item.version, query)}
-      key={item.version}
-      onClick={handleClick}
-      label={getItemLabel(item)}
-      icon={getItemIcon(item)}
-    />
-  );
-};
-
-export interface VersionChooserState {
-  value: string;
-}
+import { VersionSelect } from './version-select';
 
 export interface VersionChooserProps {
   appState: AppState;
 }
 
-
-export const getVersionsFromAppState = (appState: AppState) => {
-  const { versions, versionsToShow, statesToShow } = appState;
-
-  return sortedElectronMap<ElectronVersion>(versions, (_key, item) => item)
-    .filter((item) => {
-      if (!item) {
-        return false;
-      }
-
-      // Check if we want to show the version
-      if (!versionsToShow.includes(getReleaseChannel(item))) {
-        return false;
-      }
-
-      // Check if we want to show the state
-      if (!statesToShow.includes(item.state)) {
-        return false;
-      }
-
-      return true;
-    });
-};
-
 /**
  * A dropdown allowing the selection of Electron versions. The actual
  * download is managed in the state.
- *
- * @class VersionChooser
- * @extends {React.Component<VersionChooserProps, VersionChooserState>}
  */
-@observer
-export class VersionChooser extends React.Component<VersionChooserProps, VersionChooserState> {
-  constructor(props: VersionChooserProps) {
-    super(props);
+export const VersionChooser = observer((props: VersionChooserProps) => {
+  const { currentElectronVersion, Bisector, setVersion } = props.appState;
 
-    this.onItemSelect = this.onItemSelect.bind(this);
-  }
-
-  /**
-   * Handle change, which usually means that we'd like update
-   * the selection version.
-   *
-   * @param {React.ChangeEvent<HTMLSelectElement>} event
-   */
-  public onItemSelect({ version }: ElectronVersion) {
-    this.props.appState.setVersion(version);
-  }
-
-  public render() {
-    const { currentElectronVersion, Bisector } = this.props.appState;
-    const { version } = currentElectronVersion;
-
-    return (
-      <ButtonGroup>
-        <ElectronVersionSelect
-          filterable={true}
-          items={getVersionsFromAppState(this.props.appState)}
-          itemRenderer={renderItem}
-          itemPredicate={filterItem}
-          onItemSelect={this.onItemSelect}
-          noResults={<MenuItem disabled={true} text='No results.' />}
-          disabled={!!Bisector}
-        >
-          <Button
-            className='version-chooser'
-            text={`Electron v${version}`}
-            icon={getItemIcon(currentElectronVersion)}
-            disabled={!!Bisector}
-          />
-        </ElectronVersionSelect>
-      </ButtonGroup>
-    );
-  }
-}
+  return (
+    <ButtonGroup>
+      <VersionSelect
+        appState={props.appState}
+        onVersionSelect={({ version }) => setVersion(version)}
+        currentVersion={currentElectronVersion}
+        disabled={!!Bisector}
+      />
+    </ButtonGroup>
+  );
+});

--- a/src/renderer/components/dialog-bisect.tsx
+++ b/src/renderer/components/dialog-bisect.tsx
@@ -1,22 +1,19 @@
-import { Button, Dialog, Label, MenuItem } from '@blueprintjs/core';
-import { Select } from '@blueprintjs/select';
+import { Button, ButtonGroup, Dialog, Label } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { ElectronVersion } from '../../interfaces';
 import { Bisector } from '../bisect';
 import { AppState } from '../state';
-import { filterItem, getItemIcon, getVersionsFromAppState, renderItem } from './commands-version-chooser';
-
-const ElectronVersionSelect = Select.ofType<ElectronVersion>();
+import { VersionSelect } from './version-select';
 
 export interface BisectDialogProps {
   appState: AppState;
 }
 
 export interface BisectDialogState {
-  startIndex?: number;
-  endIndex?: number;
+  startIndex: number;
+  endIndex: number;
   allVersions: Array<ElectronVersion>;
 }
 
@@ -36,8 +33,11 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
     this.onBeginSelect = this.onBeginSelect.bind(this);
     this.onEndSelect = this.onEndSelect.bind(this);
 
-    const allVersions = getVersionsFromAppState(this.props.appState);
-    this.state = { allVersions };
+    this.state = {
+      allVersions: this.props.appState.versionsToShow,
+      startIndex: 0,
+      endIndex: 0
+    };
   }
 
   public onBeginSelect(version: ElectronVersion) {
@@ -118,39 +118,23 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
         <div className='bp3-dialog-body'>
           <Label>
             Earliest Version
-            <ElectronVersionSelect
-              filterable={true}
-              items={allVersions}
-              itemRenderer={renderItem}
-              itemPredicate={filterItem}
-              onItemSelect={this.onBeginSelect}
-              noResults={<MenuItem disabled={true} text='No results.' />}
-            >
-              <Button
-                text={startIndex ? `v${allVersions[startIndex].version}` : ``}
-                icon={startIndex ? getItemIcon(allVersions[startIndex]) : 'small-minus'}
-                fill={true}
+            <ButtonGroup fill={true}>
+              <VersionSelect
+                currentVersion={allVersions[startIndex]}
+                appState={this.props.appState}
+                onVersionSelect={this.onBeginSelect}
               />
-            </ElectronVersionSelect>
+            </ButtonGroup>
           </Label>
           <Label>
             Latest Version
-            <ElectronVersionSelect
-              filterable={true}
-              items={allVersions.slice(0, startIndex!)}
-              itemRenderer={renderItem}
-              itemPredicate={filterItem}
-              onItemSelect={this.onEndSelect}
-              noResults={<MenuItem disabled={true} text='No results.' />}
-              disabled={!startIndex}
-            >
-              <Button
-                text={endIndex ? `v${allVersions[endIndex].version}` : ``}
-                icon={endIndex ? getItemIcon(allVersions[endIndex]) : 'small-minus'}
-                fill={true}
-                disabled={!startIndex}
+            <ButtonGroup fill={true}>
+              <VersionSelect
+                currentVersion={allVersions[endIndex]}
+                appState={this.props.appState}
+                onVersionSelect={this.onEndSelect}
               />
-            </ElectronVersionSelect>
+            </ButtonGroup>
           </Label>
         </div>
         <div className='bp3-dialog-footer'>

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -85,9 +85,9 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
     const { appState } = this.props;
 
     if (!checked) {
-      appState.versionsToShow = appState.versionsToShow.filter((c) => c !== id);
+      appState.channelsToShow = appState.channelsToShow.filter((c) => c !== id);
     } else {
-      appState.versionsToShow.push(id as ElectronReleaseChannel);
+      appState.channelsToShow.push(id as ElectronReleaseChannel);
     }
   }
 
@@ -244,7 +244,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
   private renderVersionChannelOptions(): JSX.Element {
     const { appState } = this.props;
     const getIsChecked = (channel: ElectronReleaseChannel) => {
-      return appState.versionsToShow.includes(channel);
+      return appState.channelsToShow.includes(channel);
     };
 
     return (
@@ -316,11 +316,11 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
    * @returns {Array<JSX.Element>}
    */
   private renderTableRows(): Array<JSX.Element | null> {
-    const { versions, versionsToShow, statesToShow } = this.props.appState;
+    const { versions, channelsToShow, statesToShow } = this.props.appState;
 
     return sortedElectronMap<JSX.Element | null>(versions, (key, item) => {
       // Check if we want to show the version
-      if (!versionsToShow.includes(getReleaseChannel(item))) {
+      if (!channelsToShow.includes(getReleaseChannel(item))) {
         return null;
       }
 

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -1,0 +1,132 @@
+import { Button, IButtonGroupProps, MenuItem } from '@blueprintjs/core';
+import { ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../interfaces';
+import { highlightText } from '../../utils/highlight-text';
+import { AppState } from '../state';
+
+const ElectronVersionSelect = Select.ofType<ElectronVersion>();
+
+/**
+ * Helper method: Returns the <Select /> label for an Electron
+ * version.
+ *
+ * @param {ElectronVersion} { source, state }
+ * @returns {string}
+ */
+export function getItemLabel({ source, state, name }: ElectronVersion): string {
+  let label = '';
+
+  if (source === ElectronVersionSource.local) {
+    label = name || 'Local';
+  } else {
+    if (state === ElectronVersionState.unknown) {
+      label = `Not downloaded`;
+    } else if (state === ElectronVersionState.ready) {
+      label = `Downloaded`;
+    } else if (state === ElectronVersionState.downloading) {
+      label = `Downloading`;
+    }
+  }
+
+  return label;
+}
+
+/**
+ * Helper method: Returns the <Select /> icon for an Electron
+ * version.
+ *
+ * @param {ElectronVersion} { state }
+ * @returns
+ */
+export function getItemIcon({ state }: ElectronVersion) {
+  return state === 'ready'
+    ? 'saved'
+    : state === 'downloading' ? 'cloud-download' : 'cloud';
+}
+
+/**
+ * Helper method: Returns the <Select /> predicate for an Electron
+ * version.
+ *
+ * @param {string} query
+ * @param {ElectronVersion} { version }
+ * @returns
+ */
+export const filterItem: ItemPredicate<ElectronVersion> = (query, { version }) => {
+  return version.toLowerCase().includes(query.toLowerCase());
+};
+
+/**
+ * Helper method: Returns the <Select /> <MenuItem /> for Electron
+ * versions.
+ *
+ * @param {ElectronVersion} item
+ * @param {IItemRendererProps} { handleClick, modifiers, query }
+ * @returns
+ */
+export const renderItem: ItemRenderer<ElectronVersion> = (item, { handleClick, modifiers, query }) => {
+  if (!modifiers.matchesPredicate) {
+    return null;
+  }
+
+  return (
+    <MenuItem
+      active={modifiers.active}
+      disabled={modifiers.disabled}
+      text={highlightText(item.version, query)}
+      key={item.version}
+      onClick={handleClick}
+      label={getItemLabel(item)}
+      icon={getItemIcon(item)}
+    />
+  );
+};
+
+export interface VersionSelectState {
+  value: string;
+}
+
+export interface VersionSelectProps {
+  appState: AppState;
+  disabled?: boolean;
+  currentVersion: ElectronVersion;
+  onVersionSelect: (version: ElectronVersion) => void;
+  buttonGroupProps?: IButtonGroupProps;
+}
+
+/**
+ * A dropdown allowing the selection of Electron versions. The actual
+ * download is managed in the state.
+ *
+ * @class VersionSelect
+ * @extends {React.Component<VersionSelectProps, VersionSelectState>}
+ */
+@observer
+export class VersionSelect extends React.Component<VersionSelectProps, VersionSelectState> {
+  public render() {
+    const { currentVersion } = this.props;
+    const { version } = currentVersion;
+
+    return (
+      <ElectronVersionSelect
+        filterable={true}
+        items={this.props.appState.versionsToShow}
+        itemRenderer={renderItem}
+        itemPredicate={filterItem}
+        onItemSelect={this.props.onVersionSelect}
+        noResults={<MenuItem disabled={true} text='No results.' />}
+        disabled={!!this.props.disabled}
+      >
+        <Button
+          className='version-chooser'
+          text={`Electron v${version}`}
+          icon={getItemIcon(currentVersion)}
+          disabled={!!this.props.disabled}
+        />
+      </ElectronVersionSelect>
+    );
+  }
+}

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -162,11 +162,11 @@ export class RemoteLoader {
     // check if version is part of release channel
     const versionReleaseChannel: ElectronReleaseChannel = getReleaseChannel(version);
 
-    if (!this.appState.versionsToShow.includes(versionReleaseChannel)) {
+    if (!this.appState.channelsToShow.includes(versionReleaseChannel)) {
       const ok = await this.verifyReleaseChannelEnabled(versionReleaseChannel);
       if (!ok) return false;
 
-      this.appState.versionsToShow.push(versionReleaseChannel);
+      this.appState.channelsToShow.push(versionReleaseChannel);
     }
 
     this.appState.setVersion(version);

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -1,113 +1,127 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VersionChooser component handles corrupt data 1`] = `
+exports[`VersionSelect component handles corrupt data 1`] = `
 <Blueprint3.ButtonGroup>
-  <Blueprint3.Select
-    disabled={false}
-    filterable={true}
-    itemPredicate={[Function]}
-    itemRenderer={[Function]}
-    items={
-      Array [
-        Object {
+  <VersionSelect
+    appState={
+      Object {
+        "channelsToShow": Array [
+          "Stable",
+          "Beta",
+        ],
+        "currentElectronVersion": Object {
           "source": "remote",
           "state": "ready",
           "version": "2.0.2",
         },
-        Object {
-          "source": "remote",
-          "state": "ready",
-          "version": "2.0.1",
+        "setVersion": [MockFunction],
+        "statesToShow": Array [
+          "ready",
+          "downloading",
+        ],
+        "version": "blub",
+        "versions": Object {
+          "1.0.0": Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "1.0.0",
+          },
+          "1.8.7": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "1.8.7",
+          },
+          "2.0.1": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.1",
+          },
+          "2.0.2": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.2",
+          },
+          "3.0.0-unsupported": Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "3.0.0-unsupported",
+          },
+          "3.1.3": undefined,
         },
-        Object {
-          "source": "remote",
-          "state": "ready",
-          "version": "1.8.7",
-        },
-      ]
+      }
     }
-    noResults={
-      <Blueprint3.MenuItem
-        disabled={true}
-        multiline={false}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="No results."
-      />
+    currentVersion={
+      Object {
+        "source": "remote",
+        "state": "ready",
+        "version": "2.0.2",
+      }
     }
-    onItemSelect={[Function]}
-  >
-    <Blueprint3.Button
-      className="version-chooser"
-      disabled={false}
-      icon="saved"
-      text="Electron v2.0.2"
-    />
-  </Blueprint3.Select>
+    disabled={false}
+    onVersionSelect={[Function]}
+  />
 </Blueprint3.ButtonGroup>
 `;
 
-exports[`VersionChooser component renderItem() renders an item 1`] = `
-<Blueprint3.MenuItem
-  active={true}
-  disabled={false}
-  icon="cloud"
-  label="Not downloaded"
-  multiline={false}
-  onClick={[Function]}
-  popoverProps={Object {}}
-  shouldDismissPopover={true}
-  text={
-    Array [
-      "1.0.0",
-    ]
-  }
-/>
-`;
-
-exports[`VersionChooser component renders 1`] = `
+exports[`VersionSelect component renders 1`] = `
 <Blueprint3.ButtonGroup>
-  <Blueprint3.Select
-    disabled={false}
-    filterable={true}
-    itemPredicate={[Function]}
-    itemRenderer={[Function]}
-    items={
-      Array [
-        Object {
+  <VersionSelect
+    appState={
+      Object {
+        "channelsToShow": Array [
+          "Stable",
+          "Beta",
+        ],
+        "currentElectronVersion": Object {
           "source": "remote",
           "state": "ready",
           "version": "2.0.2",
         },
-        Object {
-          "source": "remote",
-          "state": "ready",
-          "version": "2.0.1",
+        "setVersion": [MockFunction],
+        "statesToShow": Array [
+          "ready",
+          "downloading",
+        ],
+        "version": "2.0.2",
+        "versions": Object {
+          "1.0.0": Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "1.0.0",
+          },
+          "1.8.7": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "1.8.7",
+          },
+          "2.0.1": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.1",
+          },
+          "2.0.2": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.2",
+          },
+          "3.0.0-unsupported": Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "3.0.0-unsupported",
+          },
+          "3.1.3": undefined,
         },
-        Object {
-          "source": "remote",
-          "state": "ready",
-          "version": "1.8.7",
-        },
-      ]
+      }
     }
-    noResults={
-      <Blueprint3.MenuItem
-        disabled={true}
-        multiline={false}
-        popoverProps={Object {}}
-        shouldDismissPopover={true}
-        text="No results."
-      />
+    currentVersion={
+      Object {
+        "source": "remote",
+        "state": "ready",
+        "version": "2.0.2",
+      }
     }
-    onItemSelect={[Function]}
-  >
-    <Blueprint3.Button
-      className="version-chooser"
-      disabled={false}
-      icon="saved"
-      text="Electron v2.0.2"
-    />
-  </Blueprint3.Select>
+    disabled={false}
+    onVersionSelect={[Function]}
+  />
 </Blueprint3.ButtonGroup>
 `;

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -1,68 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VersionSelect component handles corrupt data 1`] = `
-<Blueprint3.ButtonGroup>
-  <VersionSelect
-    appState={
-      Object {
-        "channelsToShow": Array [
-          "Stable",
-          "Beta",
-        ],
-        "currentElectronVersion": Object {
-          "source": "remote",
-          "state": "ready",
-          "version": "2.0.2",
-        },
-        "setVersion": [MockFunction],
-        "statesToShow": Array [
-          "ready",
-          "downloading",
-        ],
-        "version": "blub",
-        "versions": Object {
-          "1.0.0": Object {
-            "source": "remote",
-            "state": "unknown",
-            "version": "1.0.0",
-          },
-          "1.8.7": Object {
-            "source": "remote",
-            "state": "ready",
-            "version": "1.8.7",
-          },
-          "2.0.1": Object {
-            "source": "remote",
-            "state": "ready",
-            "version": "2.0.1",
-          },
-          "2.0.2": Object {
-            "source": "remote",
-            "state": "ready",
-            "version": "2.0.2",
-          },
-          "3.0.0-unsupported": Object {
-            "source": "remote",
-            "state": "unknown",
-            "version": "3.0.0-unsupported",
-          },
-          "3.1.3": undefined,
-        },
-      }
-    }
-    currentVersion={
-      Object {
-        "source": "remote",
-        "state": "ready",
-        "version": "2.0.2",
-      }
-    }
-    disabled={false}
-    onVersionSelect={[Function]}
-  />
-</Blueprint3.ButtonGroup>
-`;
-
 exports[`VersionSelect component renders 1`] = `
 <Blueprint3.ButtonGroup>
   <VersionSelect
@@ -111,6 +48,33 @@ exports[`VersionSelect component renders 1`] = `
           },
           "3.1.3": undefined,
         },
+        "versionsToShow": Array [
+          Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.2",
+          },
+          Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.1",
+          },
+          Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "1.8.7",
+          },
+          Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "1.0.0",
+          },
+          Object {
+            "source": "remote",
+            "state": "unknown",
+            "version": "3.0.0-unsupported",
+          },
+        ],
       }
     }
     currentVersion={

--- a/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
@@ -578,3 +578,203 @@ exports[`BisectDialog component renders 3`] = `
   </div>
 </Blueprint3.Dialog>
 `;
+
+exports[`BisectDialog component renders 4`] = `
+<Blueprint3.Dialog
+  canOutsideClickClose={true}
+  className="dialog-add-version"
+  isOpen={false}
+  onClose={[Function]}
+  title="Start a bisect session"
+>
+  <div
+    className="bp3-dialog-body"
+  >
+    <Component>
+      Earliest Version
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
+            Object {
+              "source": "local",
+              "state": "ready",
+              "version": "4.0.0",
+            }
+          }
+          onVersionSelect={[Function]}
+        />
+      </Blueprint3.ButtonGroup>
+    </Component>
+    <Component>
+      Latest Version
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
+            Object {
+              "source": "local",
+              "state": "ready",
+              "version": "5.0.0",
+            }
+          }
+          onVersionSelect={[Function]}
+        />
+      </Blueprint3.ButtonGroup>
+    </Component>
+  </div>
+  <div
+    className="bp3-dialog-footer"
+  >
+    <div
+      className="bp3-dialog-footer-actions"
+    >
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        key="submit"
+        onClick={[Function]}
+        text="Begin"
+      />
+      <Blueprint3.Button
+        icon="cross"
+        key="cancel"
+        onClick={[Function]}
+        text="Cancel"
+      />
+    </div>
+  </div>
+</Blueprint3.Dialog>
+`;

--- a/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
@@ -13,101 +13,167 @@ exports[`BisectDialog component renders 1`] = `
   >
     <Component>
       Earliest Version
-      <Blueprint3.Select
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
             Object {
-              "source": "local",
-              "state": "ready",
-              "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
             Object {
               "source": "local",
               "state": "ready",
               "version": "4.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "5.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
-      >
-        <Blueprint3.Button
-          fill={true}
-          icon="saved"
-          text="v4.0.0"
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
     <Component>
       Latest Version
-      <Blueprint3.Select
-        disabled={false}
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
             Object {
               "source": "local",
               "state": "ready",
               "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
-      >
-        <Blueprint3.Button
-          disabled={false}
-          fill={true}
-          icon="small-minus"
-          text=""
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
   </div>
   <div
@@ -147,111 +213,153 @@ exports[`BisectDialog component renders 2`] = `
   >
     <Component>
       Earliest Version
-      <Blueprint3.Select
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "4.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "5.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
+      <Blueprint3.ButtonGroup
+        fill={true}
       >
-        <Blueprint3.Button
-          fill={true}
-          icon="small-minus"
-          text=""
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
     <Component>
       Latest Version
-      <Blueprint3.Select
-        disabled={true}
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "4.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "5.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
+      <Blueprint3.ButtonGroup
+        fill={true}
       >
-        <Blueprint3.Button
-          disabled={true}
-          fill={true}
-          icon="small-minus"
-          text=""
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
   </div>
   <div
@@ -291,101 +399,160 @@ exports[`BisectDialog component renders 3`] = `
   >
     <Component>
       Earliest Version
-      <Blueprint3.Select
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
             Object {
-              "source": "local",
-              "state": "ready",
-              "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
             Object {
               "source": "local",
               "state": "ready",
               "version": "4.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "5.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
-      >
-        <Blueprint3.Button
-          fill={true}
-          icon="saved"
-          text="v4.0.0"
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
     <Component>
       Latest Version
-      <Blueprint3.Select
-        disabled={false}
-        filterable={true}
-        itemPredicate={[Function]}
-        itemRenderer={[Function]}
-        items={
-          Array [
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "1.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "2.0.0",
-            },
-            Object {
-              "source": "local",
-              "state": "ready",
-              "version": "3.0.0",
-            },
-          ]
-        }
-        noResults={
-          <Blueprint3.MenuItem
-            disabled={true}
-            multiline={false}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="No results."
-          />
-        }
-        onItemSelect={[Function]}
+      <Blueprint3.ButtonGroup
+        fill={true}
       >
-        <Blueprint3.Button
-          disabled={false}
-          fill={true}
-          icon="small-minus"
-          text=""
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          onVersionSelect={[Function]}
         />
-      </Blueprint3.Select>
+      </Blueprint3.ButtonGroup>
     </Component>
   </div>
   <div

--- a/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
@@ -1,31 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VersionSelect component handles corrupt data 1`] = `
-<Blueprint3.Select
-  disabled={false}
-  filterable={true}
-  itemPredicate={[Function]}
-  itemRenderer={[Function]}
-  noResults={
-    <Blueprint3.MenuItem
-      disabled={true}
-      multiline={false}
-      popoverProps={Object {}}
-      shouldDismissPopover={true}
-      text="No results."
-    />
-  }
-  onItemSelect={[Function]}
->
-  <Blueprint3.Button
-    className="version-chooser"
-    disabled={false}
-    icon="cloud"
-    text="Electron v1.0.0"
-  />
-</Blueprint3.Select>
-`;
-
 exports[`VersionSelect component renderItem() renders an item 1`] = `
 <Blueprint3.MenuItem
   active={true}

--- a/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VersionSelect component handles corrupt data 1`] = `
+<Blueprint3.Select
+  disabled={false}
+  filterable={true}
+  itemPredicate={[Function]}
+  itemRenderer={[Function]}
+  noResults={
+    <Blueprint3.MenuItem
+      disabled={true}
+      multiline={false}
+      popoverProps={Object {}}
+      shouldDismissPopover={true}
+      text="No results."
+    />
+  }
+  onItemSelect={[Function]}
+>
+  <Blueprint3.Button
+    className="version-chooser"
+    disabled={false}
+    icon="cloud"
+    text="Electron v1.0.0"
+  />
+</Blueprint3.Select>
+`;
+
+exports[`VersionSelect component renderItem() renders an item 1`] = `
+<Blueprint3.MenuItem
+  active={true}
+  disabled={false}
+  icon="cloud"
+  label="Not downloaded"
+  multiline={false}
+  onClick={[Function]}
+  popoverProps={Object {}}
+  shouldDismissPopover={true}
+  text={
+    Array [
+      "1.0.0",
+    ]
+  }
+/>
+`;
+
+exports[`VersionSelect component renders 1`] = `
+<Blueprint3.Select
+  disabled={false}
+  filterable={true}
+  itemPredicate={[Function]}
+  itemRenderer={[Function]}
+  noResults={
+    <Blueprint3.MenuItem
+      disabled={true}
+      multiline={false}
+      popoverProps={Object {}}
+      shouldDismissPopover={true}
+      text="No results."
+    />
+  }
+  onItemSelect={[Function]}
+>
+  <Blueprint3.Button
+    className="version-chooser"
+    disabled={false}
+    icon="cloud"
+    text="Electron v1.0.0"
+  />
+</Blueprint3.Select>
+`;

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
 import { ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
@@ -6,8 +6,8 @@ import { VersionChooser } from '../../../src/renderer/components/commands-versio
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
 
-const { ready, unknown, downloading } = ElectronVersionState;
-const { remote, local } = ElectronVersionSource;
+const { unknown } = ElectronVersionState;
+const { remote } = ElectronVersionSource;
 
 describe('VersionSelect component', () => {
   let store: any;
@@ -25,14 +25,17 @@ describe('VersionSelect component', () => {
   };
 
   beforeEach(() => {
+    const versions = {
+      ...mockVersions,
+      '3.1.3': undefined,
+      '1.0.0': { ...mockVersion1 },
+      '3.0.0-unsupported': { ...mockVersion2 }
+    };
+
     store = {
       version: '2.0.2',
-      versions: {
-        ...mockVersions,
-        '3.1.3': undefined,
-        '1.0.0': { ...mockVersion1 },
-        '3.0.0-unsupported': { ...mockVersion2 }
-      },
+      versionsToShow: Object.values(versions).filter((v) => !!v),
+      versions,
       channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
       statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       setVersion: jest.fn(),
@@ -47,5 +50,15 @@ describe('VersionSelect component', () => {
       <VersionChooser appState={store} />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('selects a new version', () => {
+    const wrapper = mount(
+      <VersionChooser appState={store} />
+    );
+
+    const onVersionSelect: any = wrapper.find('VersionSelect').prop('onVersionSelect');
+    onVersionSelect(mockVersion1);
+    expect(store.setVersion).toHaveBeenCalledWith(mockVersion1.version);
   });
 });

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -1,15 +1,15 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
-import { filterItem, getItemIcon, getItemLabel, renderItem, VersionChooser } from '../../../src/renderer/components/commands-version-chooser';
+import { ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { VersionChooser } from '../../../src/renderer/components/commands-version-chooser';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
 
 const { ready, unknown, downloading } = ElectronVersionState;
 const { remote, local } = ElectronVersionSource;
 
-describe('VersionChooser component', () => {
+describe('VersionSelect component', () => {
   let store: any;
 
   const mockVersion1 = {
@@ -33,7 +33,7 @@ describe('VersionChooser component', () => {
         '1.0.0': { ...mockVersion1 },
         '3.0.0-unsupported': { ...mockVersion2 }
       },
-      versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
+      channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
       statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       setVersion: jest.fn(),
       get currentElectronVersion() {
@@ -43,108 +43,9 @@ describe('VersionChooser component', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<VersionChooser appState={store} />);
+    const wrapper = shallow(
+      <VersionChooser appState={store} />
+    );
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('handles a change appropriately', () => {
-    const wrapper = shallow(<VersionChooser appState={store} />);
-    const instance: VersionChooser = wrapper.instance() as any;
-
-    instance.onItemSelect({ version: 'v2.0.1' } as any);
-
-    expect(store.setVersion).toHaveBeenCalledWith('v2.0.1');
-  });
-
-  it('handles corrupt data', () => {
-    store.version = 'blub';
-
-    const wrapper = shallow(<VersionChooser appState={store} />);
-
-    expect(wrapper).toMatchSnapshot();
-    expect(wrapper.html()).toContain('Electron v2.0.2');
-  });
-
-  describe('renderItem()', () => {
-    it('renders an item', () => {
-      const item = renderItem(mockVersion1, {
-        handleClick: () => ({}),
-        index: 0,
-        modifiers: { active: true, disabled: false, matchesPredicate: true },
-        query: ''
-      });
-
-      expect(item).toMatchSnapshot();
-    });
-
-    it('returns null if it does not match predicate', () => {
-      const item = renderItem(mockVersion1, {
-        handleClick: () => ({}),
-        index: 0,
-        modifiers: { active: true, disabled: false, matchesPredicate: false },
-        query: ''
-      });
-
-      expect(item).toBe(null);
-    });
-  });
-
-  describe('getItemLabel()', () => {
-    it('returns the correct label for a local version', () => {
-      const input: ElectronVersion = {
-        ...mockVersion1,
-        source: local,
-      };
-
-      expect(getItemLabel(input)).toBe('Local');
-      expect(getItemLabel({ ...input, name: 'Hi' })).toBe('Hi');
-    });
-
-    it('returns the correct label for a version not downloaded', () => {
-      const input: ElectronVersion = {
-        ...mockVersion1,
-        state: unknown
-      };
-
-      expect(getItemLabel(input)).toBe('Not downloaded');
-    });
-
-    it('returns the correct label for a version downloaded', () => {
-      const input: ElectronVersion = {
-        ...mockVersion1,
-        state: ready
-      };
-
-      expect(getItemLabel(input)).toBe('Downloaded');
-    });
-
-    it('returns the correct label for a version downloading', () => {
-      const input: ElectronVersion = {
-        ...mockVersion1,
-        state: downloading
-      };
-
-      expect(getItemLabel(input)).toBe('Downloading');
-    });
-  });
-
-  describe('getItemIcon()', () => {
-    it('returns the correct icon', () => {
-      const vDownloaded = { ...mockVersion1, state: ready };
-      expect(getItemIcon(vDownloaded)).toBe('saved');
-
-      const vDownloading = { ...mockVersion1, state: downloading };
-      expect(getItemIcon(vDownloading)).toBe('cloud-download');
-
-      const vUnknown = { ...mockVersion1, state: unknown };
-      expect(getItemIcon(vUnknown)).toBe('cloud');
-    });
-  });
-
-  describe('filterItem()', () => {
-    it('correctly matches a query', () => {
-      expect(filterItem('test', mockVersion1)).toBe(false);
-      expect(filterItem('1.0.0', mockVersion1)).toBe(true);
-    });
   });
 });

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -18,9 +18,12 @@ describe('BisectDialog component', () => {
     }));
 
   beforeEach(() => {
+    const versions = generateVersionRange(5);
+
     store = {
-      versions: generateVersionRange(5),
-      versionsToShow: [ElectronReleaseChannel.stable],
+      versions,
+      versionsToShow: versions,
+      channelsToShow: [ElectronReleaseChannel.stable],
       statesToShow: [ElectronVersionState.ready],
       setVersion: jest.fn()
     };
@@ -58,7 +61,7 @@ describe('BisectDialog component', () => {
       const wrapper = shallow(<BisectDialog appState={store} />);
       const instance: BisectDialog = wrapper.instance() as any;
 
-      expect(instance.state.startIndex).toBeUndefined();
+      expect(instance.state.startIndex).toBe(0);
       instance.onBeginSelect(store.versions[2]);
       expect(instance.state.startIndex).toBe(2);
     });
@@ -69,7 +72,7 @@ describe('BisectDialog component', () => {
       const wrapper = shallow(<BisectDialog appState={store} />);
       const instance: BisectDialog = wrapper.instance() as any;
 
-      expect(instance.state.endIndex).toBeUndefined();
+      expect(instance.state.endIndex).toBe(0);
       instance.onEndSelect(store.versions[2]);
       expect(instance.state.endIndex).toBe(2);
     });

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -54,6 +54,14 @@ describe('BisectDialog component', () => {
       allVersions: generateVersionRange(5)
     });
     expect(wrapper).toMatchSnapshot();
+
+    // Incorrect order
+    wrapper.setState({
+      startIndex: 3,
+      endIndex: 4,
+      allVersions: generateVersionRange(5)
+    });
+    expect(wrapper).toMatchSnapshot();
   });
 
   describe('onBeginSelect()', () => {

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -13,7 +13,7 @@ describe('ElectronSettings component', () => {
     store = {
       version: '2.0.1',
       versions: { ...mockVersions },
-      versionsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
+      channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
       statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
       downloadVersion: jest.fn(),
       removeVersion: jest.fn(),
@@ -178,7 +178,7 @@ describe('ElectronSettings component', () => {
         }
       });
 
-      expect(store.versionsToShow).toEqual([
+      expect(store.channelsToShow).toEqual([
         ElectronReleaseChannel.beta,
         ElectronReleaseChannel.nightly
       ]);

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -1,0 +1,136 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { filterItem, getItemIcon, getItemLabel, renderItem, VersionSelect } from '../../../src/renderer/components/version-select';
+import { ElectronReleaseChannel } from '../../../src/renderer/versions';
+import { mockVersions } from '../../mocks/electron-versions';
+
+const { ready, unknown, downloading } = ElectronVersionState;
+const { remote, local } = ElectronVersionSource;
+
+describe('VersionSelect component', () => {
+  let store: any;
+
+  const mockVersion1 = {
+    source: remote,
+    state: unknown,
+    version: '1.0.0'
+  };
+
+  const mockVersion2 = {
+    source: remote,
+    state: unknown,
+    version: '3.0.0-unsupported'
+  };
+
+  beforeEach(() => {
+    store = {
+      version: '2.0.2',
+      versions: {
+        ...mockVersions,
+        '3.1.3': undefined,
+        '1.0.0': { ...mockVersion1 },
+        '3.0.0-unsupported': { ...mockVersion2 }
+      },
+      channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
+      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
+      setVersion: jest.fn(),
+      get currentElectronVersion() {
+        return mockVersions['2.0.2'];
+      }
+    };
+  });
+
+  const onVersionSelect = () => ({});
+
+  it('renders', () => {
+    const wrapper = shallow(
+      <VersionSelect appState={store} currentVersion={mockVersion1} onVersionSelect={onVersionSelect} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('renderItem()', () => {
+    it('renders an item', () => {
+      const item = renderItem(mockVersion1, {
+        handleClick: () => ({}),
+        index: 0,
+        modifiers: { active: true, disabled: false, matchesPredicate: true },
+        query: ''
+      });
+
+      expect(item).toMatchSnapshot();
+    });
+
+    it('returns null if it does not match predicate', () => {
+      const item = renderItem(mockVersion1, {
+        handleClick: () => ({}),
+        index: 0,
+        modifiers: { active: true, disabled: false, matchesPredicate: false },
+        query: ''
+      });
+
+      expect(item).toBe(null);
+    });
+  });
+
+  describe('getItemLabel()', () => {
+    it('returns the correct label for a local version', () => {
+      const input: ElectronVersion = {
+        ...mockVersion1,
+        source: local,
+      };
+
+      expect(getItemLabel(input)).toBe('Local');
+      expect(getItemLabel({ ...input, name: 'Hi' })).toBe('Hi');
+    });
+
+    it('returns the correct label for a version not downloaded', () => {
+      const input: ElectronVersion = {
+        ...mockVersion1,
+        state: unknown
+      };
+
+      expect(getItemLabel(input)).toBe('Not downloaded');
+    });
+
+    it('returns the correct label for a version downloaded', () => {
+      const input: ElectronVersion = {
+        ...mockVersion1,
+        state: ready
+      };
+
+      expect(getItemLabel(input)).toBe('Downloaded');
+    });
+
+    it('returns the correct label for a version downloading', () => {
+      const input: ElectronVersion = {
+        ...mockVersion1,
+        state: downloading
+      };
+
+      expect(getItemLabel(input)).toBe('Downloading');
+    });
+  });
+
+  describe('getItemIcon()', () => {
+    it('returns the correct icon', () => {
+      const vDownloaded = { ...mockVersion1, state: ready };
+      expect(getItemIcon(vDownloaded)).toBe('saved');
+
+      const vDownloading = { ...mockVersion1, state: downloading };
+      expect(getItemIcon(vDownloading)).toBe('cloud-download');
+
+      const vUnknown = { ...mockVersion1, state: unknown };
+      expect(getItemIcon(vUnknown)).toBe('cloud');
+    });
+  });
+
+  describe('filterItem()', () => {
+    it('correctly matches a query', () => {
+      expect(filterItem('test', mockVersion1)).toBe(false);
+      expect(filterItem('1.0.0', mockVersion1)).toBe(true);
+    });
+  });
+});

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -66,7 +66,7 @@ class MockStore {
       version: '4.0.0-beta'
     }
   };
-  public versionsToShow = [ElectronReleaseChannel.stable];
+  public channelsToShow = [ElectronReleaseChannel.stable];
   public setVersion = jest.fn();
 }
 
@@ -188,7 +188,7 @@ describe('RemoteLoader', () => {
 
       const result = await instance.setElectronVersionWithRef('4.0.0-beta');
       expect(result).toBe(true);
-      expect(store.versionsToShow).toContain(ElectronReleaseChannel.beta);
+      expect(store.channelsToShow).toContain(ElectronReleaseChannel.beta);
     });
 
     it('does not load unsupported versions of Fiddle', async () => {


### PR DESCRIPTION
This PR improves the existing bisect helper by turning our "Electron Version Select" into a generic component that can be consumed by both the command bar as well as the bisect helper. I have a feeling that we'll need more of these in the future.

It also ensures that the bisect helper will show the same versions as the command bar as configured in the preferences.

(This PR _seems_ to add more lines than it deletes, but that's just snapshots. The code is _actually_ smaller)