### PR TITLE
fix: load unsave handlers only after editors mount

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -78,7 +78,6 @@ export class App {
 
     // once loaded, we have a "saved" state
     this.state.isUnsaved = false;
-    this.setupUnsavedOnChangeListener();
 
     return true;
   }
@@ -177,28 +176,7 @@ export class App {
 
     ipcRenderer.send(WEBCONTENTS_READY_FOR_IPC_SIGNAL);
 
-    // TODO: A timer here is terrible. Let's fix this
-    // and ensure we actually do it once Editors have mounted.
-    setTimeout(() => {
-      this.setupUnsavedOnChangeListener();
-    }, 1500);
-
     return rendered;
-  }
-
-  /**
-   * If the editor is changed for the first time, we'll
-   * set `isUnsaved` to true. That way, the app can warn you
-   * if you're about to throw things away.
-   */
-  public setupUnsavedOnChangeListener() {
-    Object.keys(window.ElectronFiddle.editors).forEach((key) => {
-      const editor = window.ElectronFiddle.editors[key];
-      const disposable = editor.onDidChangeModelContent(() => {
-        this.state.isUnsaved = true;
-        disposable.dispose();
-      });
-    });
   }
 
   /**

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -66,8 +66,6 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     this.setFocused = this.setFocused.bind(this);
 
     this.state = { monacoOptions: defaultMonacoOptions };
-
-    this.loadMonaco();
   }
 
   /**
@@ -75,7 +73,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
    *
    * @memberof Editors
    */
-  public componentDidMount() {
+  public async componentDidMount() {
     ipcRendererManager.on(IpcEvents.MONACO_EXECUTE_COMMAND, (_event, cmd: string) => {
       this.executeCommand(cmd);
     });
@@ -95,6 +93,8 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     });
 
     this.setState({ isMounted: true });
+    await this.loadMonaco();
+    this.props.appState.isUnsaved = false;
   }
 
   public componentWillUnmount() {
@@ -280,7 +280,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
    * We're doing things a bit roundabout to ensure that we're not overloading the
    * mobx state with a gigantic Monaco tree.
    */
-  public async loadMonaco(): Promise<void> {
+  public async loadMonaco() {
     const { app } = window.ElectronFiddle;
     const loader = require('monaco-loader');
     const monaco = app.monaco || await loader();
@@ -298,7 +298,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
       this.setState({ monaco });
     }
 
-    activateTheme(monaco, undefined, this.props.appState.theme);
+    await activateTheme(monaco, undefined, this.props.appState.theme);
   }
 
   /**

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -110,7 +110,6 @@ export class FileManager {
       }
 
       this.appState.isUnsaved = false;
-      window.ElectronFiddle.app.setupUnsavedOnChangeListener();
     }
   }
 

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -40,11 +40,9 @@ describe('Editors component', () => {
 
       const app = new App();
       const result = (await app.setup()) as HTMLDivElement;
-      app.setupUnsavedOnChangeListener = jest.fn();
       jest.runAllTimers();
 
       expect(result.innerHTML).toBe('Dialogs;Header;OutputEditorsWrapper;');
-      expect(app.setupUnsavedOnChangeListener).toHaveBeenCalled();
 
       jest.useRealTimers();
     });
@@ -174,7 +172,6 @@ describe('Editors component', () => {
       const app = new App();
       (app.state as Partial<AppState>) = new MockState();
       app.state.isUnsaved = false;
-      app.setupUnsavedOnChangeListener = jest.fn();
       app.setEditorValues = jest.fn();
 
       const editorValues = {
@@ -190,7 +187,6 @@ describe('Editors component', () => {
       })
         .then(() => {
           expect(app.state.isUnsaved).toBe(false);
-          expect(app.setupUnsavedOnChangeListener).toHaveBeenCalled();
           done();
         });
     });
@@ -333,23 +329,6 @@ describe('Editors component', () => {
       expect(
         (window as any).ElectronFiddle.editors.renderer.setValue
       ).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('setupUnsavedOnChangeListener()', () => {
-    it('listens for model change events', async () => {
-      const app = new App();
-
-      app.setupUnsavedOnChangeListener();
-
-      const fn = window.ElectronFiddle.editors!.renderer!
-        .onDidChangeModelContent;
-      const call = (fn as jest.Mock<any>).mock.calls[0];
-      const cb = call[0];
-
-      cb();
-
-      expect(app.state.isUnsaved).toBe(true);
     });
   });
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -55,8 +55,8 @@ describe('AppState', () => {
     expect(appState).toBeTruthy();
   });
 
-  describe('onbeforeunload handler', () => {
-    it('closes the window', (done) => {
+  describe('isUnsaved autorun handler', () => {
+    it('can close the window if user accepts the dialog', (done) => {
       window.close = jest.fn();
       appState.isUnsaved = true;
       expect(window.onbeforeunload).toBeTruthy();
@@ -73,7 +73,7 @@ describe('AppState', () => {
       });
     });
 
-    it('closes the app', (done) => {
+    it('can close the app after user accepts dialog', (done) => {
       const { remote } = require('electron');
       window.close = jest.fn();
       appState.isUnsaved = true;
@@ -93,7 +93,7 @@ describe('AppState', () => {
       });
     });
 
-    it('does not close the window', (done) => {
+    it('takes no action if user cancels the dialog', (done) => {
       window.close = jest.fn();
       appState.isUnsaved = true;
       expect(window.onbeforeunload).toBeTruthy();
@@ -108,6 +108,21 @@ describe('AppState', () => {
         expect(window.close).toHaveBeenCalledTimes(0);
         done();
       });
+    });
+
+    it('sets the onDidChangeModelContent handler if saved', () => {
+      appState.isUnsaved = false;
+
+      expect(window.onbeforeunload).toBe(null);
+
+      const fn = window.ElectronFiddle.editors!.renderer!
+        .onDidChangeModelContent;
+      const call = (fn as jest.Mock<any>).mock.calls[0];
+      const cb = call[0];
+
+      cb();
+
+      expect(appState.isUnsaved).toBe(true);
     });
   });
 


### PR DESCRIPTION
Fixes #337.

Previously, we would attempt to load all of our unsaved handlers after a 1500ms timeout, since we didn't know when exactly the editors would mount.

https://github.com/electron/fiddle/blob/8e4238275c881e5ff09aedb48fbf029ae37c4bdf/src/renderer/app.tsx#L180-L184

No longer now.

* `this.setupUnsavedOnChangeListener()` has been refactored out to fit into the `autorun()` that handles the `appState.isUnsaved` state, so every time we mark something as not unsaved (i.e. _is saved_), we set up these handlers already. No more manual calls to do so!
* We now use async/await to ensure that `monaco` is loaded before we initially set up the `isUnsaved` state so that the handlers won't error out.

Caveat: This does make loading the Fiddle editors visibly slower. Is it a worthy tradeoff?
