### PR TITLE
feat: improved bisect commands UX

### DIFF
--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -2,7 +2,7 @@ import { Button } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { GenericDialogType } from '../../../src/interfaces';
+import { ElectronVersionState, GenericDialogType } from '../../../src/interfaces';
 import { AppState } from '../state';
 
 interface BisectHandlerProps {
@@ -19,6 +19,8 @@ export class BisectHandler extends React.Component<BisectHandlerProps> {
   }
 
   public continueBisect(isGood: boolean) {
+    window.ElectronFiddle.app.runner.stop();
+
     const { appState } = this.props;
     const response = appState.Bisector!.continue(isGood);
 
@@ -49,15 +51,18 @@ export class BisectHandler extends React.Component<BisectHandlerProps> {
   public render() {
     const { appState } = this.props;
     if (!!appState.Bisector) {
+      const isDownloading = appState.currentElectronVersion.state === ElectronVersionState.downloading;
       return (
         <>
           <Button
             icon={'thumbs-up'}
             onClick={() => this.continueBisect(true)}
+            disabled={isDownloading}
           />
           <Button
             icon={'thumbs-down'}
             onClick={() => this.continueBisect(false)}
+            disabled={isDownloading}
           />
           <Button
             icon={'cross'}

--- a/tests/renderer/components/__snapshots__/commands-bisect-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-bisect-spec.tsx.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Bisect commands component disables helper buttons if Electron binary is downloading 1`] = `
+<Fragment>
+  <Blueprint3.Button
+    disabled={true}
+    icon="thumbs-up"
+    onClick={[Function]}
+  />
+  <Blueprint3.Button
+    disabled={true}
+    icon="thumbs-down"
+    onClick={[Function]}
+  />
+  <Blueprint3.Button
+    icon="cross"
+    onClick={[Function]}
+  >
+    Cancel Bisect
+  </Blueprint3.Button>
+</Fragment>
+`;
+
 exports[`Bisect commands component renders bisect dialog button if no bisect instance 1`] = `
 <Blueprint3.Button
   icon="git-branch"
@@ -10,10 +31,12 @@ exports[`Bisect commands component renders bisect dialog button if no bisect ins
 exports[`Bisect commands component renders helper buttons if bisect instance is active 1`] = `
 <Fragment>
   <Blueprint3.Button
+    disabled={false}
     icon="thumbs-up"
     onClick={[Function]}
   />
   <Blueprint3.Button
+    disabled={false}
     icon="thumbs-down"
     onClick={[Function]}
   />


### PR DESCRIPTION
Fixes #319.

This does two things to improve the Bisect experience, based on my own usage of the feature:
* Upon selecting "Good" or "Bad", we kill the current Fiddle app.
* The "Good" and "Bad" buttons are disabled while the current Electron version is downloading.