### PR TITLE
build: Only notarize during make

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -106,8 +106,8 @@ function notarizeMaybe() {
     return;
   }
 
-  if (process.env.npm_lifecycle_event !== 'make') {
-    console.log(`Not in "make" mode, skipping notarization`);
+  if (process.env.npm_lifecycle_event !== 'publish') {
+    console.log(`Not in "publish" mode, skipping notarization`);
     return;
   }
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -7,6 +7,10 @@ const packageJson = require('./package.json')
 const { version } = packageJson
 const iconDir = path.resolve(__dirname, 'assets', 'icons')
 
+console.log(process.env)
+process.exit()
+
+
 const config = {
   hooks: {
     generateAssets: require('./tools/generateAssets')
@@ -106,8 +110,18 @@ function notarizeMaybe() {
     return;
   }
 
+  if (process.env.npm_lifecycle_event !== 'make') {
+    console.log(`Not in "make" mode, skipping notarization`);
+    return;
+  }
+
   if (!process.env.CI) {
     console.log(`Not in CI, skipping notarization`);
+    return;
+  }
+
+  if (!process.env.TRAVIS_TAG && !process.env.NOTARIZE_WITHOUT_TAG) {
+    console.log(`Not a tag, not notarizing`);
     return;
   }
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -7,10 +7,6 @@ const packageJson = require('./package.json')
 const { version } = packageJson
 const iconDir = path.resolve(__dirname, 'assets', 'icons')
 
-console.log(process.env)
-process.exit()
-
-
 const config = {
   hooks: {
     generateAssets: require('./tools/generateAssets')


### PR DESCRIPTION
This PR ensures that we only notarize during `npm run make` and only if we're on a Travis tag. 