### PR TITLE
build: create a PR for releases.json updates instead of trying to push to master

### DIFF
--- a/.github/actions/create_releases_pr.js
+++ b/.github/actions/create_releases_pr.js
@@ -1,0 +1,31 @@
+const { Octokit } = require('@octokit/action')
+
+const octokit = new Octokit()
+
+const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
+
+async function main () {
+  const prs = await octokit.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:update-releases`
+  })
+
+  if (prs.data.length === 0) {
+    const pr = await octokit.pulls.create({
+      owner,
+      repo,
+      title: 'build: update Electron releases JSON',
+      base: 'master',
+      head: 'update-releases',
+      body: 'Auto-update from GitHub Actions.',
+      maintainer_can_modify: true
+    })
+    console.log('Pull request created:', pr.html_url)
+  } else {
+    console.log('Pull request updated:', prs.data[0].html_url)
+  }
+}
+
+main()

--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch git branches
+      run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -21,6 +23,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - run: npm ci
+    - name: Switch to release update branch
+      run: |
+        if git branch --remotes | grep -q origin/update-releases; then
+          git checkout update-releases
+        else
+          git checkout -b update-releases
+        fi
     - name: Update Releases JSON
       run: npm run electron-releases
     - name: Commit Changes to Releases JSON
@@ -29,13 +38,14 @@ jobs:
       run: |
         echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
         chmod 600 ~/.netrc
-        git add static/releases.json
+        git add static/releases.json tests/fixtures/releases-metadata.json
         if test -n "$(git status -s)"; then
           git config user.name "$GITHUB_ACTOR"
           git config user.email "electron-bot@users.noreply.github.com"
           git diff --cached
           git commit -m "build: update Electron releases JSON"
-          git push origin HEAD:$GITHUB_REF
+          git push origin update-releases
+          node --unhandled-rejections=strict .github/actions/create_releases_pr.js
         else
           echo No update needed
         fi

--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -1,7 +1,7 @@
 name: Auto-update Releases JSON file
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
 jobs:
   autoupdate:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -2940,12 +2940,70 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/action": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-2.0.0.tgz",
+      "integrity": "sha512-XkZwA1TIYbaliUaKHEV3Riz016tUrTJOzvvPfC4sMfRakXD3VatsJd0ZU8aFWdqi6hfKcfMAD5WRpA4cWpBjRA==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-action": "^1.2.0",
+        "@octokit/core": "^2.1.1",
+        "@octokit/plugin-paginate-rest": "^2.0.1",
+        "@octokit/plugin-rest-endpoint-methods": "^3.2.0",
+        "@octokit/types": "^2.0.2"
+      },
+      "dependencies": {
+        "@octokit/plugin-paginate-rest": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.0.2.tgz",
+          "integrity": "sha512-HzODcSUt9mjErly26TlTOGZrhf9bmF/FEDQ2zln1izhgmIV6ulsjsHmgmR4VZ0wzVr/m52Eb6U2XuyS8fkcR1A==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.1"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.2.0.tgz",
+          "integrity": "sha512-k+RLsegQn4s0wvAFYuk3R18FVKRg3ktvzIGW6MkmrSiSXBwYfaEsv4CuPysyef0DL+74DRj/X9MLJYlbleUO+Q==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.1",
+            "deprecation": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@octokit/auth-action": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-1.2.0.tgz",
+      "integrity": "sha512-AlHcxjGUGIw86FNhEjO+kvNfcSeV1YDrV8BdGgceHCdtbh1DlI3jwsujY4Y2JjIsVpwKaoGQ4mL1s0354SiODA==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/types": "^2.0.0"
+      }
+    },
     "@octokit/auth-token": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
       "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
       "requires": {
         "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.4.2.tgz",
+      "integrity": "sha512-fUx/Qt774cgiPhb3HRKfdl6iufVL/ltECkwkCg373I4lIPYvAPY4cbidVZqyVqHI+ThAIlFlTW8FT4QHChv3Sg==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.3.1",
+        "@octokit/types": "^2.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/endpoint": {
@@ -2970,6 +3028,28 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
+      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.1.0"
+          }
         }
       }
     },
@@ -14795,7 +14875,7 @@
           "dependencies": {
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:ci": "jest --config=jest.json --coverage --runInBand",
     "test:coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "tsc": "tsc --noEmit -p .",
-    "electron-releases": "node ./tools/fetch-releases.js"
+    "electron-releases": "node --unhandled-rejections=strict ./tools/fetch-releases.js"
   },
   "keywords": [
     "Electron",
@@ -69,6 +69,7 @@
     "@electron-forge/maker-squirrel": "^6.0.0-beta.50",
     "@electron-forge/maker-zip": "^6.0.0-beta.50",
     "@electron-forge/publisher-github": "^6.0.0-beta.50",
+    "@octokit/action": "^2.0.0",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.5",
     "@types/fs-extra": "^8.1.0",

--- a/tests/fixtures/releases-metadata.json
+++ b/tests/fixtures/releases-metadata.json
@@ -1,0 +1,4 @@
+{
+  "expectedVersionCount": 315,
+  "lastElectronVersion": "8.0.2"
+}

--- a/tests/renderer/touch-bar-manager-spec.ts
+++ b/tests/renderer/touch-bar-manager-spec.ts
@@ -4,6 +4,8 @@ import { TouchBarManager } from '../../src/renderer/touch-bar-manager';
 import { mockVersions } from '../mocks/electron-versions';
 import { overridePlatform, resetPlatform } from '../utils';
 
+const { lastElectronVersion } = require('../fixtures/releases-metadata.json');
+
 describe('TouchBarManager', () => {
   const appState = new AppState();
 
@@ -86,9 +88,9 @@ describe('TouchBarManager', () => {
     const { click } = touchBarMgr.getVersionSelectorEscButtonOptions();
 
     touchBarMgr.selectedVersion = '3.3.3';
-    expect(appState.version).toBe('8.0.2');
+    expect(appState.version).toBe(lastElectronVersion);
     click!();
-    expect(appState.version).toBe('8.0.2');
+    expect(appState.version).toBe(lastElectronVersion);
   });
 
   it('version scrubber "select" method goes from index to version', () => {

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -15,6 +15,8 @@ import {
 } from '../../src/renderer/versions';
 import { mockFetchOnce } from '../utils';
 
+const { expectedVersionCount } = require('../fixtures/releases-metadata.json');
+
 const mockVersions: Array<Partial<ElectronVersion>> = [
   { version: 'test-0', localPath: '/test/path/0' },
   { version: 'test-1', localPath: '/test/path/1' },
@@ -180,13 +182,13 @@ describe('versions', () => {
     it('falls back to a local require', () => {
       (window as any).localStorage.getItem.mockReturnValueOnce(`garbage`);
 
-      expect(getKnownVersions().length).toBe(315);
+      expect(getKnownVersions().length).toBe(expectedVersionCount);
     });
 
     it('falls back to a local require', () => {
       (window as any).localStorage.getItem.mockReturnValueOnce(`[{ "garbage": "true" }]`);
 
-      expect(getKnownVersions().length).toBe(315);
+      expect(getKnownVersions().length).toBe(expectedVersionCount);
     });
   });
 

--- a/tools/fetch-releases.js
+++ b/tools/fetch-releases.js
@@ -36,6 +36,15 @@ async function main() {
 
   await fs.remove(file)
   await fs.outputFile(file, JSON.stringify(releases))
+
+  console.log('Updating tests with new expected version count.')
+
+  const metadata = {
+    expectedVersionCount: releases.length,
+    lastElectronVersion: releases[releases.length - 1].version
+  }
+  const releasesMetadataPath = path.resolve(__dirname, '..', 'tests', 'fixtures', 'releases-metadata.json')
+  await fs.writeJson(releasesMetadataPath, metadata, { spaces: 2 })
 }
 
 main()


### PR DESCRIPTION
Turns out that we can't use GitHub Actions to automatically push release metadata changes to master due to branch protection. However, @erickzhao made a great suggestion to have the action create PRs instead.

* Move expected version count & latest Electron version to its own fixture file
* Automatically update expected version count & latest Electron version when updating the JSON file
* Throw an error if a rejection occurs when the fetch releases script is run
* Reduce the update frequency to once a week, now that we're creating pull requests

I've been testing on my fork, here's an example PR (base changed because it's using a test branch as the base): https://github.com/malept/fiddle/pull/6

It shouldn't create a new branch or new PR if one already exists.

This might conflict with #339.