### PR TITLE
chore: fix test:report bailing

### DIFF
--- a/jest.json
+++ b/jest.json
@@ -5,6 +5,7 @@
   "testURL": "http://localhost",
   "testRegex": "(-spec)\\.(ts|tsx)$",
   "resetMocks": true,
+  "bail": true,
   "resetModules": true,
   "snapshotSerializers": [
     "enzyme-to-json/serializer"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --config=jest.json",
     "test:ci": "jest --config=jest.json --coverage --runInBand",
     "test:coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "test:report": "jest --config=jest.json --json --outputFile=report.json | exit 0",
+    "test:report": "jest --config=jest.json --json --bail=false --outputFile=report.json | true",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "node --unhandled-rejections=strict ./tools/fetch-releases.js"
   },


### PR DESCRIPTION
Follow up to https://github.com/electron/fiddle/pull/340#pullrequestreview-371336100.

I accidentally forgot to cherry-pick over the `--bail=false` update from `jest.json` but you can also just specify it at the cli level so this does that. Also uses more idiomatic `|| true` instead of `|| exit 0`

cc @erickzhao @ckerr 