### PR TITLE
fix: remove broken "Reload" menu item

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -247,7 +247,9 @@ export function setupMenu() {
 
       // Tweak "View" menu
       if (label === 'View' && isSubmenu(item.submenu)) {
-        item.submenu = item.submenu.filter((subItem) => subItem.label !== 'Toggle Developer Tools'); // Remove "Toggle Developer Tools"
+        // remove "Reload" (has weird behaviour) and "Toggle Developer Tools"
+        item.submenu = item.submenu
+          .filter((subItem) => subItem.label !== 'Toggle Developer Tools' && subItem.label !== 'Reload');
         item.submenu.push({ type: 'separator' }, { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' }); // Add zooming actions
         item.submenu.push({ type: 'separator' }, {
           label: 'Toggle Soft Wrap',


### PR DESCRIPTION
I hit <kbd>⌘+R</kbd> once and realized that the Reload function has very wonky behaviour. Also, not much use. This PR removes the menu item.

* When reloading from a clean save state, the editors revert to the default fiddle (regardless if you have a saved gist or locally saved fiddle open).
![out1](https://user-images.githubusercontent.com/16010076/75060531-d5ac8380-5493-11ea-9e23-87800a0b9c5c.gif)
* When reloading from an unclean save state, you get a "quit" prompt, and Fiddle closes if you accept.
![out1](https://user-images.githubusercontent.com/16010076/75060613-fffe4100-5493-11ea-9574-a6ef601a8557.gif)


