### PR TITLE
chore: Unregister various listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "parcel:watch": "node ./tools/parcel-watch.js",
     "publish": "electron-forge publish",
     "start": "rimraf ./dist && electron-forge start",
-    "test": "jest --config=jest.json --coverage",
+    "test": "jest --config=jest.json",
     "test:ci": "jest --config=jest.json --coverage --runInBand",
     "test:coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "tsc": "node ./tools/tsc.js",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -20,6 +20,7 @@ export class IpcMainManager extends EventEmitter {
     super();
 
     ipcMainEvents.forEach((name) => {
+      ipcMain.removeAllListeners(name);
       ipcMain.on(name, (...args: Array<any>) => this.emit(name, ...args));
     });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/electron';
-Sentry.init({dsn: 'https://966a5b01ac8d4941b81e4ebd0ab4c991@sentry.io/1882540'});
+import { initSentry } from '../sentry';
+initSentry();
 
 import { app } from 'electron';
 

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -76,6 +76,7 @@ export const listenForProtocolHandler = () => {
   const gotTheLock = app.requestSingleInstanceLock();
   if (!gotTheLock) app.quit();
 
+  app.removeAllListeners('open-url');
   app.on('open-url', (_, url) => {
     if (url.startsWith(`${PROTOCOL}://`)) {
       handlePotentialProtocolLaunch(url);

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/electron';
-Sentry.init({dsn: 'https://966a5b01ac8d4941b81e4ebd0ab4c991@sentry.io/1882540'});
+import { initSentry } from '../sentry';
+initSentry();
 
 import { when } from 'mobx';
 import * as MonacoType from 'monaco-editor';

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -34,6 +34,10 @@ export class PublishButton extends React.Component<PublishButtonProps> {
     ipcRendererManager.on(IpcEvents.FS_SAVE_FIDDLE_GIST, this.handleClick);
   }
 
+  public componentWillUnmount() {
+    ipcRendererManager.off(IpcEvents.FS_SAVE_FIDDLE_GIST, this.handleClick);
+  }
+
   /**
    * When the user clicks the publish button, we either show the
    * authentication dialog or publish right away.

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -98,6 +98,10 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
 
   public componentWillUnmount() {
     this.disposeLayoutAutorun();
+
+    ipcRendererManager.removeAllListeners(IpcEvents.MONACO_EXECUTE_COMMAND);
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_NEW_FIDDLE);
+    ipcRendererManager.removeAllListeners(IpcEvents.MONACO_TOGGLE_OPTION);
   }
 
   /**

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -17,6 +17,11 @@ export class FileManager {
     this.openFiddle = this.openFiddle.bind(this);
     this.saveFiddle = this.saveFiddle.bind(this);
 
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_OPEN_FIDDLE);
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_OPEN_TEMPLATE);
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_SAVE_FIDDLE);
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_SAVE_FIDDLE_FORGE);
+
     ipcRendererManager.on(IpcEvents.FS_OPEN_FIDDLE, (_event, filePath) => {
       this.openFiddle(filePath);
     });

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -15,6 +15,7 @@ export class IpcRendererManager extends EventEmitter {
     super();
 
     ipcRendererEvents.forEach((name) => {
+      ipcRenderer.removeAllListeners(name);
       ipcRenderer.on(name, (...args: Array<any>) => this.emit(name, ...args));
     });
   }

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -22,6 +22,11 @@ export class Runner {
     this.run = this.run.bind(this);
     this.stop = this.stop.bind(this);
 
+    ipcRendererManager.removeAllListeners(IpcEvents.FIDDLE_RUN);
+    ipcRendererManager.removeAllListeners(IpcEvents.FIDDLE_PACKAGE);
+    ipcRendererManager.removeAllListeners(IpcEvents.FIDDLE_MAKE);
+
+
     ipcRendererManager.on(IpcEvents.FIDDLE_RUN, this.run);
     ipcRendererManager.on(IpcEvents.FIDDLE_PACKAGE, () => {
       this.performForgeOperation(ForgeCommands.PACKAGE);

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -141,6 +141,11 @@ export class AppState {
     this.toggleBisectDialog = this.toggleBisectDialog.bind(this);
     this.updateElectronVersions = this.updateElectronVersions.bind(this);
 
+    ipcRendererManager.removeAllListeners(IpcEvents.OPEN_SETTINGS);
+    ipcRendererManager.removeAllListeners(IpcEvents.SHOW_WELCOME_TOUR);
+    ipcRendererManager.removeAllListeners(IpcEvents.CLEAR_CONSOLE);
+    ipcRendererManager.removeAllListeners(IpcEvents.BISECT_COMMANDS_TOGGLE);
+
     ipcRendererManager.on(IpcEvents.OPEN_SETTINGS, this.toggleSettings);
     ipcRendererManager.on(IpcEvents.SHOW_WELCOME_TOUR, this.showTour);
     ipcRendererManager.on(IpcEvents.CLEAR_CONSOLE, this.clearConsole);

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/electron';
+
+export function initSentry() {
+  if (!(global as any).__JEST__) {
+    Sentry.init({dsn: 'https://966a5b01ac8d4941b81e4ebd0ab4c991@sentry.io/1882540'});
+  }
+}

--- a/tests/main/context-menu-spec.ts
+++ b/tests/main/context-menu-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createContextMenu, getInspectItems, getMonacoItems, getRunItems } from '../../src/main/context-menu';
 import { ipcMainManager } from '../../src/main/ipc';
 import { isDevMode } from '../../src/utils/devmode';

--- a/tests/main/devtools-spec.ts
+++ b/tests/main/devtools-spec.ts
@@ -1,5 +1,10 @@
+/**
+ * @jest-environment node
+ */
+
 import { setupDevTools } from '../../src/main/devtools';
 import { isDevMode } from '../../src/utils/devmode';
+
 jest.mock('../../src/utils/devmode');
 
 jest.mock('electron-devtools-installer', () => ({

--- a/tests/main/dialogs-spec.ts
+++ b/tests/main/dialogs-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { IpcEvents } from '../../src/ipc-events';
 import { setupDialogs } from '../../src/main/dialogs';
 import { ipcMainManager } from '../../src/main/ipc';

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { IpcEvents } from '../../src/ipc-events';
 import {
   setupFileListeners,

--- a/tests/main/first-run-spec.ts
+++ b/tests/main/first-run-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { app, dialog } from 'electron';
 
 import { onFirstRunMaybe } from '../../src/main/first-run';

--- a/tests/main/ipc-spec.ts
+++ b/tests/main/ipc-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import * as electron from 'electron';
 import { IpcEvents } from '../../src/ipc-events';
 import { ipcMainManager } from '../../src/main/ipc';

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { app } from 'electron';
 
 import { main, onBeforeQuit, onReady, onWindowsAllClosed } from '../../src/main/main';

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import * as electron from 'electron';
 
 import { IpcEvents } from '../../src/ipc-events';

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { app } from 'electron';
 import * as fs from 'fs';
 

--- a/tests/main/squirrel-spec.ts
+++ b/tests/main/squirrel-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { shouldQuit } from '../../src/main/squirrel';
 
 jest.mock('electron-squirrel-startup', () => ({ mock: true }));

--- a/tests/main/update-spec.ts
+++ b/tests/main/update-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 jest.useFakeTimers();
 
 const mockUpdateApp = jest.fn();

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -1,6 +1,10 @@
+/**
+ * @jest-environment node
+ */
+
 import { createContextMenu } from '../../src/main/context-menu';
 import {
-  getMainWindowOptions, getOrCreateMainWindow
+  browserWindows, getMainWindowOptions, getOrCreateMainWindow
 } from '../../src/main/windows';
 import { overridePlatform, resetPlatform } from '../utils';
 

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -1,6 +1,6 @@
 import { createContextMenu } from '../../src/main/context-menu';
 import {
-  browserWindows, getMainWindowOptions, getOrCreateMainWindow
+  getMainWindowOptions, getOrCreateMainWindow
 } from '../../src/main/windows';
 import { overridePlatform, resetPlatform } from '../utils';
 

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -118,7 +118,9 @@ const app = {
   setJumpList: jest.fn(),
   requestSingleInstanceLock: jest.fn(),
   on: jest.fn(),
-  once: jest.fn()
+  off: jest.fn(),
+  once: jest.fn(),
+  removeAllListeners: jest.fn(),
 };
 
 const mainWindowStub = CreateWindowStub();

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -15,6 +15,13 @@ jest.mock('electron', () => require('./mocks/electron'));
 jest.mock('fs-extra');
 jest.mock('electron-download');
 
+// We want to detect jest sometimes
+global.__JEST__ = global.__JEST__ || {};
+
+// Setup for main tests
+global.window = global.window || {};
+global.document = global.document || { body: {} };
+
 delete window.localStorage;
 // We'll do this twice.
 window.localStorage = {};


### PR DESCRIPTION
This PR improves the speed and memory consumption of our tests considerably. It does by doing the following things:

- Main process tests are now run without setting up a whole `jsdom` environment
- We're now tearing down all listeners, even for components that never get unmounted in "real life". A good example here are the listeners on the `App` component.
- We're no longer initializing Sentry during tests.