### PR TITLE
refactor: grab release list from unpkg

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,7 +14,7 @@ export enum ElectronVersionSource {
   remote = 'remote',
   local = 'local'
 }
-export interface NpmVersion {
+export interface Version {
   version: string;
   name?: string;
   localPath?: string;
@@ -29,7 +29,7 @@ export interface EditorValues {
   package?: string;
 }
 
-export interface ElectronVersion extends NpmVersion {
+export interface ElectronVersion extends Version {
   state: ElectronVersionState;
   source: ElectronVersionSource;
 }

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as React from 'react';
 import * as semver from 'semver';
 
-import { NpmVersion } from '../../interfaces';
+import { Version } from '../../interfaces';
 import { IpcEvents } from '../../ipc-events';
 import { getElectronNameForPlatform } from '../../utils/electron-name';
 import { ipcRendererManager } from '../ipc';
@@ -90,7 +90,7 @@ export class AddVersionDialog extends React.Component<AddVersionDialogProps, Add
       .slice(1)
       .join(path.sep);
 
-    const toAdd: NpmVersion = {
+    const toAdd: Version = {
       localPath: folderPath,
       version,
       name

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -12,7 +12,7 @@ import {
   GenericDialogOptions,
   GenericDialogType,
   MosaicId,
-  NpmVersion,
+  Version,
   OutputEntry,
   OutputOptions
 } from '../interfaces';
@@ -347,7 +347,7 @@ export class AppState {
     };
   }
 
-  @action public addLocalVersion(input: NpmVersion) {
+  @action public addLocalVersion(input: Version) {
     addLocalVersion(input);
 
     this.versions = arrayToStringMap(getElectronVersions());

--- a/tests/mocks/npm-response-nightlies.json
+++ b/tests/mocks/npm-response-nightlies.json
@@ -1,221 +1,255 @@
-{  
-  "_id":"electron-nightly",
-  "_rev":"39-dd135109793df50686b198663b6af607",
-  "name":"electron-nightly",
-  "dist-tags":{  
-    "latest":"7.0.0-nightly.20190704"
+{
+  "_id": "electron-nightly",
+  "_rev": "39-dd135109793df50686b198663b6af607",
+  "name": "electron-nightly",
+  "dist-tags": {
+    "latest": "7.0.0-nightly.20190704"
   },
-  "versions":{  
-    "7.0.0-nightly.20190529":{  
-      "main":"index.js",
-      "types":"electron.d.ts",
-      "bin":{  
-        "electron":"cli.js"
+  "versions": {
+    "0.0.0": {
+      "name": "electron-nightly",
+      "version": "0.0.0",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
       },
-      "scripts":{  
-        "postinstall":"node install.js"
+      "author": "",
+      "license": "ISC",
+      "_id": "electron-nightly@0.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "marshallofsound",
+        "email": "samuel.r.attard@gmail.com"
       },
-      "dependencies":{  
-        "@electron/get":"^1.0.1",
-        "@types/node":"^10.12.18",
-        "extract-zip":"^1.0.3"
+      "dist": {
+        "integrity": "sha512-oEBAnNUqDCsBdAFeEE1GDVuNTsPC84UnxjvSip0QnCG6N71wTCLGTanIQ395t6hfv5KLI0p0pnfhnW2Iviavuw==",
+        "shasum": "12628b65d30fabc4603842d8de2f3687e2c9b7ac",
+        "tarball": "https://registry.npmjs.org/electron-nightly/-/electron-nightly-0.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 212,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcBa78CRA9TVsSAnZWagAAjZ4P/25hG+EifXkJCa7nOtZ4\nax1m5EXFsoPCwye4jJhwrOsokTtxBwp5gvhmib1Bt6sKcy6WqB91o9FwOylp\ncw5ZMRcvSUydJt7MbohptjekT9dPGyFiWAMrTyvgQsPzM9wF6Z1YdhkWNGrn\noGgI4tQfd9f6AuaHLfNErKpV/nqdk0YXFnO4yDTatwSFP9Gl1PG6vY0fHld4\n6FUw9he9MeN7WKaIroOM2DxSaVkeK2Zbtx+H2HtMptp0NDkFfIePq3w35v0p\nQAm8V5CTrwWEe31Egp2lblDPEUgst2H8HC/l4mIoSkOa0z9/pyhuijkipdsE\nMEvBTjVJXLynoFBuPbWti2s26DMD7ieHtoDjGqSw3eTIE2qkm3N/DghEDo4J\nieOtFa+vosLWTT5SxEwcEQ8GkOfAeXMl8ydUbw0OiODx2EOmW+CHSLLkB6Cx\n97rbiriuAzp0AmPDVqeUsY4D34kWYCwOYaVaho+HbnzGtQEK8Ec+kKRzjx/U\n8jQXXmpbtp3D6sGIx3ykqEuW5ku6F/asarzGso0gWyjeCLqrS74k2i3r9dvd\nutTFgOoiET0Fyi474gB7cuxIvbRdk8b7WQN3GwoQY8YSEYf/1i9MNzrzgKfS\nctp/B5y46xxY6FFalYx4GskrGipBPLZRKhEIQyncWfTzAmBAZ/XSVHSfEUH0\nNuDI\r\n=r9Vj\r\n-----END PGP SIGNATURE-----\r\n"
       },
-      "engines":{  
-        "node":">= 8.6"
-      },
-      "name":"electron-nightly",
-      "version":"7.0.0-nightly.20190529",
-      "repository":{  
-        "type":"git",
-        "url":"git+https://github.com/electron/electron.git"
-      },
-      "description":"Build cross platform desktop apps with JavaScript, HTML, and CSS",
-      "license":"MIT",
-      "author":{  
-        "name":"Electron Community"
-      },
-      "keywords":[  
-        "electron"
-      ],
-      "_resolved":"",
-      "_integrity":"",
-      "_from":"file:/tmp/electron-npm119429-1761-mthe72.vpfro/electron-nightly-7.0.0-nightly.20190529.tgz",
-      "bugs":{  
-        "url":"https://github.com/electron/electron/issues"
-      },
-      "homepage":"https://github.com/electron/electron#readme",
-      "_id":"electron-nightly@7.0.0-nightly.20190529",
-      "_npmVersion":"6.4.1",
-      "_nodeVersion":"10.15.3",
-      "_npmUser":{  
-        "name":"electron-nightly",
-        "email":"info@electronjs.org"
-      },
-      "dist":{  
-        "integrity":"sha512-Jgkdi+a699SU+BIHDBnwN2MLREnYzhK+EP+ND584dHvneMhgc+40b+bR80QGZnYnv+WmFJitbSnAZZtCLLELUw==",
-        "shasum":"f51ed54268f4a1605dc2291e7a0cff63076a2c3c",
-        "tarball":"https://registry.npmjs.org/electron-nightly/-/electron-nightly-7.0.0-nightly.20190529.tgz",
-        "fileCount":7,
-        "unpackedSize":497378,
-        "npm-signature":"-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc7s4XCRA9TVsSAnZWagAAk/sP/jQWuved1eBio59cjbv6\nR/q8uSg+r+4SUx8yTwXlnUAInbvidvY5FtfGtgnQw8XD9TnzCDsBOIRHrdue\nX+Cja/vAdYn0OESn7G2FGEypW65KP8OmDTpVn0onRPr/0oSsiS+z27YYgmPL\nCW5L34yCcIVWhDBfJgzB8gtl8vE/UWvH0IvZjoRlqs5J9b9P0zOQGso9rWcd\naskp8JEZWIxp6aBk9GrYXWBT2NiBUqaKE/bqElz9GrAo6wmXjfZDdMEU0cg3\n7fHuK4tIyXPqMIa6/+csdhdARCQ9iLBgn1QVZXu9lhorF612em2LeMRrM1XO\n3Ac4hDCmwKrvk+GZwn8zVqZW7rsSoYI7uFBV285r0x6joqcQezyGxxDNILvg\nGl3bdmLzqQPaHjOqT+cghwkYFSza2xJlpERpwSpZCxcqSD1M+d5s4cxpkkY1\n6AkufKl8rPGUb/IGf8c9ZpN6ejnyoWDIMMhu+Bra/PnrCEnegnjXgxtkR06c\nXquXpIN0ErM2+dRG2n2MJ3RXg2tiZ0kwed0poGo9ukF8Mk/LxgULLJYIK1bR\nlWn6I6AUAPzC4f7o/kTi8S5ylV0Hzk1fMnj4pE8JTf7wZNGEr5mZj+fbzVdy\nRF5f+gn7MktFRizIlwYazgArV9OVJYg5UB9vKQnynCKFjIRquzuuSL58541Z\ne8PW\r\n=U4HL\r\n-----END PGP SIGNATURE-----\r\n"
-      },
-      "maintainers":[  
-        {  
-          "email":"info@electronjs.org",
-          "name":"electron-nightly"
-        },
-        {  
-          "email":"samuel.r.attard@gmail.com",
-          "name":"marshallofsound"
+      "maintainers": [
+        {
+          "name": "marshallofsound",
+          "email": "samuel.r.attard@gmail.com"
         }
       ],
-      "directories":{  
-
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/electron-nightly_0.0.0_1543876348316_0.3909768013193977"
       },
-      "_npmOperationalInternal":{  
-        "host":"s3://npm-registry-packages",
-        "tmp":"tmp/electron-nightly_7.0.0-nightly.20190529_1559154198863_0.4602392895148406"
-      },
-      "_hasShrinkwrap":false
+      "_hasShrinkwrap": false
     },
-    "7.0.0-nightly.20190704":{  
-      "main":"index.js",
-      "types":"electron.d.ts",
-      "bin":{  
-        "electron":"cli.js"
+    "7.0.0-nightly.20190529": {
+      "main": "index.js",
+      "types": "electron.d.ts",
+      "bin": {
+        "electron": "cli.js"
       },
-      "scripts":{  
-        "postinstall":"node install.js"
+      "scripts": {
+        "postinstall": "node install.js"
       },
-      "dependencies":{  
-        "@electron/get":"^1.0.1",
-        "@types/node":"^12.0.12",
-        "extract-zip":"^1.0.3"
+      "dependencies": {
+        "@electron/get": "^1.0.1",
+        "@types/node": "^10.12.18",
+        "extract-zip": "^1.0.3"
       },
-      "engines":{  
-        "node":">= 8.6"
+      "engines": {
+        "node": ">= 8.6"
       },
-      "name":"electron-nightly",
-      "version":"7.0.0-nightly.20190704",
-      "repository":{  
-        "type":"git",
-        "url":"git+https://github.com/electron/electron.git"
+      "name": "electron-nightly",
+      "version": "7.0.0-nightly.20190529",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/electron/electron.git"
       },
-      "description":"Build cross platform desktop apps with JavaScript, HTML, and CSS",
-      "license":"MIT",
-      "author":{  
-        "name":"Electron Community"
+      "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
+      "license": "MIT",
+      "author": {
+        "name": "Electron Community"
       },
-      "keywords":[  
+      "keywords": [
         "electron"
       ],
-      "_resolved":"",
-      "_integrity":"",
-      "_from":"file:/tmp/electron-npm11964-411-1ukz5oe.jvak/electron-nightly-7.0.0-nightly.20190704.tgz",
-      "bugs":{  
-        "url":"https://github.com/electron/electron/issues"
+      "_resolved": "",
+      "_integrity": "",
+      "_from": "file:/tmp/electron-npm119429-1761-mthe72.vpfro/electron-nightly-7.0.0-nightly.20190529.tgz",
+      "bugs": {
+        "url": "https://github.com/electron/electron/issues"
       },
-      "homepage":"https://github.com/electron/electron#readme",
-      "_id":"electron-nightly@7.0.0-nightly.20190704",
-      "_nodeVersion":"10.16.0",
-      "_npmVersion":"6.9.0",
-      "dist":{  
-        "integrity":"sha512-nTcQiwbkxwXqvlVhPACDSoBMbIi+2TwXz+e31/UB755kOVmSQiR53x+rFDUDA+YRdL6cwfe5+t3yESe9B66H0w==",
-        "shasum":"88b01159b26da35baee963dde9909cc5e349d7e0",
-        "tarball":"https://registry.npmjs.org/electron-nightly/-/electron-nightly-7.0.0-nightly.20190704.tgz",
-        "fileCount":7,
-        "unpackedSize":513721,
-        "npm-signature":"-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdHj5jCRA9TVsSAnZWagAAfrUP/2BoX5PsdDr1B9SEVYeu\nXFRcKGgVCjfRPXujpNB5k411YwSmnjGzOgZH5Gj06MoBKJysST4YHZHCuNhM\nb3yD+qEIo109SoxZbitPojBgaPiRMCbFewhmnwzmFOkyZAD/rRk7nwo/dK9O\nogsuns8lxKSOq+5nMXgxuirwfHxCsLYxSNUd9/c7C6hz0Jl+8xjZSEDgILte\nMsF0kz5M7atSsi28WT9gv90w1mAlBAmqoqI6IKv6mu7LDV/EncwdpInb4HOa\nIxqAx3BixQbtwG+Hsj3I625q4sZZcqsdc7I2sTEaPinNCuv1xga107Gy3BRl\ndalC1FTjxalCfOz59ehBXBIXteRY946c9Pdhg87txGQrLcEIGqGOAyPo9QNI\n6Qc1yUGGMYO2OnG8bDOaJn6j++bJ1xprgDI+Dn6KusNqqjBAIxVggzNqSYik\n8QnWiTgwCc8+643AIPQKN8zhTw4xGxyhTTCuIdCegsQbKKygGRHGkQOdqeLQ\n98tSHbtODPr99WOEspBpYFn8SHjNDohCKRoKHzFIHPHTa95TWeL89qonpq2e\nI8mjRse1bpsizQKED6N7cm3jA/rcSTSDGbDOtvmnA6WfNmsPbO9oziCiupgn\nDeEZ8JOUwoHJ3Mq8drp/wnbe48BdroxEk/aWDR9LFk/AwzyUmxx+/IyG10AP\nJii4\r\n=rW8C\r\n-----END PGP SIGNATURE-----\r\n"
+      "homepage": "https://github.com/electron/electron#readme",
+      "_id": "electron-nightly@7.0.0-nightly.20190529",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.3",
+      "_npmUser": {
+        "name": "electron-nightly",
+        "email": "info@electronjs.org"
       },
-      "maintainers":[  
-        {  
-          "email":"info@electronjs.org",
-          "name":"electron-nightly"
+      "dist": {
+        "integrity": "sha512-Jgkdi+a699SU+BIHDBnwN2MLREnYzhK+EP+ND584dHvneMhgc+40b+bR80QGZnYnv+WmFJitbSnAZZtCLLELUw==",
+        "shasum": "f51ed54268f4a1605dc2291e7a0cff63076a2c3c",
+        "tarball": "https://registry.npmjs.org/electron-nightly/-/electron-nightly-7.0.0-nightly.20190529.tgz",
+        "fileCount": 7,
+        "unpackedSize": 497378,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc7s4XCRA9TVsSAnZWagAAk/sP/jQWuved1eBio59cjbv6\nR/q8uSg+r+4SUx8yTwXlnUAInbvidvY5FtfGtgnQw8XD9TnzCDsBOIRHrdue\nX+Cja/vAdYn0OESn7G2FGEypW65KP8OmDTpVn0onRPr/0oSsiS+z27YYgmPL\nCW5L34yCcIVWhDBfJgzB8gtl8vE/UWvH0IvZjoRlqs5J9b9P0zOQGso9rWcd\naskp8JEZWIxp6aBk9GrYXWBT2NiBUqaKE/bqElz9GrAo6wmXjfZDdMEU0cg3\n7fHuK4tIyXPqMIa6/+csdhdARCQ9iLBgn1QVZXu9lhorF612em2LeMRrM1XO\n3Ac4hDCmwKrvk+GZwn8zVqZW7rsSoYI7uFBV285r0x6joqcQezyGxxDNILvg\nGl3bdmLzqQPaHjOqT+cghwkYFSza2xJlpERpwSpZCxcqSD1M+d5s4cxpkkY1\n6AkufKl8rPGUb/IGf8c9ZpN6ejnyoWDIMMhu+Bra/PnrCEnegnjXgxtkR06c\nXquXpIN0ErM2+dRG2n2MJ3RXg2tiZ0kwed0poGo9ukF8Mk/LxgULLJYIK1bR\nlWn6I6AUAPzC4f7o/kTi8S5ylV0Hzk1fMnj4pE8JTf7wZNGEr5mZj+fbzVdy\nRF5f+gn7MktFRizIlwYazgArV9OVJYg5UB9vKQnynCKFjIRquzuuSL58541Z\ne8PW\r\n=U4HL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "info@electronjs.org",
+          "name": "electron-nightly"
         },
-        {  
-          "email":"samuel.r.attard@gmail.com",
-          "name":"marshallofsound"
+        {
+          "email": "samuel.r.attard@gmail.com",
+          "name": "marshallofsound"
         }
       ],
-      "_npmUser":{  
-        "name":"electron-nightly",
-        "email":"info@electronjs.org"
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/electron-nightly_7.0.0-nightly.20190529_1559154198863_0.4602392895148406"
       },
-      "directories":{  
-
+      "_hasShrinkwrap": false
+    },
+    "7.0.0-nightly.20190704": {
+      "main": "index.js",
+      "types": "electron.d.ts",
+      "bin": {
+        "electron": "cli.js"
       },
-      "_npmOperationalInternal":{  
-        "host":"s3://npm-registry-packages",
-        "tmp":"tmp/electron-nightly_7.0.0-nightly.20190704_1562263137190_0.2784974234136546"
+      "scripts": {
+        "postinstall": "node install.js"
       },
-      "_hasShrinkwrap":false
+      "dependencies": {
+        "@electron/get": "^1.0.1",
+        "@types/node": "^12.0.12",
+        "extract-zip": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 8.6"
+      },
+      "name": "electron-nightly",
+      "version": "7.0.0-nightly.20190704",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/electron/electron.git"
+      },
+      "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
+      "license": "MIT",
+      "author": {
+        "name": "Electron Community"
+      },
+      "keywords": [
+        "electron"
+      ],
+      "_resolved": "",
+      "_integrity": "",
+      "_from": "file:/tmp/electron-npm11964-411-1ukz5oe.jvak/electron-nightly-7.0.0-nightly.20190704.tgz",
+      "bugs": {
+        "url": "https://github.com/electron/electron/issues"
+      },
+      "homepage": "https://github.com/electron/electron#readme",
+      "_id": "electron-nightly@7.0.0-nightly.20190704",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-nTcQiwbkxwXqvlVhPACDSoBMbIi+2TwXz+e31/UB755kOVmSQiR53x+rFDUDA+YRdL6cwfe5+t3yESe9B66H0w==",
+        "shasum": "88b01159b26da35baee963dde9909cc5e349d7e0",
+        "tarball": "https://registry.npmjs.org/electron-nightly/-/electron-nightly-7.0.0-nightly.20190704.tgz",
+        "fileCount": 7,
+        "unpackedSize": 513721,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdHj5jCRA9TVsSAnZWagAAfrUP/2BoX5PsdDr1B9SEVYeu\nXFRcKGgVCjfRPXujpNB5k411YwSmnjGzOgZH5Gj06MoBKJysST4YHZHCuNhM\nb3yD+qEIo109SoxZbitPojBgaPiRMCbFewhmnwzmFOkyZAD/rRk7nwo/dK9O\nogsuns8lxKSOq+5nMXgxuirwfHxCsLYxSNUd9/c7C6hz0Jl+8xjZSEDgILte\nMsF0kz5M7atSsi28WT9gv90w1mAlBAmqoqI6IKv6mu7LDV/EncwdpInb4HOa\nIxqAx3BixQbtwG+Hsj3I625q4sZZcqsdc7I2sTEaPinNCuv1xga107Gy3BRl\ndalC1FTjxalCfOz59ehBXBIXteRY946c9Pdhg87txGQrLcEIGqGOAyPo9QNI\n6Qc1yUGGMYO2OnG8bDOaJn6j++bJ1xprgDI+Dn6KusNqqjBAIxVggzNqSYik\n8QnWiTgwCc8+643AIPQKN8zhTw4xGxyhTTCuIdCegsQbKKygGRHGkQOdqeLQ\n98tSHbtODPr99WOEspBpYFn8SHjNDohCKRoKHzFIHPHTa95TWeL89qonpq2e\nI8mjRse1bpsizQKED6N7cm3jA/rcSTSDGbDOtvmnA6WfNmsPbO9oziCiupgn\nDeEZ8JOUwoHJ3Mq8drp/wnbe48BdroxEk/aWDR9LFk/AwzyUmxx+/IyG10AP\nJii4\r\n=rW8C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "info@electronjs.org",
+          "name": "electron-nightly"
+        },
+        {
+          "email": "samuel.r.attard@gmail.com",
+          "name": "marshallofsound"
+        }
+      ],
+      "_npmUser": {
+        "name": "electron-nightly",
+        "email": "info@electronjs.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/electron-nightly_7.0.0-nightly.20190704_1562263137190_0.2784974234136546"
+      },
+      "_hasShrinkwrap": false
     }
   },
-  "time":{  
-    "created":"2018-12-03T22:32:28.316Z",
-    "0.0.0":"2018-12-03T22:32:28.442Z",
-    "modified":"2019-07-04T17:59:01.719Z",
-    "5.0.0-nightly.20190107":"2019-01-08T04:24:52.483Z",
-    "5.0.0-nightly.20190121":"2019-01-22T16:19:35.377Z",
-    "5.0.0-nightly.20190122":"2019-01-22T19:30:42.307Z",
-    "6.0.0-nightly.20190123":"2019-01-24T16:24:03.070Z",
-    "6.0.0-nightly.20190212":"2019-02-12T21:02:51.442Z",
-    "6.0.0-nightly.20190213":"2019-02-14T01:02:31.814Z",
-    "6.0.0-nightly.20190311":"2019-03-11T20:40:29.503Z",
-    "7.0.0-nightly.20190521":"2019-05-21T21:22:46.089Z",
-    "7.0.0-nightly.20190529":"2019-05-29T18:23:18.983Z",
-    "7.0.0-nightly.20190530":"2019-05-30T17:47:39.518Z",
-    "7.0.0-nightly.20190531":"2019-05-31T17:49:45.571Z",
-    "7.0.0-nightly.20190602":"2019-06-02T17:45:31.369Z",
-    "7.0.0-nightly.20190603":"2019-06-03T17:47:53.178Z",
-    "7.0.0-nightly.20190604":"2019-06-04T19:10:40.487Z",
-    "7.0.0-nightly.20190605":"2019-06-05T17:53:28.392Z",
-    "7.0.0-nightly.20190606":"2019-06-06T18:01:10.738Z",
-    "7.0.0-nightly.20190607":"2019-06-07T18:27:34.974Z",
-    "7.0.0-nightly.20190608":"2019-06-08T23:58:24.637Z",
-    "7.0.0-nightly.20190611":"2019-06-11T17:46:53.644Z",
-    "7.0.0-nightly.20190612":"2019-06-12T17:47:53.611Z",
-    "7.0.0-nightly.20190613":"2019-06-13T19:21:31.611Z",
-    "7.0.0-nightly.20190615":"2019-06-15T18:18:56.669Z",
-    "7.0.0-nightly.20190616":"2019-06-17T00:31:33.256Z",
-    "7.0.0-nightly.20190618":"2019-06-18T18:37:38.589Z",
-    "7.0.0-nightly.20190619":"2019-06-19T18:05:29.464Z",
-    "7.0.0-nightly.20190622":"2019-06-22T21:03:59.892Z",
-    "7.0.0-nightly.20190623":"2019-06-24T00:21:08.293Z",
-    "7.0.0-nightly.20190624":"2019-06-24T20:44:19.412Z",
-    "7.0.0-nightly.20190627":"2019-06-27T18:05:46.976Z",
-    "7.0.0-nightly.20190629":"2019-06-29T19:10:21.787Z",
-    "7.0.0-nightly.20190630":"2019-07-01T06:44:14.177Z",
-    "7.0.0-nightly.20190701":"2019-07-01T17:57:37.596Z",
-    "7.0.0-nightly.20190702":"2019-07-02T18:08:41.276Z",
-    "7.0.0-nightly.20190704":"2019-07-04T17:58:57.305Z"
+  "time": {
+    "created": "2018-12-03T22:32:28.316Z",
+    "0.0.0": "2018-12-03T22:32:28.442Z",
+    "modified": "2019-07-04T17:59:01.719Z",
+    "5.0.0-nightly.20190107": "2019-01-08T04:24:52.483Z",
+    "5.0.0-nightly.20190121": "2019-01-22T16:19:35.377Z",
+    "5.0.0-nightly.20190122": "2019-01-22T19:30:42.307Z",
+    "6.0.0-nightly.20190123": "2019-01-24T16:24:03.070Z",
+    "6.0.0-nightly.20190212": "2019-02-12T21:02:51.442Z",
+    "6.0.0-nightly.20190213": "2019-02-14T01:02:31.814Z",
+    "6.0.0-nightly.20190311": "2019-03-11T20:40:29.503Z",
+    "7.0.0-nightly.20190521": "2019-05-21T21:22:46.089Z",
+    "7.0.0-nightly.20190529": "2019-05-29T18:23:18.983Z",
+    "7.0.0-nightly.20190530": "2019-05-30T17:47:39.518Z",
+    "7.0.0-nightly.20190531": "2019-05-31T17:49:45.571Z",
+    "7.0.0-nightly.20190602": "2019-06-02T17:45:31.369Z",
+    "7.0.0-nightly.20190603": "2019-06-03T17:47:53.178Z",
+    "7.0.0-nightly.20190604": "2019-06-04T19:10:40.487Z",
+    "7.0.0-nightly.20190605": "2019-06-05T17:53:28.392Z",
+    "7.0.0-nightly.20190606": "2019-06-06T18:01:10.738Z",
+    "7.0.0-nightly.20190607": "2019-06-07T18:27:34.974Z",
+    "7.0.0-nightly.20190608": "2019-06-08T23:58:24.637Z",
+    "7.0.0-nightly.20190611": "2019-06-11T17:46:53.644Z",
+    "7.0.0-nightly.20190612": "2019-06-12T17:47:53.611Z",
+    "7.0.0-nightly.20190613": "2019-06-13T19:21:31.611Z",
+    "7.0.0-nightly.20190615": "2019-06-15T18:18:56.669Z",
+    "7.0.0-nightly.20190616": "2019-06-17T00:31:33.256Z",
+    "7.0.0-nightly.20190618": "2019-06-18T18:37:38.589Z",
+    "7.0.0-nightly.20190619": "2019-06-19T18:05:29.464Z",
+    "7.0.0-nightly.20190622": "2019-06-22T21:03:59.892Z",
+    "7.0.0-nightly.20190623": "2019-06-24T00:21:08.293Z",
+    "7.0.0-nightly.20190624": "2019-06-24T20:44:19.412Z",
+    "7.0.0-nightly.20190627": "2019-06-27T18:05:46.976Z",
+    "7.0.0-nightly.20190629": "2019-06-29T19:10:21.787Z",
+    "7.0.0-nightly.20190630": "2019-07-01T06:44:14.177Z",
+    "7.0.0-nightly.20190701": "2019-07-01T17:57:37.596Z",
+    "7.0.0-nightly.20190702": "2019-07-02T18:08:41.276Z",
+    "7.0.0-nightly.20190704": "2019-07-04T17:58:57.305Z"
   },
-  "maintainers":[  
-    {  
-      "email":"info@electronjs.org",
-      "name":"electron-nightly"
+  "maintainers": [
+    {
+      "email": "info@electronjs.org",
+      "name": "electron-nightly"
     },
-    {  
-      "email":"samuel.r.attard@gmail.com",
-      "name":"marshallofsound"
+    {
+      "email": "samuel.r.attard@gmail.com",
+      "name": "marshallofsound"
     }
   ],
-  "license":"MIT",
-  "readme":"[![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)\n\n\n[![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/master.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/master)\n[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/master)\n[![devDependency Status](https://david-dm.org/electron/electron/dev-status.svg)](https://david-dm.org/electron/electron?type=dev)\n\n:memo: Available Translations: 🇨🇳 🇹🇼 🇧🇷 🇪🇸 🇰🇷 🇯🇵 🇷🇺 🇫🇷 🇹🇭 🇳🇱 🇹🇷 🇮🇩 🇺🇦 🇨🇿 🇮🇹 🇵🇱.\nView these docs in other languages at [electron/i18n](https://github.com/electron/i18n/tree/master/content/).\n\nThe Electron framework lets you write cross-platform desktop applications\nusing JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and\n[Chromium](https://www.chromium.org) and is used by the [Atom\neditor](https://github.com/atom/atom) and many other [apps](https://electronjs.org/apps).\n\nFollow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important\nannouncements.\n\nThis project adheres to the Contributor Covenant\n[code of conduct](https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md).\nBy participating, you are expected to uphold this code. Please report unacceptable\nbehavior to [coc@electronjs.org](mailto:coc@electronjs.org).\n\n## Installation\n\nTo install prebuilt Electron binaries, use [`npm`](https://docs.npmjs.com/).\nThe preferred method is to install Electron as a development dependency in your\napp:\n\n```sh\nnpm install electron --save-dev [--save-exact]\n```\n\nThe `--save-exact` flag is recommended for Electron prior to version 2, as it does not follow semantic\nversioning. As of version 2.0.0, Electron follows semver, so you don't need `--save-exact` flag. For info on how to manage Electron versions in your apps, see\n[Electron versioning](docs/tutorial/electron-versioning.md).\n\nFor more installation options and troubleshooting tips, see\n[installation](docs/tutorial/installation.md).\n\n## Quick start & Electron Fiddle\n\nUse [`Electron Fiddle`](https://github.com/electron/fiddle)\nto build, run, and package small Electron experiments, to see code examples for all of Electron's APIs, and\nto try out different versions of Electron. It's designed to make the start of your journey with\nElectron easier.\n\nAlternatively, clone and run the\n[electron/electron-quick-start](https://github.com/electron/electron-quick-start)\nrepository to see a minimal Electron app in action:\n\n```sh\ngit clone https://github.com/electron/electron-quick-start\ncd electron-quick-start\nnpm install\nnpm start\n```\n\n## Resources for learning Electron\n\n- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation\n- [electron/fiddle](https://github.com/electron/fiddle) - A tool to build, run, and package small Electron experiments\n- [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app\n- [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community\n- [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further\n- [electron/electron-api-demos](https://github.com/electron/electron-api-demos) - an Electron app that teaches you how to use Electron\n- [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) - small demo apps for the various Electron APIs\n\n## Programmatic usage\n\nMost people use Electron from the command line, but if you require `electron` inside\nyour **Node app** (not your Electron app) it will return the file path to the\nbinary. Use this to spawn Electron from Node scripts:\n\n```javascript\nconst electron = require('electron')\nconst proc = require('child_process')\n\n// will print something similar to /Users/maf/.../Electron\nconsole.log(electron)\n\n// spawn Electron\nconst child = proc.spawn(electron)\n```\n\n### Mirrors\n\n- [China](https://npm.taobao.org/mirrors/electron)\n\n## Documentation Translations\n\nFind documentation translations in [electron/i18n](https://github.com/electron/i18n).\n\n## Contributing\n\nIf you are interested in reporting/fixing issues and contributing directly to the code base, please see [CONTRIBUTING.md](CONTRIBUTING.md) for more information on what we're looking for and how to get started.\n\n## Community\n\nInfo on reporting bugs, getting help, finding third-party tools and sample apps,\nand more can be found in the [support document](docs/tutorial/support.md#finding-support).\n\n## License\n\n[MIT](https://github.com/electron/electron/blob/master/LICENSE)\n\nWhen using the Electron or other GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).\n",
-  "readmeFilename":"README.md",
-  "description":"Build cross platform desktop apps with JavaScript, HTML, and CSS",
-  "homepage":"https://github.com/electron/electron#readme",
-  "keywords":[  
+  "license": "MIT",
+  "readme": "[![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)\n\n\n[![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/master.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/master)\n[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/master)\n[![devDependency Status](https://david-dm.org/electron/electron/dev-status.svg)](https://david-dm.org/electron/electron?type=dev)\n\n:memo: Available Translations: 🇨🇳 🇹🇼 🇧🇷 🇪🇸 🇰🇷 🇯🇵 🇷🇺 🇫🇷 🇹🇭 🇳🇱 🇹🇷 🇮🇩 🇺🇦 🇨🇿 🇮🇹 🇵🇱.\nView these docs in other languages at [electron/i18n](https://github.com/electron/i18n/tree/master/content/).\n\nThe Electron framework lets you write cross-platform desktop applications\nusing JavaScript, HTML and CSS. It is based on [Node.js](https://nodejs.org/) and\n[Chromium](https://www.chromium.org) and is used by the [Atom\neditor](https://github.com/atom/atom) and many other [apps](https://electronjs.org/apps).\n\nFollow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important\nannouncements.\n\nThis project adheres to the Contributor Covenant\n[code of conduct](https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md).\nBy participating, you are expected to uphold this code. Please report unacceptable\nbehavior to [coc@electronjs.org](mailto:coc@electronjs.org).\n\n## Installation\n\nTo install prebuilt Electron binaries, use [`npm`](https://docs.npmjs.com/).\nThe preferred method is to install Electron as a development dependency in your\napp:\n\n```sh\nnpm install electron --save-dev [--save-exact]\n```\n\nThe `--save-exact` flag is recommended for Electron prior to version 2, as it does not follow semantic\nversioning. As of version 2.0.0, Electron follows semver, so you don't need `--save-exact` flag. For info on how to manage Electron versions in your apps, see\n[Electron versioning](docs/tutorial/electron-versioning.md).\n\nFor more installation options and troubleshooting tips, see\n[installation](docs/tutorial/installation.md).\n\n## Quick start & Electron Fiddle\n\nUse [`Electron Fiddle`](https://github.com/electron/fiddle)\nto build, run, and package small Electron experiments, to see code examples for all of Electron's APIs, and\nto try out different versions of Electron. It's designed to make the start of your journey with\nElectron easier.\n\nAlternatively, clone and run the\n[electron/electron-quick-start](https://github.com/electron/electron-quick-start)\nrepository to see a minimal Electron app in action:\n\n```sh\ngit clone https://github.com/electron/electron-quick-start\ncd electron-quick-start\nnpm install\nnpm start\n```\n\n## Resources for learning Electron\n\n- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation\n- [electron/fiddle](https://github.com/electron/fiddle) - A tool to build, run, and package small Electron experiments\n- [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app\n- [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community\n- [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further\n- [electron/electron-api-demos](https://github.com/electron/electron-api-demos) - an Electron app that teaches you how to use Electron\n- [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) - small demo apps for the various Electron APIs\n\n## Programmatic usage\n\nMost people use Electron from the command line, but if you require `electron` inside\nyour **Node app** (not your Electron app) it will return the file path to the\nbinary. Use this to spawn Electron from Node scripts:\n\n```javascript\nconst electron = require('electron')\nconst proc = require('child_process')\n\n// will print something similar to /Users/maf/.../Electron\nconsole.log(electron)\n\n// spawn Electron\nconst child = proc.spawn(electron)\n```\n\n### Mirrors\n\n- [China](https://npm.taobao.org/mirrors/electron)\n\n## Documentation Translations\n\nFind documentation translations in [electron/i18n](https://github.com/electron/i18n).\n\n## Contributing\n\nIf you are interested in reporting/fixing issues and contributing directly to the code base, please see [CONTRIBUTING.md](CONTRIBUTING.md) for more information on what we're looking for and how to get started.\n\n## Community\n\nInfo on reporting bugs, getting help, finding third-party tools and sample apps,\nand more can be found in the [support document](docs/tutorial/support.md#finding-support).\n\n## License\n\n[MIT](https://github.com/electron/electron/blob/master/LICENSE)\n\nWhen using the Electron or other GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).\n",
+  "readmeFilename": "README.md",
+  "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
+  "homepage": "https://github.com/electron/electron#readme",
+  "keywords": [
     "electron"
   ],
-  "repository":{  
-    "type":"git",
-    "url":"git+https://github.com/electron/electron.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron/electron.git"
   },
-  "author":{  
-    "name":"Electron Community"
+  "author": {
+    "name": "Electron Community"
   },
-  "bugs":{  
-    "url":"https://github.com/electron/electron/issues"
+  "bugs": {
+    "url": "https://github.com/electron/electron/issues"
   }
 }

--- a/tests/mocks/unpkg-mock.json
+++ b/tests/mocks/unpkg-mock.json
@@ -1,0 +1,77 @@
+[
+    {
+        "node_id": "MDc6UmVsZWFzZTI0MTc1NzU0",
+        "tag_name": "v10.0.0-nightly.20200303",
+        "name": "electron v10.0.0-nightly.20200303",
+        "prerelease": true,
+        "published_at": "2020-03-03T18:06:05Z",
+        "version": "10.0.0-nightly.20200303",
+        "npm_package_name": "electron-nightly",
+        "deps": {
+            "node": "12.16.1",
+            "v8": "8.2.8-electron.0",
+            "uv": "1.34.0",
+            "zlib": "1.2.11",
+            "openssl": "1.1.0",
+            "modules": "82",
+            "chrome": "82.0.4050.0"
+        },
+        "npm_dist_tags": [
+            "nightly"
+        ],
+        "total_downloads": 6
+    },
+    {
+        "node_id": "MDc6UmVsZWFzZTI0MTM1NzIw",
+        "tag_name": "v9.0.0-beta.5",
+        "name": "electron v9.0.0-beta.5",
+        "prerelease": true,
+        "published_at": "2020-03-02T18:05:08Z",
+        "version": "9.0.0-beta.5",
+        "npm_package_name": "electron",
+        "deps": {
+            "node": "12.14.1",
+            "v8": "8.2.1-electron.0",
+            "uv": "1.33.1",
+            "zlib": "1.2.11",
+            "openssl": "1.1.0",
+            "modules": "80",
+            "chrome": "82.0.4048.0"
+        },
+        "npm_dist_tags": [
+            "beta",
+            "beta-9-x-y"
+        ],
+        "total_downloads": 110
+    },
+    {
+        "node_id": "MDc6UmVsZWFzZTE3MTIxODMx",
+        "tag_name": "v4.2.0",
+        "name": "electron v4.2.0",
+        "prerelease": false,
+        "published_at": "2019-05-03T03:16:59Z",
+        "version": "4.2.0",
+        "npm_package_name": "electron",
+        "deps": {
+            "node": "10.11.0",
+            "v8": "6.9.427.31-electron.0",
+            "uv": "1.23.0",
+            "zlib": "1.2.11",
+            "openssl": "1.1.0",
+            "modules": "69",
+            "chrome": "69.0.3497.128"
+        },
+        "npm_dist_tags": [],
+        "total_downloads": 21041
+    },
+    {
+        "node_id": "MDc6UmVsZWFzZTI0ODk2",
+        "tag_name": "v0.3.1",
+        "name": "atom-shell v0.3.1",
+        "prerelease": false,
+        "published_at": "2013-08-12T09:20:23Z",
+        "version": "0.3.1",
+        "npm_dist_tags": [],
+        "total_downloads": 0
+    }
+]

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -14,6 +14,7 @@ import {
   VersionKeys
 } from '../../src/renderer/versions';
 import { mockFetchOnce } from '../utils';
+import semver from 'semver';
 
 const mockVersions: Array<Partial<ElectronVersion>> = [
   { version: 'test-0', localPath: '/test/path/0' },
@@ -21,29 +22,35 @@ const mockVersions: Array<Partial<ElectronVersion>> = [
   { version: 'test-2', localPath: '/test/path/2' },
 ];
 
+jest.mock('semver', () => ({
+  default: {
+    gte: jest.fn()
+  }
+}));
+
 describe('versions', () => {
   describe('getDefaultVersion()', () => {
     it('handles a stored version', () => {
       (localStorage.getItem as any).mockReturnValue('2.0.2');
-      const output = getDefaultVersion([ { version: '2.0.2' } ] as any);
+      const output = getDefaultVersion([{ version: '2.0.2' }] as any);
       expect(output).toBe('2.0.2');
     });
 
     it('handles a v-prefixed version', () => {
       (localStorage.getItem as any).mockReturnValue('v2.0.2');
-      const output = getDefaultVersion([ { version: '2.0.2' } ] as any);
+      const output = getDefaultVersion([{ version: '2.0.2' }] as any);
       expect(output).toBe('2.0.2');
     });
 
     it('handles garbage data', () => {
       (localStorage.getItem as any).mockReturnValue('v3.0.0');
-      const output = getDefaultVersion([ { version: '2.0.2' } ] as any);
+      const output = getDefaultVersion([{ version: '2.0.2' }] as any);
       expect(output).toBe('2.0.2');
     });
 
     it('handles if no version is set', () => {
       (localStorage.getItem as any).mockReturnValue(null);
-      const output = getDefaultVersion([ { version: '2.0.2' } ] as any);
+      const output = getDefaultVersion([{ version: '2.0.2' }] as any);
       expect(output).toBe('2.0.2');
     });
 
@@ -94,11 +101,11 @@ describe('versions', () => {
     });
 
     it('adds a local version', () => {
-      expect(addLocalVersion(mockVersions[1] as any)).toEqual([ mockVersions[0], mockVersions[1] ]);
+      expect(addLocalVersion(mockVersions[1] as any)).toEqual([mockVersions[0], mockVersions[1]]);
     });
 
     it('does not add duplicates', () => {
-      expect(addLocalVersion(mockVersions[0] as any)).toEqual([ mockVersions[0] ]);
+      expect(addLocalVersion(mockVersions[0] as any)).toEqual([mockVersions[0]]);
     });
   });
 
@@ -149,20 +156,21 @@ describe('versions', () => {
   });
 
   describe('fetchVersions()', () => {
-    const mockResponseMain = fs.readFileSync(path.join(__dirname, '../mocks/npm-response-main.json'));
-    const mockResponseNightlies = fs.readFileSync(path.join(__dirname, '../mocks/npm-response-nightlies.json'));
+    it('fetches versions >= 0.24.0', async () => {
+      const mockUnpkgResponse = fs.readFileSync(path.join(__dirname, '../mocks/unpkg-mock.json'));
+      mockFetchOnce(mockUnpkgResponse.toString());
 
-    it('fetches versions', async () => {
-      mockFetchOnce(mockResponseMain.toString());
-      mockFetchOnce(mockResponseNightlies.toString());
+      // return whether or not version in JSON is >=0.24.0
+      (semver.gte as jest.Mock).mockReturnValueOnce(true);
+      (semver.gte as jest.Mock).mockReturnValueOnce(true);
+      (semver.gte as jest.Mock).mockReturnValueOnce(true);
+      (semver.gte as jest.Mock).mockReturnValueOnce(false);
 
       const result = await fetchVersions();
       const expected = [
-        { version: '3.0.1' },
-        { version: '3.0.2' },
-        { version: '4.0.0-nightly.20181006' },
-        { version: '7.0.0-nightly.20190529' },
-        { version: '7.0.0-nightly.20190704' }
+        { version: '10.0.0-nightly.20200303' },
+        { version: '9.0.0-beta.5' },
+        { version: '4.2.0' }
       ];
 
       expect(result).toEqual(expected);

--- a/tests/utils/array-to-stringmap-spec.ts
+++ b/tests/utils/array-to-stringmap-spec.ts
@@ -1,9 +1,9 @@
-import { NpmVersion } from '../../src/interfaces';
+import { Version } from '../../src/interfaces';
 import { arrayToStringMap } from '../../src/utils/array-to-stringmap';
 
 describe('array-to-stringmap', () => {
   it('correctly turns an array of versions into a stringmap', () => {
-    const input: Array<Partial<NpmVersion>> = [
+    const input: Array<Partial<Version>> = [
       {
         version: 'v1.0.0'
       }, {


### PR DESCRIPTION
Fixes #332.

This pull request swaps out fetching (partially undoing what was done in #126). Instead, we fetch Electron releases from [`https://unpkg.com/electron-releases/lite.json`](https://unpkg.com/electron-releases/lite.json), which _should_ be more accurate. 

It also cuts off all versions under `0.24.0`, since `electron-download` cannot handle the old binaries that were called `atom-shell`. _N.B. There are still more versions available now._

The NPM registry had bogus releases on both the nightly channel (an odd `v0.0.0`), as well as on the regular one (relics from the old project that once held the `electron` name on NPM).