### PR TITLE
fix: test:report makes a report even if tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --config=jest.json",
     "test:ci": "jest --config=jest.json --coverage --runInBand",
     "test:coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "test:report": "jest --config=jest.json --json --outputFile=report.json | exit 0",
+    "test:report": "jest --config=jest.json --bail=false --json --outputFile=report.json || true; test -f report.json",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "node --unhandled-rejections=strict ./tools/fetch-releases.js"
   },


### PR DESCRIPTION
Fixes the invocation of `test:report` to not bail out when tests fail. Bailing causes jest to not generate a report.

Discussion @ https://github.com/electron/fiddle/pull/340#pullrequestreview-371336100 but my code review was a few minutes too late :smile: 

CC @codebytere @erickzhao 