### PR TITLE
chore: add test report generation helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ yarn-error.log
 # Coverage
 coverage
 
+# Test report
+report.json
+
 # npm package
 /npm/dist
 /npm/path.txt

--- a/jest.json
+++ b/jest.json
@@ -4,7 +4,6 @@
   },
   "testURL": "http://localhost",
   "testRegex": "(-spec)\\.(ts|tsx)$",
-  "bail": true,
   "resetMocks": true,
   "resetModules": true,
   "snapshotSerializers": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "jest --config=jest.json",
     "test:ci": "jest --config=jest.json --coverage --runInBand",
     "test:coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test:report": "jest --config=jest.json --json --outputFile=report.json | exit 0",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "node ./tools/fetch-releases.js"
   },


### PR DESCRIPTION
Add a command to generate a json report for a given test run. I'm working on consuming these in a reportable way, so this helps me out with that venture a bit.

cc @erickzhao @felixrieseberg 