### PR TITLE
fix: preserve 'downloading' version state post-refresh

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -164,6 +164,12 @@ export class BinaryManager {
     }
   }
 
+  public getDownloadingVersions() {
+    return Object.entries(this.state)
+      .filter(([_, state]) => state === 'downloading')
+      .map(([version, _]) => version);
+  }
+
   /**
    * Did we already download a given version?
    *

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -12,9 +12,9 @@ import {
   GenericDialogOptions,
   GenericDialogType,
   MosaicId,
-  Version,
   OutputEntry,
-  OutputOptions
+  OutputOptions,
+  Version
 } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { arrayToStringMap } from '../utils/array-to-stringmap';
@@ -478,14 +478,23 @@ export class AppState {
    * @returns {Promise<void>}
    */
   @action public async updateDownloadedVersionState(): Promise<void> {
-    const downloadedVersions = await this.binaryManager.getDownloadedVersions();
     const updatedVersions = { ...this.versions };
 
+    // Keep state of currently downloading binaries first
+    const downloadingVersions = this.binaryManager.getDownloadingVersions();
+    (downloadingVersions || []).forEach((version) => {
+      if (updatedVersions[version]) {
+        updatedVersions[version].state = ElectronVersionState.downloading;
+      }
+    });
+
+    const downloadedVersions = await this.binaryManager.getDownloadedVersions();
     (downloadedVersions || []).forEach((version) => {
       if (updatedVersions[version]) {
         updatedVersions[version].state = ElectronVersionState.ready;
       }
     });
+
     console.log(`State: Updated version state`, updatedVersions);
 
     this.versions = updatedVersions;

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -1,6 +1,6 @@
+import semver from 'semver';
 import { ElectronVersion, ElectronVersionSource, ElectronVersionState, Version } from '../interfaces';
 import { normalizeVersion } from '../utils/normalize-version';
-import semver from 'semver';
 
 export const enum ElectronReleaseChannel {
   stable = 'Stable',

--- a/tests/mocks/binary.ts
+++ b/tests/mocks/binary.ts
@@ -2,4 +2,5 @@ export class MockBinaryManager {
   public remove = jest.fn();
   public setup = jest.fn();
   public getDownloadedVersions = jest.fn();
+  public getDownloadingVersions = jest.fn();
 }

--- a/tests/renderer/binary-spec.ts
+++ b/tests/renderer/binary-spec.ts
@@ -140,6 +140,15 @@ describe('binary', () => {
     });
   });
 
+  describe('getDownloadingVersions()', () => {
+    it('returns currently downloading versions', () => {
+      binaryManager.state['3.0.0'] = 'downloading';
+
+      const result = binaryManager.getDownloadingVersions();
+      expect(result).toEqual(['3.0.0']);
+    });
+  });
+
   describe('getDownloadPath()', () => {
     it('returns the correct path on Windows', () => {
       overridePlatform('win32');

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -416,6 +416,13 @@ describe('AppState', () => {
 
       expect(appState.versions['2.0.2'].state).toBe(ElectronVersionState.ready);
     });
+
+    it('keeps downloading state intact', async () => {
+      (appState.binaryManager.getDownloadingVersions as jest.Mock).mockReturnValueOnce(['2.0.2']);
+      await appState.updateDownloadedVersionState();
+
+      expect(appState.versions['2.0.2'].state).toBe(ElectronVersionState.downloading);
+    });
   });
 
   describe('signOutGitHub()', () => {

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import semver from 'semver';
 import { ElectronVersion, ElectronVersionSource } from '../../src/interfaces';
 import {
   addLocalVersion,
@@ -14,7 +15,6 @@ import {
   VersionKeys
 } from '../../src/renderer/versions';
 import { mockFetchOnce } from '../utils';
-import semver from 'semver';
 
 const { expectedVersionCount } = require('../fixtures/releases-metadata.json');
 


### PR DESCRIPTION
Fixes #321.

When updating version lists, we would previously remove all of the states from the previous versions. However, we would only reinstate the `Downloaded` versions and not the `Downloading` ones.

This PR checks the `BinaryManager` state to see which versions were currently downloading, and marks them as such.