### PR TITLE
feat: Add some help to the bisect

### DIFF
--- a/src/renderer/components/dialog-bisect.tsx
+++ b/src/renderer/components/dialog-bisect.tsx
@@ -92,7 +92,6 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
    * Can we get this show on the road?
    */
   get canSubmit(): boolean {
-    console.log(`Calculating cansubmit`);
     return this.state.startIndex > this.state.endIndex;
   }
 
@@ -220,7 +219,7 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
     // 1: 4.0.0
     // 2: 3.0.0
     // ...
-    return allVersions.indexOf(version) < endIndex;
+    return allVersions.indexOf(version) < endIndex + 1;
   }
 
   /**
@@ -232,6 +231,6 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
   public isLatestItemDisabled(version: ElectronVersion): boolean {
     const { allVersions, startIndex } = this.state;
 
-    return allVersions.indexOf(version) > startIndex;
+    return allVersions.indexOf(version) > startIndex - 1;
   }
 }

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -95,6 +95,7 @@ export interface VersionSelectProps {
   currentVersion: ElectronVersion;
   onVersionSelect: (version: ElectronVersion) => void;
   buttonGroupProps?: IButtonGroupProps;
+  itemDisabled?: keyof ElectronVersion | ((item: ElectronVersion, index: number) => boolean);
 }
 
 /**
@@ -107,7 +108,7 @@ export interface VersionSelectProps {
 @observer
 export class VersionSelect extends React.Component<VersionSelectProps, VersionSelectState> {
   public render() {
-    const { currentVersion } = this.props;
+    const { currentVersion, itemDisabled } = this.props;
     const { version } = currentVersion;
 
     return (
@@ -116,6 +117,7 @@ export class VersionSelect extends React.Component<VersionSelectProps, VersionSe
         items={this.props.appState.versionsToShow}
         itemRenderer={renderItem}
         itemPredicate={filterItem}
+        itemDisabled={itemDisabled}
         onItemSelect={this.props.onVersionSelect}
         noResults={<MenuItem disabled={true} text='No results.' />}
         disabled={!!this.props.disabled}

--- a/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
@@ -11,8 +11,35 @@ exports[`BisectDialog component renders 1`] = `
   <div
     className="bp3-dialog-body"
   >
+    <Blueprint3.Callout
+      style={
+        Object {
+          "marginBottom": "1rem",
+          "marginTop": 0,
+        }
+      }
+    >
+      <p>
+        A "bisect" is a popular method 
+        <a
+          href="https://git-scm.com/docs/git-bisect"
+          target="_blank"
+        >
+          borrowed from 
+          <code>
+            git
+          </code>
+        </a>
+         for learning which version of Electron introduced a bug. This tool helps you perform a bisect.
+      </p>
+      <Blueprint3.Button
+        icon="help"
+        onClick={[Function]}
+        text="Show help"
+      />
+    </Blueprint3.Callout>
     <Component>
-      Earliest Version
+      Earliest Version (Last "known good" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -89,12 +116,13 @@ exports[`BisectDialog component renders 1`] = `
               "version": "4.0.0",
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
     </Component>
     <Component>
-      Latest Version
+      Latest Version (First "known bad" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -171,6 +199,7 @@ exports[`BisectDialog component renders 1`] = `
               "version": "1.0.0",
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
@@ -183,7 +212,7 @@ exports[`BisectDialog component renders 1`] = `
       className="bp3-dialog-footer-actions"
     >
       <Blueprint3.Button
-        disabled={true}
+        disabled={false}
         icon="play"
         key="submit"
         onClick={[Function]}
@@ -211,8 +240,35 @@ exports[`BisectDialog component renders 2`] = `
   <div
     className="bp3-dialog-body"
   >
+    <Blueprint3.Callout
+      style={
+        Object {
+          "marginBottom": "1rem",
+          "marginTop": 0,
+        }
+      }
+    >
+      <p>
+        A "bisect" is a popular method 
+        <a
+          href="https://git-scm.com/docs/git-bisect"
+          target="_blank"
+        >
+          borrowed from 
+          <code>
+            git
+          </code>
+        </a>
+         for learning which version of Electron introduced a bug. This tool helps you perform a bisect.
+      </p>
+      <Blueprint3.Button
+        icon="help"
+        onClick={[Function]}
+        text="Show help"
+      />
+    </Blueprint3.Callout>
     <Component>
-      Earliest Version
+      Earliest Version (Last "known good" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -282,12 +338,13 @@ exports[`BisectDialog component renders 2`] = `
               ],
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
     </Component>
     <Component>
-      Latest Version
+      Latest Version (First "known bad" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -357,6 +414,7 @@ exports[`BisectDialog component renders 2`] = `
               ],
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
@@ -397,8 +455,35 @@ exports[`BisectDialog component renders 3`] = `
   <div
     className="bp3-dialog-body"
   >
+    <Blueprint3.Callout
+      style={
+        Object {
+          "marginBottom": "1rem",
+          "marginTop": 0,
+        }
+      }
+    >
+      <p>
+        A "bisect" is a popular method 
+        <a
+          href="https://git-scm.com/docs/git-bisect"
+          target="_blank"
+        >
+          borrowed from 
+          <code>
+            git
+          </code>
+        </a>
+         for learning which version of Electron introduced a bug. This tool helps you perform a bisect.
+      </p>
+      <Blueprint3.Button
+        icon="help"
+        onClick={[Function]}
+        text="Show help"
+      />
+    </Blueprint3.Callout>
     <Component>
-      Earliest Version
+      Earliest Version (Last "known good" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -475,12 +560,13 @@ exports[`BisectDialog component renders 3`] = `
               "version": "4.0.0",
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
     </Component>
     <Component>
-      Latest Version
+      Latest Version (First "known bad" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -550,6 +636,7 @@ exports[`BisectDialog component renders 3`] = `
               ],
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
@@ -590,8 +677,35 @@ exports[`BisectDialog component renders 4`] = `
   <div
     className="bp3-dialog-body"
   >
+    <Blueprint3.Callout
+      style={
+        Object {
+          "marginBottom": "1rem",
+          "marginTop": 0,
+        }
+      }
+    >
+      <p>
+        A "bisect" is a popular method 
+        <a
+          href="https://git-scm.com/docs/git-bisect"
+          target="_blank"
+        >
+          borrowed from 
+          <code>
+            git
+          </code>
+        </a>
+         for learning which version of Electron introduced a bug. This tool helps you perform a bisect.
+      </p>
+      <Blueprint3.Button
+        icon="help"
+        onClick={[Function]}
+        text="Show help"
+      />
+    </Blueprint3.Callout>
     <Component>
-      Earliest Version
+      Earliest Version (Last "known good" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -668,12 +782,13 @@ exports[`BisectDialog component renders 4`] = `
               "version": "4.0.0",
             }
           }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>
     </Component>
     <Component>
-      Latest Version
+      Latest Version (First "known bad" version)
       <Blueprint3.ButtonGroup
         fill={true}
       >
@@ -750,6 +865,237 @@ exports[`BisectDialog component renders 4`] = `
               "version": "5.0.0",
             }
           }
+          itemDisabled={[Function]}
+          onVersionSelect={[Function]}
+        />
+      </Blueprint3.ButtonGroup>
+    </Component>
+  </div>
+  <div
+    className="bp3-dialog-footer"
+  >
+    <div
+      className="bp3-dialog-footer-actions"
+    >
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        key="submit"
+        onClick={[Function]}
+        text="Begin"
+      />
+      <Blueprint3.Button
+        icon="cross"
+        key="cancel"
+        onClick={[Function]}
+        text="Cancel"
+      />
+    </div>
+  </div>
+</Blueprint3.Dialog>
+`;
+
+exports[`BisectDialog component renders 5`] = `
+<Blueprint3.Dialog
+  canOutsideClickClose={true}
+  className="dialog-add-version"
+  isOpen={false}
+  onClose={[Function]}
+  title="Start a bisect session"
+>
+  <div
+    className="bp3-dialog-body"
+  >
+    <Blueprint3.Callout
+      style={
+        Object {
+          "marginBottom": "1rem",
+          "marginTop": 0,
+        }
+      }
+    >
+      <p>
+        A "bisect" is a popular method 
+        <a
+          href="https://git-scm.com/docs/git-bisect"
+          target="_blank"
+        >
+          borrowed from 
+          <code>
+            git
+          </code>
+        </a>
+         for learning which version of Electron introduced a bug. This tool helps you perform a bisect.
+      </p>
+      <p>
+        First, write a fiddle that reproduces a bug or an issue. Then, select the earliest version to start your search with. Typically, that's the "last known good" version that did not have the bug. Then, select that latest version to end the search with, usually the "first known bad" version.
+      </p>
+      <p>
+        Once you begin your bisect, Fiddle will run your fiddle with a number of Electron versions, closing in on the version that introduced the bug. Once completed, you will know which Electron version introduced your issue.
+      </p>
+    </Blueprint3.Callout>
+    <Component>
+      Earliest Version (Last "known good" version)
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
+            Object {
+              "source": "local",
+              "state": "ready",
+              "version": "4.0.0",
+            }
+          }
+          itemDisabled={[Function]}
+          onVersionSelect={[Function]}
+        />
+      </Blueprint3.ButtonGroup>
+    </Component>
+    <Component>
+      Latest Version (First "known bad" version)
+      <Blueprint3.ButtonGroup
+        fill={true}
+      >
+        <VersionSelect
+          appState={
+            Object {
+              "channelsToShow": Array [
+                "Stable",
+              ],
+              "setVersion": [MockFunction],
+              "statesToShow": Array [
+                "ready",
+              ],
+              "versions": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+              "versionsToShow": Array [
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "1.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "2.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "3.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "4.0.0",
+                },
+                Object {
+                  "source": "local",
+                  "state": "ready",
+                  "version": "5.0.0",
+                },
+              ],
+            }
+          }
+          currentVersion={
+            Object {
+              "source": "local",
+              "state": "ready",
+              "version": "5.0.0",
+            }
+          }
+          itemDisabled={[Function]}
           onVersionSelect={[Function]}
         />
       </Blueprint3.ButtonGroup>

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -62,6 +62,10 @@ describe('BisectDialog component', () => {
       allVersions: generateVersionRange(5)
     });
     expect(wrapper).toMatchSnapshot();
+
+    // Help displayed
+    (wrapper.instance() as any).showHelp();
+    expect(wrapper).toMatchSnapshot();
   });
 
   describe('onBeginSelect()', () => {
@@ -69,7 +73,7 @@ describe('BisectDialog component', () => {
       const wrapper = shallow(<BisectDialog appState={store} />);
       const instance: BisectDialog = wrapper.instance() as any;
 
-      expect(instance.state.startIndex).toBe(0);
+      expect(instance.state.startIndex).toBe(10);
       instance.onBeginSelect(store.versions[2]);
       expect(instance.state.startIndex).toBe(2);
     });
@@ -106,7 +110,7 @@ describe('BisectDialog component', () => {
 
       const instance: BisectDialog = wrapper.instance() as any;
       await instance.onSubmit();
-      expect(Bisector).toHaveBeenCalledWith(versions.slice(0, 5).reverse());
+      expect(Bisector).toHaveBeenCalledWith(versions.slice(0, 5));
       expect(store.Bisector).toBeDefined();
       expect(store.setVersion).toHaveBeenCalledWith(version);
     });
@@ -126,10 +130,51 @@ describe('BisectDialog component', () => {
         startIndex: 4,
         endIndex: undefined
       });
+
       const instance2: BisectDialog = wrapper.instance() as any;
       await instance2.onSubmit();
       expect(Bisector).not.toHaveBeenCalled();
+    });
+  });
 
+  describe('items disabled', () => {
+    let instance: BisectDialog;
+
+    beforeEach(() => {
+      const wrapper = shallow(<BisectDialog appState={store} />);
+      instance = wrapper.instance() as any;
+    });
+
+    describe('isEarliestItemDisabled', () => {
+      it('enables a version older than the "latest version"', () => {
+        instance.setState({ endIndex: 2 });
+
+        const result = instance.isEarliestItemDisabled(store.versions[3]);
+        expect(result).toBeFalsy();
+      });
+
+      it('disables a version newer than the "latest version"', () => {
+        instance.setState({ endIndex: 2 });
+
+        const result = instance.isEarliestItemDisabled(store.versions[1]);
+        expect(result).toBeTruthy();
+      });
+    });
+
+    describe('isLatestItemDisabled', () => {
+      it('enables a version newer than the "earliest version"', () => {
+        instance.setState({ startIndex: 2 });
+
+        const result = instance.isLatestItemDisabled(store.versions[1]);
+        expect(result).toBeFalsy();
+      });
+
+      it('disables a version older than the "earliest version"', () => {
+        instance.setState({ startIndex: 2 });
+
+        const result = instance.isLatestItemDisabled(store.versions[4]);
+        expect(result).toBeTruthy();
+      });
     });
   });
 });


### PR DESCRIPTION
@erickzhao suggested, correctly, that the reorganization of code in #324 resulted in a bisect helper that wasn't _quite_ as helpful as it was before. I'm hoping that these suggestions go a bit above and beyond, making the result even more helpful than we had before - to make up for how I made it worse :wink:

Two things here: First, I added some actual help text. Secondly, the dropdowns now let you only select versions that make sense, ensuring that you never end up in a situation where you can't start the bisect. I left our sanity checks in there though, even if you should never be able to select versions that result in inability to start the bisect.

Help, by default mostly minimized:
![1](https://user-images.githubusercontent.com/1426799/74598979-0d4ca300-5030-11ea-8d6d-e426dd740e9d.png)

Then extended:
![2](https://user-images.githubusercontent.com/1426799/74598976-fd34c380-502f-11ea-9b5f-8ce69360253e.png)

Disabled versions:
![image](https://user-images.githubusercontent.com/1426799/74598982-0faefd00-5030-11ea-8045-9de119d527d0.png)

