### PR TITLE
feat: add CSS support

### DIFF
--- a/src/content/html.ts
+++ b/src/content/html.ts
@@ -3,6 +3,7 @@ export const html = `<!DOCTYPE html>
   <head>
     <meta charset="UTF-8">
     <title>Hello World!</title>
+    <link rel="stylesheet" type="text/css" href="./styles.css">
   </head>
   <body>
     <h1>Hello World!</h1>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface EditorValues {
   renderer: string;
   html: string;
   preload: string;
+  css: string;
   package?: string;
 }
 
@@ -72,7 +73,8 @@ export const enum EditorId {
   'main' = 'main',
   'renderer' = 'renderer',
   'html' = 'html',
-  'preload' = 'preload'
+  'preload' = 'preload',
+  'css' = 'css'
 }
 
 // Panels that can show up as a mosaic
@@ -82,9 +84,9 @@ export const enum PanelId {
 
 export type MosaicId = EditorId | PanelId;
 
-export const ALL_EDITORS =  [ EditorId.main, EditorId.renderer, EditorId.preload, EditorId.html ];
-export const ALL_PANELS = [ PanelId.docsDemo ];
-export const ALL_MOSAICS = [ ...ALL_EDITORS, ...ALL_PANELS ];
+export const ALL_EDITORS = [EditorId.main, EditorId.renderer, EditorId.preload, EditorId.html, EditorId.css];
+export const ALL_PANELS = [PanelId.docsDemo];
+export const ALL_MOSAICS = [...ALL_EDITORS, ...ALL_PANELS];
 
 export type ArrowPosition = 'top' | 'left' | 'bottom' | 'right';
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -133,6 +133,7 @@ export class App {
     }
 
     const values: EditorValues = {
+      css: getEditorValue(EditorId.css),
       html: getEditorValue(EditorId.html),
       main: getEditorValue(EditorId.main),
       preload: getEditorValue(EditorId.preload),

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { when } from 'mobx';
 import { IpcEvents } from '../../ipc-events';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLES_CSS_NAME } from '../../shared-constants';
 import { getOctokit } from '../../utils/octokit';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
@@ -89,6 +89,9 @@ export class PublishButton extends React.Component<PublishButtonProps> {
           },
           [PRELOAD_JS_NAME]: {
             content: values.preload || '// Empty',
+          },
+          [STYLES_CSS_NAME]: {
+            content: values.css || '/* Empty */',
           },
         },
       } as any); // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -28,7 +28,17 @@ export class Editor extends React.Component<EditorProps> {
 
   constructor(props: EditorProps) {
     super(props);
-    this.language = props.id === 'html' ? 'html' : 'javascript';
+
+    switch(props.id) {
+      case 'html':
+        this.language = 'html';
+        break;
+      case 'css':
+        this.language = 'css';
+        break;
+      default:
+        this.language = 'javascript';
+    }
   }
 
   public shouldComponentUpdate() {

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -32,6 +32,7 @@ export const TITLE_MAP: Record<MosaicId, string> = {
   renderer: 'Renderer Process (renderer.js)',
   preload: 'Preload (preload.js)',
   html: 'HTML (index.html)',
+  css: 'Stylesheet (styles.css)',
   docsDemo: 'Docs & Demos',
 };
 

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -22,7 +22,8 @@ export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<MosaicId> = {
 
 export const DEFAULT_CLOSED_PANELS: Partial<Record<MosaicId, EditorBackup | true>> = {
   docsDemo: true,
-  preload: {}
+  preload: {},
+  css: {}
 };
 
 export const ELECTRON_ORG = 'electron';

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { EditorValues, Files, FileTransform } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, PACKAGE_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PACKAGE_NAME, PRELOAD_JS_NAME, STYLES_CSS_NAME, RENDERER_JS_NAME } from '../shared-constants';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
 import { fancyImport } from '../utils/import';
 import { ipcRendererManager } from './ipc';
@@ -63,6 +63,7 @@ export class FileManager {
       main: await this.readFile(path.join(filePath, MAIN_JS_NAME)),
       renderer: await this.readFile(path.join(filePath, RENDERER_JS_NAME)),
       preload: await this.readFile(path.join(filePath, PRELOAD_JS_NAME)),
+      css: await this.readFile(path.join(filePath, STYLES_CSS_NAME))
     };
 
 
@@ -126,6 +127,7 @@ export class FileManager {
     output.set(MAIN_JS_NAME, values.main);
     output.set(INDEX_HTML_NAME, values.html);
     output.set(PRELOAD_JS_NAME, values.preload);
+    output.set(STYLES_CSS_NAME, values.css);
     output.set(PACKAGE_NAME, values.package!);
 
     for (const transform of transforms) {

--- a/src/renderer/templates.ts
+++ b/src/renderer/templates.ts
@@ -2,7 +2,7 @@ import * as fsExtraType from 'fs-extra';
 import * as pathType from 'path';
 
 import { EditorValues } from '../interfaces';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLES_CSS_NAME } from '../shared-constants';
 import { fancyImport } from '../utils/import';
 
 /**
@@ -41,6 +41,7 @@ export async function getTemplateValues(name: string): Promise<EditorValues> {
     renderer: await getFile(RENDERER_JS_NAME),
     main: await getFile(MAIN_JS_NAME),
     html: await getFile(INDEX_HTML_NAME),
-    preload: await getFile(PRELOAD_JS_NAME)
+    preload: await getFile(PRELOAD_JS_NAME),
+    css: await getFile(STYLES_CSS_NAME)
   };
 }

--- a/src/shared-constants.ts
+++ b/src/shared-constants.ts
@@ -2,4 +2,5 @@ export const INDEX_HTML_NAME = 'index.html';
 export const MAIN_JS_NAME = 'main.js';
 export const RENDERER_JS_NAME = 'renderer.js';
 export const PRELOAD_JS_NAME = 'preload.js';
+export const STYLES_CSS_NAME = 'styles.css'
 export const PACKAGE_NAME = 'package.json';

--- a/tests/mocks/app.ts
+++ b/tests/mocks/app.ts
@@ -10,7 +10,8 @@ export class AppMock {
     main: 'main-content',
     preload: 'preload-content',
     renderer: 'renderer-content',
-    html: 'html-content'
+    html: 'html-content',
+    css: 'css-content'
   }));
 
   public setupTheme = jest.fn();

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -290,18 +290,21 @@ describe('Editors component', () => {
         model: { setValue: jest.fn() }
       };
       app.state.closedPanels.preload = {};
+      app.state.closedPanels.css = {};
 
       app.setEditorValues({
         html: 'html-value',
         main: 'main-value',
         renderer: 'renderer-value',
-        preload: 'preload-value'
+        preload: 'preload-value',
+        css: 'css-value'
       });
 
       expect(
         (app.state.closedPanels.main as EditorBackup)!.model!.setValue
       ).toHaveBeenCalledWith('main-value');
       expect(app.state.closedPanels.preload).toEqual({ value: 'preload-value' });
+      expect(app.state.closedPanels.css).toEqual({ value: 'css-value' });
 
       window.ElectronFiddle.editors.main = oldMainEditor;
     });

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -47,6 +47,16 @@ exports[`EditorDropdown component renders 1`] = `
           shouldDismissPopover={true}
           text="HTML (index.html)"
         />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-off"
+          id="css"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Stylesheet (styles.css)"
+        />
       </Blueprint3.Menu>
     }
     defaultIsOpen={false}
@@ -127,6 +137,16 @@ exports[`EditorDropdown component renders the extra button if the FIDDLE_DOCS_DE
           popoverProps={Object {}}
           shouldDismissPopover={true}
           text="HTML (index.html)"
+        />
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="eye-off"
+          id="css"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Stylesheet (styles.css)"
         />
       </Blueprint3.Menu>
     }

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -185,7 +185,7 @@ exports[`Editors component renders 1`] = `
       key="renderer"
       style={
         Object {
-          "bottom": "0%",
+          "bottom": "25%",
           "left": "0%",
           "right": "50%",
           "top": "50%",
@@ -338,14 +338,14 @@ exports[`Editors component renders 1`] = `
       </div>
     </div>
     <div
-      className="mosaic-split -row"
+      className="mosaic-split -column"
       onMouseDown={[Function]}
       style={
         Object {
           "bottom": "0%",
-          "left": "50%",
-          "right": "0%",
-          "top": "0%",
+          "left": "0%",
+          "right": "50%",
+          "top": "75%",
         }
       }
     >
@@ -358,10 +358,10 @@ exports[`Editors component renders 1`] = `
       key="preload"
       style={
         Object {
-          "bottom": "50%",
-          "left": "50%",
-          "right": "0%",
-          "top": "0%",
+          "bottom": "0%",
+          "left": "0%",
+          "right": "50%",
+          "top": "75%",
         }
       }
     >
@@ -511,14 +511,14 @@ exports[`Editors component renders 1`] = `
       </div>
     </div>
     <div
-      className="mosaic-split -column"
+      className="mosaic-split -row"
       onMouseDown={[Function]}
       style={
         Object {
           "bottom": "0%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "0%",
         }
       }
     >
@@ -531,10 +531,10 @@ exports[`Editors component renders 1`] = `
       key="html"
       style={
         Object {
-          "bottom": "25%",
+          "bottom": "50%",
           "left": "50%",
           "right": "0%",
-          "top": "50%",
+          "top": "0%",
         }
       }
     >
@@ -642,6 +642,179 @@ exports[`Editors component renders 1`] = `
           >
             <h4>
               HTML (index.html)
+            </h4>
+            <span
+              className="bp3-icon bp3-icon-application"
+              icon="application"
+            >
+              <svg
+                data-icon="application"
+                height={72}
+                viewBox="0 0 20 20"
+                width={72}
+              >
+                <desc>
+                  application
+                </desc>
+                <path
+                  d="M3.5 9h9c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-9c-.28 0-.5.22-.5.5s.22.5.5.5zm0 2h5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-5c-.28 0-.5.22-.5.5s.22.5.5.5zM19 1H1c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm-1 16H2V6h16v11zM3.5 13h7c.28 0 .5-.22.5-.5s-.22-.5-.5-.5h-7c-.28 0-.5.22-.5.5s.22.5.5.5z"
+                  fillRule="evenodd"
+                  key="0"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          className="drop-target-container"
+        >
+          <div
+            className="drop-target top"
+          />
+          <div
+            className="drop-target bottom"
+          />
+          <div
+            className="drop-target left"
+          />
+          <div
+            className="drop-target right"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="mosaic-split -column"
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "bottom": "0%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
+        }
+      }
+    >
+      <div
+        className="mosaic-split-line"
+      />
+    </div>
+    <div
+      className="mosaic-tile"
+      key="css"
+      style={
+        Object {
+          "bottom": "25%",
+          "left": "50%",
+          "right": "0%",
+          "top": "50%",
+        }
+      }
+    >
+      <div
+        className="mosaic-window mosaic-drop-target css"
+      >
+        <div
+          className="mosaic-window-toolbar draggable"
+        >
+          <div>
+            <div>
+              <h5>
+                Stylesheet (styles.css)
+              </h5>
+            </div>
+            <div />
+            <div
+              className="mosaic-controls"
+            >
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-maximize"
+                  icon="maximize"
+                >
+                  <svg
+                    data-icon="maximize"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      maximize
+                    </desc>
+                    <path
+                      d="M5.99 8.99c-.28 0-.53.11-.71.29l-3.29 3.29v-1.59c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1h4c.55 0 1-.45 1-1s-.45-1-1-1H3.41L6.7 10.7a1.003 1.003 0 00-.71-1.71zm9-9h-4c-.55 0-1 .45-1 1s.45 1 1 1h1.59l-3.3 3.3a.99.99 0 00-.29.7 1.003 1.003 0 001.71.71l3.29-3.29V5c0 .55.45 1 1 1s1-.45 1-1V1c0-.56-.45-1.01-1-1.01z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="bp3-button bp3-small"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-icon bp3-icon-cross"
+                  icon="cross"
+                >
+                  <svg
+                    data-icon="cross"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      cross
+                    </desc>
+                    <path
+                      d="M9.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L8 6.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42L6.59 8 3.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71L8 9.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L9.41 8z"
+                      fillRule="evenodd"
+                      key="0"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="mosaic-window-body"
+        >
+          Editor
+        </div>
+        <div
+          className="mosaic-window-body-overlay"
+          onClick={[Function]}
+        />
+        <div
+          className="mosaic-window-additional-actions-bar"
+        />
+        <div
+          className="mosaic-preview"
+        >
+          <div
+            className="mosaic-window-toolbar"
+          >
+            <div
+              className="mosaic-window-title"
+            >
+              Stylesheet (styles.css)
+            </div>
+          </div>
+          <div
+            className="mosaic-window-body"
+          >
+            <h4>
+              Stylesheet (styles.css)
             </h4>
             <span
               className="bp3-icon bp3-icon-application"
@@ -1038,14 +1211,18 @@ exports[`Editors component renders a toolbar 1`] = `
             "first": Object {
               "direction": "column",
               "first": "main",
-              "second": "renderer",
+              "second": Object {
+                "direction": "column",
+                "first": "renderer",
+                "second": "preload",
+              },
             },
             "second": Object {
               "direction": "column",
-              "first": "preload",
+              "first": "html",
               "second": Object {
                 "direction": "column",
-                "first": "html",
+                "first": "css",
                 "second": "docsDemo",
               },
             },
@@ -1066,14 +1243,18 @@ exports[`Editors component renders a toolbar 1`] = `
             "first": Object {
               "direction": "column",
               "first": "main",
-              "second": "renderer",
+              "second": Object {
+                "direction": "column",
+                "first": "renderer",
+                "second": "preload",
+              },
             },
             "second": Object {
               "direction": "column",
-              "first": "preload",
+              "first": "html",
               "second": Object {
                 "direction": "column",
-                "first": "html",
+                "first": "css",
                 "second": "docsDemo",
               },
             },

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -16,6 +16,7 @@ describe('Publish button component', () => {
       'renderer.js': { content: 'renderer-content' },
       'main.js': { content: 'main-content' },
       'preload.js': { content: 'preload-content' },
+      'styles.css': { content: 'css-content' },
     },
     public: true
   };
@@ -74,6 +75,7 @@ describe('Publish button component', () => {
         'renderer.js': { content: 'renderer-content' },
         'main.js': { content: 'main-content' },
         'preload.js': { content: 'preload-content' },
+        'styles.css': { content: 'css-content' },
       },
       public: true
     });
@@ -102,7 +104,8 @@ describe('Publish button component', () => {
         'index.html': { content: '<!-- Empty -->' },
         'renderer.js': { content: '// Empty' },
         'main.js': { content: '// Empty' },
-        'preload.js': { content: '// Empty' }
+        'preload.js': { content: '// Empty' },
+        'styles.css': { content: '/* Empty */' },
       },
       public: true
     });

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -58,6 +58,13 @@ describe('Editor component', () => {
     );
 
     expect((wrapper.instance() as any).language).toBe('html');
+
+    wrapper = shallow(
+      <Editor appState={store} monaco={monaco} monacoOptions={{}} id={EditorId.css} setFocused={() => undefined} />
+    );
+
+    expect((wrapper.instance() as any).language).toBe('css');
+
   });
 
   it('denies updates', () => {

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -61,6 +61,7 @@ describe('FileManager', () => {
         renderer: '',
         preload: '',
         main: '',
+        css: ''
       }, {filePath: fakePath});
     });
 
@@ -82,12 +83,12 @@ describe('FileManager', () => {
   });
 
   describe('saveFiddle()', () => {
-    it('saves as a local fiddle', async () => {
+    it('saves all non-empty files in Fiddle', async () => {
       const fs = require('fs-extra');
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(4);
+      expect(fs.outputFile).toHaveBeenCalledTimes(5);
     });
 
     it('removes a file that is newly empty', async () => {
@@ -106,8 +107,8 @@ describe('FileManager', () => {
 
       await fm.saveFiddle('/fake/path');
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(4);
-      expect(ipcRendererManager.send).toHaveBeenCalledTimes(4);
+      expect(fs.outputFile).toHaveBeenCalledTimes(5);
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(5);
     });
 
     it('handles an error (remove)', async () => {
@@ -150,7 +151,7 @@ describe('FileManager', () => {
 
       await fm.saveToTemp({ includeDependencies: false, includeElectron: false });
 
-      expect(fs.outputFile).toHaveBeenCalledTimes(5);
+      expect(fs.outputFile).toHaveBeenCalledTimes(6);
       expect(tmp.setGracefulCleanup).toHaveBeenCalled();
     });
 

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -87,7 +87,8 @@ describe('npm', () => {
         html: '',
         main: mockMain,
         renderer: '',
-        preload: ''
+        preload: '',
+        css: ''
       });
 
       expect(result).toEqual(['say']);

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -3,25 +3,28 @@ import { GenericDialogType } from '../../src/interfaces';
 import { ipcRendererManager } from '../../src/renderer/ipc';
 import { RemoteLoader } from '../../src/renderer/remote-loader';
 import { ElectronReleaseChannel } from '../../src/renderer/versions';
-import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME } from '../../src/shared-constants';
+import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLES_CSS_NAME } from '../../src/shared-constants';
 import { getOctokit } from '../../src/utils/octokit';
 import { ElectronFiddleMock } from '../mocks/electron-fiddle';
 
 jest.mock('../../src/utils/octokit');
 
 const mockGistFiles = {
-    [RENDERER_JS_NAME]: {
-      content: 'renderer-content'
-    },
-    [MAIN_JS_NAME]: {
-      content: 'main-content'
-    },
-    [INDEX_HTML_NAME]: {
-      content: 'html'
-    },
-    [PRELOAD_JS_NAME]: {
-      content: 'preload'
-    }
+  [RENDERER_JS_NAME]: {
+    content: 'renderer-content'
+  },
+  [MAIN_JS_NAME]: {
+    content: 'main-content'
+  },
+  [INDEX_HTML_NAME]: {
+    content: 'html'
+  },
+  [PRELOAD_JS_NAME]: {
+    content: 'preload'
+  },
+  [STYLES_CSS_NAME]: {
+    content: 'css'
+  }
 };
 
 const mockGetGists = {
@@ -42,6 +45,9 @@ const mockRepos = [
   }, {
     name: INDEX_HTML_NAME,
     download_url: 'https://html'
+  }, {
+    name: STYLES_CSS_NAME,
+    download_url: 'https://css'
   }, {
     name: 'other_stuff',
     download_url: 'https://google.com'
@@ -99,7 +105,8 @@ describe('RemoteLoader', () => {
         main: mockGistFiles[MAIN_JS_NAME].content,
         renderer: mockGistFiles[RENDERER_JS_NAME].content,
         preload: mockGistFiles[PRELOAD_JS_NAME].content,
-      }, {gistId: 'abcdtestid'});
+        css: mockGistFiles[STYLES_CSS_NAME].content
+      }, { gistId: 'abcdtestid' });
     });
 
     it('handles an error', async () => {
@@ -121,9 +128,10 @@ describe('RemoteLoader', () => {
       instance.setElectronVersionWithRef = jest.fn().mockReturnValueOnce(true);
       // Setup the mock
       (fetch as any).mockResponses(
-        [ 'main' ],
-        [ 'renderer' ],
-        [ 'index' ]
+        ['main'],
+        ['renderer'],
+        ['index'],
+        ['css']
       );
     });
 
@@ -135,12 +143,12 @@ describe('RemoteLoader', () => {
       const { calls } = (window.ElectronFiddle.app.replaceFiddle as jest.Mock).mock;
 
       expect(calls).toHaveLength(1);
-      expect(calls[0]).toMatchObject(expect.arrayContaining([{
+      expect(calls[0]).toMatchObject(expect.arrayContaining([expect.objectContaining({
         html: 'index',
         main: 'main',
         renderer: 'renderer',
-        preload: ''
-      }]));
+        css: 'css'
+      })]));
     });
 
     it('handles an error', async () => {

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -262,7 +262,8 @@ describe('Runner component', () => {
         html: '',
         main: `const a = require('say')`,
         renderer: '',
-        preload: ''
+        preload: '',
+        css: ''
       }, '/fake/path');
 
       expect(installModules).toHaveBeenCalledTimes(0);
@@ -276,7 +277,8 @@ describe('Runner component', () => {
         html: '',
         main: `const a = require('say')`,
         renderer: '',
-        preload: ''
+        preload: '',
+        css: ''
       }, '/fake/path');
 
       expect(installModules).toHaveBeenCalledTimes(1);

--- a/tests/renderer/templates-spec.ts
+++ b/tests/renderer/templates-spec.ts
@@ -44,8 +44,8 @@ describe('templates', () => {
       fs.existsSync.mockReturnValue(true);
 
       await getTemplateValues('test');
-      expect(fs.existsSync).toHaveBeenCalledTimes(4);
-      expect(fs.readdirSync).toHaveBeenCalledTimes(4);
+      expect(fs.existsSync).toHaveBeenCalledTimes(5);
+      expect(fs.readdirSync).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/tests/utils/get-package-spec.ts
+++ b/tests/utils/get-package-spec.ts
@@ -16,7 +16,8 @@ describe('get-package', () => {
       main: 'app.goDoTheThing()',
       renderer: `const say = require('say')`,
       html: '<html />',
-      preload: 'preload'
+      preload: 'preload',
+      css: 'body { color: black }'
     });
 
     expect(result).toEqual(JSON.stringify({
@@ -45,7 +46,8 @@ describe('get-package', () => {
       main: 'app.goDoTheThing()',
       renderer: `const say = require('say')`,
       html: '<html />',
-      preload: 'preload'
+      preload: 'preload',
+      css: 'body { color: black }'
     }, {
       includeElectron: true,
       includeDependencies: true


### PR DESCRIPTION
Closes #298 

This PR builds upon the work done in #254, #292, and #293, mirroring what we did to support `preload.js` to incorporate a `styles.css` file.

(This also means that any future bugs found with `preload` probably apply to `css` as well 😂)

This feature will be helpful for app developers looking to use Fiddle as a playground for app ideas beyond merely testing API functionality.