### PR TITLE
feat: more sensible version filtering

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -7,7 +7,8 @@ import {
   HTMLTable,
   IButtonProps,
   Icon,
-  IconName
+  IconName,
+  Tooltip
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
@@ -210,17 +211,24 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
       <FormGroup
         label='Include Electron versions that are:'
       >
+        <Tooltip
+          content='Always enabled'
+          position='bottom'
+          intent='primary'
+        >
+          <Checkbox
+            checked={getIsChecked(ElectronVersionState.ready)}
+            label='Ready'
+            id='ready'
+            onChange={this.handleStateChange}
+            inline={true}
+            disabled={true}
+          />
+        </Tooltip>
         <Checkbox
           checked={getIsChecked(ElectronVersionState.downloading)}
           label='Downloading'
           id='downloading'
-          onChange={this.handleStateChange}
-          inline={true}
-        />
-        <Checkbox
-          checked={getIsChecked(ElectronVersionState.ready)}
-          label='Downloaded'
-          id='ready'
           onChange={this.handleStateChange}
           inline={true}
         />
@@ -243,42 +251,47 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
    */
   private renderVersionChannelOptions(): JSX.Element {
     const { appState } = this.props;
+
     const getIsChecked = (channel: ElectronReleaseChannel) => {
       return appState.channelsToShow.includes(channel);
+    };
+
+    const getIsCurrentVersionReleaseChannel = (channel: ElectronReleaseChannel) => {
+      return getReleaseChannel(appState.version) === channel;
+    };
+
+    const channels = {
+      stable: ElectronReleaseChannel.stable,
+      beta: ElectronReleaseChannel.beta,
+      nightly: ElectronReleaseChannel.nightly,
+      unsupported: ElectronReleaseChannel.unsupported
     };
 
     return (
       <FormGroup
         label='Include Electron versions from these release channels:'
       >
-        <Checkbox
-          checked={getIsChecked(ElectronReleaseChannel.stable)}
-          label='Stable'
-          id='Stable'
-          onChange={this.handleChannelChange}
-          inline={true}
-        />
-        <Checkbox
-          checked={getIsChecked(ElectronReleaseChannel.beta)}
-          label='Beta'
-          id='Beta'
-          onChange={this.handleChannelChange}
-          inline={true}
-        />
-        <Checkbox
-          checked={getIsChecked(ElectronReleaseChannel.nightly)}
-          label='Nightly'
-          id='Nightly'
-          onChange={this.handleChannelChange}
-          inline={true}
-        />
-        <Checkbox
-          checked={getIsChecked(ElectronReleaseChannel.unsupported)}
-          label='Unsupported'
-          id='Unsupported'
-          onChange={this.handleChannelChange}
-          inline={true}
-        />
+        {
+          // tslint:disable-next-line:jsx-no-multiline-js
+          Object.entries(channels).map(([_, channel]) => (
+            <Tooltip
+              content={`Can't disable channel of selected version (${appState.version})`}
+              disabled={!getIsCurrentVersionReleaseChannel(channel)}
+              position='bottom'
+              intent='primary'
+              key={channel}
+            >
+              <Checkbox
+                checked={getIsChecked(channel)}
+                label={channel}
+                id={channel}
+                onChange={this.handleChannelChange}
+                disabled={getIsCurrentVersionReleaseChannel(channel)}
+                inline={true}
+              />
+            </Tooltip>
+          ))
+        }
       </FormGroup>
     );
   }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -12,9 +12,9 @@ import {
   GenericDialogOptions,
   GenericDialogType,
   MosaicId,
-  Version,
   OutputEntry,
-  OutputOptions
+  OutputOptions,
+  Version
 } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { arrayToStringMap } from '../utils/array-to-stringmap';

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -1,6 +1,6 @@
+import semver from 'semver';
 import { ElectronVersion, ElectronVersionSource, ElectronVersionState, Version } from '../interfaces';
 import { normalizeVersion } from '../utils/normalize-version';
-import semver from 'semver';
 
 export const enum ElectronReleaseChannel {
   stable = 'Stable',

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -11,50 +11,108 @@ exports[`ElectronSettings component renders 1`] = `
     <Blueprint3.FormGroup
       label="Include Electron versions from these release channels:"
     >
-      <Blueprint3.Checkbox
-        checked={true}
-        id="Stable"
-        inline={true}
-        label="Stable"
-        onChange={[Function]}
-      />
-      <Blueprint3.Checkbox
-        checked={true}
-        id="Beta"
-        inline={true}
-        label="Beta"
-        onChange={[Function]}
-      />
-      <Blueprint3.Checkbox
-        checked={false}
-        id="Nightly"
-        inline={true}
-        label="Nightly"
-        onChange={[Function]}
-      />
-      <Blueprint3.Checkbox
-        checked={false}
-        id="Unsupported"
-        inline={true}
-        label="Unsupported"
-        onChange={[Function]}
-      />
+      <Blueprint3.Tooltip
+        content="Can't disable channel of selected version (2.0.1)"
+        disabled={false}
+        hoverCloseDelay={0}
+        hoverOpenDelay={100}
+        intent="primary"
+        key="Stable"
+        position="bottom"
+        transitionDuration={100}
+      >
+        <Blueprint3.Checkbox
+          checked={true}
+          disabled={true}
+          id="Stable"
+          inline={true}
+          label="Stable"
+          onChange={[Function]}
+        />
+      </Blueprint3.Tooltip>
+      <Blueprint3.Tooltip
+        content="Can't disable channel of selected version (2.0.1)"
+        disabled={true}
+        hoverCloseDelay={0}
+        hoverOpenDelay={100}
+        intent="primary"
+        key="Beta"
+        position="bottom"
+        transitionDuration={100}
+      >
+        <Blueprint3.Checkbox
+          checked={true}
+          disabled={false}
+          id="Beta"
+          inline={true}
+          label="Beta"
+          onChange={[Function]}
+        />
+      </Blueprint3.Tooltip>
+      <Blueprint3.Tooltip
+        content="Can't disable channel of selected version (2.0.1)"
+        disabled={true}
+        hoverCloseDelay={0}
+        hoverOpenDelay={100}
+        intent="primary"
+        key="Nightly"
+        position="bottom"
+        transitionDuration={100}
+      >
+        <Blueprint3.Checkbox
+          checked={false}
+          disabled={false}
+          id="Nightly"
+          inline={true}
+          label="Nightly"
+          onChange={[Function]}
+        />
+      </Blueprint3.Tooltip>
+      <Blueprint3.Tooltip
+        content="Can't disable channel of selected version (2.0.1)"
+        disabled={true}
+        hoverCloseDelay={0}
+        hoverOpenDelay={100}
+        intent="primary"
+        key="Unsupported"
+        position="bottom"
+        transitionDuration={100}
+      >
+        <Blueprint3.Checkbox
+          checked={false}
+          disabled={false}
+          id="Unsupported"
+          inline={true}
+          label="Unsupported"
+          onChange={[Function]}
+        />
+      </Blueprint3.Tooltip>
     </Blueprint3.FormGroup>
     <Blueprint3.FormGroup
       label="Include Electron versions that are:"
     >
+      <Blueprint3.Tooltip
+        content="Always enabled"
+        hoverCloseDelay={0}
+        hoverOpenDelay={100}
+        intent="primary"
+        position="bottom"
+        transitionDuration={100}
+      >
+        <Blueprint3.Checkbox
+          checked={true}
+          disabled={true}
+          id="ready"
+          inline={true}
+          label="Ready"
+          onChange={[Function]}
+        />
+      </Blueprint3.Tooltip>
       <Blueprint3.Checkbox
         checked={true}
         id="downloading"
         inline={true}
         label="Downloading"
-        onChange={[Function]}
-      />
-      <Blueprint3.Checkbox
-        checked={true}
-        id="ready"
-        inline={true}
-        label="Downloaded"
         onChange={[Function]}
       />
       <Blueprint3.Checkbox

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import semver from 'semver';
 import { ElectronVersion, ElectronVersionSource } from '../../src/interfaces';
 import {
   addLocalVersion,
@@ -14,7 +15,6 @@ import {
   VersionKeys
 } from '../../src/renderer/versions';
 import { mockFetchOnce } from '../utils';
-import semver from 'semver';
 
 const { expectedVersionCount } = require('../fixtures/releases-metadata.json');
 


### PR DESCRIPTION
Fixes #336 indirectly.

Makes sensible restrictions for which Release Channels and Version States we can filter out, mostly so that the version selector never ends up empty and the current version you have selected cannot disappear from the selector.

* Release Channels: Cannot disable the release channel of the version that you currently have selected.
* Version States: Cannot disable "Ready" versions. It doesn't make sense to not be able to select all of the versions that you have downloaded.