### PR TITLE
fix: ensure hidden panels work on first load

### DIFF
--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -143,8 +143,6 @@ export class Editor extends React.Component<EditorProps> {
 
     const backup = appState.getAndRemoveEditorValueBackup(id);
 
-    console.log(id);
-
     if (backup) {
       console.log(`Editor: Backup found, restoring state`);
 
@@ -155,8 +153,8 @@ export class Editor extends React.Component<EditorProps> {
       // If there's a model, use the model. No model? Use the value
       if (backup.model) {
         this.editor.setModel(backup.model);
-      } else if (typeof backup.value !== 'undefined') {
-        this.createModel(backup.value);
+      } else {
+        this.createModel(backup.value ?? '');
       }
     } else {
       const value = await getContent(id, version);

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -21,9 +21,7 @@ export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<MosaicId> = {
 };
 
 export const DEFAULT_CLOSED_PANELS: Partial<Record<MosaicId, EditorBackup | true>> = {
-  docsDemo: true,
-  preload: {},
-  css: {}
+  docsDemo: true
 };
 
 export const ELECTRON_ORG = 'electron';

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -101,55 +101,58 @@ describe('Editor component', () => {
       expect(monaco.editor.createModel).toHaveBeenCalled();
     });
 
-    it('attempts to restore a backup if available', async () => {
-      store.getAndRemoveEditorValueBackup.mockReturnValueOnce({
-        model: true,
-        viewState: true
+    describe('backups', async () => {
+      it('attempts to restore a backup if contains a model', async () => {
+        store.getAndRemoveEditorValueBackup.mockReturnValueOnce({
+          model: true,
+          viewState: true
+        });
+
+        const wrapper = shallow(
+          <Editor
+            appState={store}
+            monaco={monaco}
+            monacoOptions={{}}
+            id={EditorId.main}
+            editorDidMount={() => undefined}
+            setFocused={() => undefined}
+          />
+        );
+        const instance: any = wrapper.instance();
+
+        instance.containerRef.current = 'ref';
+        await instance.initMonaco();
+
+        expect(instance.editor.restoreViewState).toHaveBeenCalledTimes(1);
+        expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
       });
 
-      const wrapper = shallow(
-        <Editor
-          appState={store}
-          monaco={monaco}
-          monacoOptions={{}}
-          id={EditorId.main}
-          editorDidMount={() => undefined}
-          setFocused={() => undefined}
-        />
-      );
-      const instance: any = wrapper.instance();
+      it('attempts to restore a backup if contains a string value', async () => {
+        store.getAndRemoveEditorValueBackup.mockReturnValueOnce({
+          value: 'hello'
+        });
 
-      instance.containerRef.current = 'ref';
-      await instance.initMonaco();
+        const wrapper = shallow(
+          <Editor
+            appState={store}
+            monaco={monaco}
+            monacoOptions={{}}
+            id={EditorId.main}
+            editorDidMount={() => undefined}
+            setFocused={() => undefined}
+          />
+        );
+        const instance: any = wrapper.instance();
 
-      expect(instance.editor.restoreViewState).toHaveBeenCalledTimes(1);
-      expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
-    });
+        instance.containerRef.current = 'ref';
+        await instance.initMonaco();
 
-    it('attempts to restore a backup value if available', async () => {
-      store.getAndRemoveEditorValueBackup.mockReturnValueOnce({
-        value: 'hello'
+        expect(instance.editor.restoreViewState).toHaveBeenCalledTimes(0);
+        expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
+        expect(monaco.editor.createModel).toHaveBeenCalledWith('hello', 'javascript');
       });
-
-      const wrapper = shallow(
-        <Editor
-          appState={store}
-          monaco={monaco}
-          monacoOptions={{}}
-          id={EditorId.main}
-          editorDidMount={() => undefined}
-          setFocused={() => undefined}
-        />
-      );
-      const instance: any = wrapper.instance();
-
-      instance.containerRef.current = 'ref';
-      await instance.initMonaco();
-
-      expect(instance.editor.restoreViewState).toHaveBeenCalledTimes(0);
-      expect(instance.editor.setModel).toHaveBeenCalledTimes(1);
-      expect(monaco.editor.createModel).toHaveBeenCalledWith('hello', 'javascript');
     });
+
 
     it('initializes with a fixed tab size', async () => {
       const didMount = jest.fn();


### PR DESCRIPTION
Fixes #338. 

In `constants.tsx`, we set the default hidden editor backup values to be `{}`.
https://github.com/electron/fiddle/blob/3709d122a6bcd75730f7322a61eb9dbee616284b/src/renderer/constants.ts#L23-L27

This initial value was problematic with our existing business logic for editor backups, which would not set the editor backup properly for `{}` due to a missing branch in the conditional flow:

https://github.com/electron/fiddle/blob/96bd2e36dd95880bff73430bb4281780277585b6/src/renderer/components/editor.tsx#L148-L165

We can see that the `setContent()` function is a no-op if the backup exists, but it has no model or value. To change that, the easiest way is the solve the problem at the root and delete the `{}` values.

Ancillary changes:
* Removed stray logging statement
* Reorganized spec (and renamed duplicate test name)