### PR TITLE
build: auto-update the Electron Releases JSON file every day

### DIFF
--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -1,0 +1,41 @@
+name: Auto-update Releases JSON file
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v1
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm ci
+    - name: Update Releases JSON
+      run: npm run electron-releases
+    - name: Commit Changes to Releases JSON
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
+        chmod 600 ~/.netrc
+        git add static/releases.json
+        if test -n "$(git status -s)"; then
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "electron-bot@users.noreply.github.com"
+          git diff --cached
+          git commit -m "build: update Electron releases JSON"
+          git push origin HEAD:$GITHUB_REF
+        else
+          echo No update needed
+        fi


### PR DESCRIPTION
Follow-up from https://github.com/electron/fiddle/pull/330#discussion_r385443905, have Electron Bot (via GitHub Actions) automate adding new Electron releases to the JSON file.

Example run: https://github.com/malept/fiddle/runs/480768703?check_suite_focus=true (although on push instead of cron)
Example commit: https://github.com/electron/fiddle/commit/2ceadbbd7c125519f28a5c7f5f57d5aa8b1d1d4d