### PR TITLE
fix: ensure you have at least one editor open

### DIFF
--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -77,6 +77,7 @@ export class EditorDropdown extends React.Component<EditorDropdownProps, EditorD
           text={TITLE_MAP[id]}
           id={id}
           onClick={this.onItemClick}
+          disabled={appState.mosaicArrangement === id} // can't hide last editor panel
         />
       );
     }

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -167,9 +167,21 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
   public renderToolbar(
     { title }: MosaicWindowProps<MosaicId>, id: MosaicId
   ): JSX.Element {
+    const { appState } = this.props;
     const docsDemoGoHomeMaybe = id === PanelId.docsDemo
-      ? <DocsDemoGoHomeButton id={id} appState={this.props.appState} />
+      ? <DocsDemoGoHomeButton id={id} appState={appState} />
       : null;
+
+    // only show toolbar controls if we have more than 1 visible editor
+    // Mosaic arrangement is type string if 1 editor, object otherwise
+    const toolbarControlsMaybe =
+      (typeof appState.mosaicArrangement !== 'string') &&
+      (
+        <>
+          <MaximizeButton id={id} appState={appState} />
+          <RemoveButton id={id} appState={appState} />
+        </>
+      );
 
     return (
       <div>
@@ -184,8 +196,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
         {/* Right */}
         <div className='mosaic-controls'>
           {docsDemoGoHomeMaybe}
-          <MaximizeButton id={id} appState={this.props.appState} />
-          <RemoveButton id={id} appState={this.props.appState} />
+          {toolbarControlsMaybe}
         </div>
       </div>
     );

--- a/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-editors-spec.tsx.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EditorDropdown component disables hide button if only one editor open 1`] = `
+Array [
+  <Blueprint3.MenuItem
+    disabled={false}
+    icon="eye-off"
+    id="main"
+    multiline={false}
+    onClick={[Function]}
+    popoverProps={Object {}}
+    shouldDismissPopover={true}
+    text="Main Process (main.js)"
+  />,
+  <Blueprint3.MenuItem
+    disabled={false}
+    icon="eye-off"
+    id="renderer"
+    multiline={false}
+    onClick={[Function]}
+    popoverProps={Object {}}
+    shouldDismissPopover={true}
+    text="Renderer Process (renderer.js)"
+  />,
+  <Blueprint3.MenuItem
+    disabled={false}
+    icon="eye-off"
+    id="preload"
+    multiline={false}
+    onClick={[Function]}
+    popoverProps={Object {}}
+    shouldDismissPopover={true}
+    text="Preload (preload.js)"
+  />,
+  <Blueprint3.MenuItem
+    disabled={true}
+    icon="eye-open"
+    id="html"
+    multiline={false}
+    onClick={[Function]}
+    popoverProps={Object {}}
+    shouldDismissPopover={true}
+    text="HTML (index.html)"
+  />,
+  <Blueprint3.MenuItem
+    disabled={false}
+    icon="eye-off"
+    id="css"
+    multiline={false}
+    onClick={[Function]}
+    popoverProps={Object {}}
+    shouldDismissPopover={true}
+    text="Stylesheet (styles.css)"
+  />,
+]
+`;
+
 exports[`EditorDropdown component renders 1`] = `
 <Fragment>
   <Blueprint3.Popover

--- a/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/editors-spec.tsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Editors component does not render toolbar controls if only one editor exists 1`] = `
+<div>
+  <div>
+    <h5>
+      Main Process (main.js)
+    </h5>
+  </div>
+  <div />
+  <div
+    className="mosaic-controls"
+  />
+</div>
+`;
+
 exports[`Editors component renders 1`] = `
 <div
   className="focused__undefined mosaic mosaic-drop-target"
@@ -1200,70 +1214,72 @@ exports[`Editors component renders a toolbar 1`] = `
   <div
     className="mosaic-controls"
   >
-    <MaximizeButton
-      appState={
-        Object {
-          "currentDocsDemoPage": "DEFAULT",
-          "isSettingsShowing": false,
-          "isTokenDialogShowing": false,
-          "mosaicArrangement": Object {
-            "direction": "row",
-            "first": Object {
-              "direction": "column",
-              "first": "main",
+    <React.Fragment>
+      <MaximizeButton
+        appState={
+          Object {
+            "currentDocsDemoPage": "DEFAULT",
+            "isSettingsShowing": false,
+            "isTokenDialogShowing": false,
+            "mosaicArrangement": Object {
+              "direction": "row",
+              "first": Object {
+                "direction": "column",
+                "first": "main",
+                "second": Object {
+                  "direction": "column",
+                  "first": "renderer",
+                  "second": "preload",
+                },
+              },
               "second": Object {
                 "direction": "column",
-                "first": "renderer",
-                "second": "preload",
+                "first": "html",
+                "second": Object {
+                  "direction": "column",
+                  "first": "css",
+                  "second": "docsDemo",
+                },
               },
             },
-            "second": Object {
-              "direction": "column",
-              "first": "html",
-              "second": Object {
-                "direction": "column",
-                "first": "css",
-                "second": "docsDemo",
-              },
-            },
-          },
-          "setGenericDialogOptions": [Function],
+            "setGenericDialogOptions": [Function],
+          }
         }
-      }
-      id="main"
-    />
-    <RemoveButton
-      appState={
-        Object {
-          "currentDocsDemoPage": "DEFAULT",
-          "isSettingsShowing": false,
-          "isTokenDialogShowing": false,
-          "mosaicArrangement": Object {
-            "direction": "row",
-            "first": Object {
-              "direction": "column",
-              "first": "main",
+        id="main"
+      />
+      <RemoveButton
+        appState={
+          Object {
+            "currentDocsDemoPage": "DEFAULT",
+            "isSettingsShowing": false,
+            "isTokenDialogShowing": false,
+            "mosaicArrangement": Object {
+              "direction": "row",
+              "first": Object {
+                "direction": "column",
+                "first": "main",
+                "second": Object {
+                  "direction": "column",
+                  "first": "renderer",
+                  "second": "preload",
+                },
+              },
               "second": Object {
                 "direction": "column",
-                "first": "renderer",
-                "second": "preload",
+                "first": "html",
+                "second": Object {
+                  "direction": "column",
+                  "first": "css",
+                  "second": "docsDemo",
+                },
               },
             },
-            "second": Object {
-              "direction": "column",
-              "first": "html",
-              "second": Object {
-                "direction": "column",
-                "first": "css",
-                "second": "docsDemo",
-              },
-            },
-          },
-          "setGenericDialogOptions": [Function],
+            "setGenericDialogOptions": [Function],
+          }
         }
-      }
-      id="main"
-    />
+        id="main"
+      />
+    </React.Fragment>
   </div>
 </div>
 `;

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -16,7 +16,7 @@ describe('EditorDropdown component', () => {
     store = {
       hideAndBackupMosaic: jest.fn(),
       showMosaic: jest.fn(),
-      closedPanels: {}
+      closedPanels: {},
     };
 
     (getVisibleMosaics as jest.Mock).mockReturnValue([ EditorId.html, EditorId.renderer ]);
@@ -45,5 +45,16 @@ describe('EditorDropdown component', () => {
     dropdown.onItemClick({ currentTarget: { id: EditorId.main } } as any);
     expect(store.hideAndBackupMosaic).toHaveBeenCalledTimes(1);
     expect(store.showMosaic).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables hide button if only one editor open', () => {
+    store.mosaicArrangement = 'html';
+    (getVisibleMosaics as jest.Mock).mockReturnValue([ EditorId.html ]);
+
+    const wrapper = mount(<EditorDropdown appState={store} />);
+    const instance = wrapper.instance() as EditorDropdown;
+    const menu = instance.renderMenuItems();
+  
+    expect(menu).toMatchSnapshot();
   });
 });

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -122,6 +122,18 @@ describe('Editors component', () => {
     expect(toolbar).toMatchSnapshot();
   });
 
+  it('does not render toolbar controls if only one editor exists', () => {
+    store.mosaicArrangement = EditorId.main;
+    const wrapper = shallow(<Editors appState={store} />);
+    const instance: Editors = wrapper.instance() as any;
+    const toolbar = instance.renderToolbar(
+      { title: TITLE_MAP[EditorId.main] } as any,
+      EditorId.main
+    );
+
+    expect(toolbar).toMatchSnapshot();
+  });
+
   it('componentWillUnmount() unsubscribes the layout reaction', () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;


### PR DESCRIPTION
Fixes #335 by ensuring that the last open editor cannot be closed.

This means two things happen when only one editor is open:
1) The toolbar controls on the top right of the panel (expand, close) are hidden.
2) You cannot close the last editor through the `commands-editor` component.

This work is done by checking `appState.mosaicArrangement`, which goes from an object to a single `EditorId` string when only one window is open.