### PR TITLE
Refactor BinaryManager, add download progress indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,10 +2185,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.8.0.tgz",
-      "integrity": "sha512-p9q2KNfN12lhLzcSJwjOKbHHZcPCP+DMHXWLE/nFzJfyFDiPFAvOgLdKwz8WvGfzn2Y8YtYk1BhqvaNRow78ag==",
-      "dev": true,
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.9.0.tgz",
+      "integrity": "sha512-OBIKtF6ttIJotDXe4KJMUyTBO4xMii+mFjlA8R4CORuD4HvCUaCK3lPjhdTRCvuEv6gzWNbAvd9DNBv0v780lw==",
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -2196,6 +2195,7 @@
         "global-agent": "^2.0.2",
         "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
+        "progress": "^2.0.3",
         "sanitize-filename": "^1.6.2",
         "sumchecker": "^3.0.1"
       },
@@ -2204,7 +2204,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2212,20 +2211,17 @@
         "env-paths": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-          "dev": true
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "sumchecker": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
           "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-          "dev": true,
           "requires": {
             "debug": "^4.1.0"
           }
@@ -3492,8 +3488,7 @@
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-      "dev": true
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
       "version": "1.7.1",
@@ -3508,7 +3503,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
@@ -3890,6 +3884,7 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
       "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -4051,7 +4046,8 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
@@ -4365,7 +4361,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -4408,7 +4405,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4553,12 +4551,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
     },
     "babel-jest": {
       "version": "25.1.0",
@@ -4794,6 +4794,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -4838,7 +4839,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
       "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
-      "dev": true,
       "optional": true
     },
     "brace-expansion": {
@@ -5172,7 +5172,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -5187,7 +5186,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -5195,8 +5193,7 @@
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
       }
     },
@@ -5241,12 +5238,14 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
@@ -5282,7 +5281,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "ccount": {
       "version": "1.0.5",
@@ -5588,7 +5588,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5596,7 +5595,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5612,7 +5612,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -5758,7 +5759,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "ini": "^1.3.4",
@@ -6448,6 +6448,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
       }
@@ -6456,6 +6457,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -6517,7 +6519,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -6539,7 +6542,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -6564,11 +6566,6 @@
         }
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -6592,8 +6589,7 @@
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-      "dev": true
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -6728,7 +6724,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-      "dev": true,
       "optional": true
     },
     "diff": {
@@ -6937,13 +6932,13 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0"
@@ -7010,52 +7005,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-        }
-      }
-    },
-    "electron-download": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
-      "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
-      "requires": {
-        "debug": "^3.0.0",
-        "env-paths": "^1.0.0",
-        "fs-extra": "^4.0.1",
-        "minimist": "^1.2.0",
-        "nugget": "^2.0.1",
-        "path-exists": "^3.0.0",
-        "rc": "^1.2.1",
-        "semver": "^5.4.1",
-        "sumchecker": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "semver": {
           "version": "5.7.0",
@@ -7509,8 +7458,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -7533,11 +7481,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
-    },
-    "env-paths": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
     },
     "envinfo": {
       "version": "7.4.0",
@@ -8037,6 +7980,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -8067,7 +8011,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "optional": true
     },
     "es6-promise": {
@@ -8830,7 +8773,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -8954,7 +8898,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "falafel": {
       "version": "2.1.0",
@@ -8985,7 +8930,8 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -9027,7 +8973,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -9173,6 +9120,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "requires": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -9182,6 +9130,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -9290,12 +9239,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
@@ -10207,7 +10158,8 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -10227,6 +10179,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -10272,7 +10225,6 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
       "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
@@ -10288,7 +10240,6 @@
           "version": "3.6.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
           "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-          "dev": true,
           "optional": true
         }
       }
@@ -10321,7 +10272,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
       "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "encodeurl": "^1.0.2",
@@ -10340,7 +10290,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
       "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "define-properties": "^1.1.3"
@@ -10350,7 +10299,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-          "dev": true,
           "optional": true,
           "requires": {
             "object-keys": "^1.0.12"
@@ -10360,7 +10308,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true,
           "optional": true
         }
       }
@@ -10483,7 +10430,6 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
       "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "dev": true,
       "requires": {
         "@sindresorhus/is": "^0.14.0",
         "@szmarczak/http-timer": "^1.1.2",
@@ -10528,12 +10474,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
         "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
@@ -10668,7 +10616,8 @@
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -10818,10 +10767,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -10848,6 +10796,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -10967,6 +10916,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -11200,7 +11150,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -11227,6 +11178,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       },
@@ -11234,7 +11186,8 @@
         "builtin-modules": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
         }
       }
     },
@@ -11344,6 +11297,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -11352,6 +11306,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -11499,7 +11454,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-url": {
       "version": "1.2.4",
@@ -11509,7 +11465,8 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -11538,7 +11495,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -11563,7 +11521,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -13522,6 +13481,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -13746,8 +13706,7 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-      "dev": true
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -13758,12 +13717,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13811,6 +13772,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -13838,7 +13800,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -13919,6 +13880,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -13930,7 +13892,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -14089,6 +14052,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -14097,8 +14061,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -14178,7 +14141,8 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -14205,7 +14169,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
       "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -14215,7 +14178,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true,
           "optional": true
         }
       }
@@ -14281,6 +14243,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
       "requires": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -14297,7 +14260,8 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -14389,8 +14353,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "min-indent": {
       "version": "1.0.0",
@@ -14867,7 +14830,7 @@
           "dependencies": {
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -14968,6 +14931,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -14978,7 +14942,8 @@
         "semver": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -15003,8 +14968,7 @@
     "normalize-url": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-      "dev": true
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "normalize.css": {
       "version": "8.0.1",
@@ -15015,7 +14979,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
@@ -15143,6 +15106,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
+      "dev": true,
       "requires": {
         "debug": "^2.1.3",
         "minimist": "^1.1.0",
@@ -15156,7 +15120,8 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -15169,7 +15134,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -15180,7 +15146,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -15232,7 +15199,8 @@
     "object-keys": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -15639,8 +15607,7 @@
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-      "dev": true
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -15960,6 +15927,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -16012,7 +15980,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -16040,6 +16009,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -16049,7 +16019,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -16074,7 +16045,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "physical-cpu-count": {
       "version": "2.0.0",
@@ -16097,8 +16069,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -17060,13 +17031,13 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "pretty-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+      "dev": true,
       "requires": {
         "get-stdin": "^4.0.1",
         "meow": "^3.1.0"
@@ -17152,13 +17123,13 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "progress-stream": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+      "dev": true,
       "requires": {
         "speedometer": "~0.1.2",
         "through2": "~0.2.3"
@@ -17224,7 +17195,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true,
       "optional": true
     },
     "prr": {
@@ -17271,7 +17241,8 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -17282,7 +17253,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -17416,24 +17388,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "rcedit": {
       "version": "2.1.0",
@@ -17604,6 +17558,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -17614,6 +17569,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -17623,6 +17579,7 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -17652,6 +17609,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
       "requires": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -17964,6 +17922,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -17978,6 +17937,7 @@
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -18107,7 +18067,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -18185,7 +18144,6 @@
       "version": "2.15.2",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
       "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
-      "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
@@ -18200,7 +18158,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-          "dev": true,
           "optional": true
         }
       }
@@ -18293,7 +18250,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
       "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-      "dev": true,
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -18332,7 +18288,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true,
       "optional": true
     },
     "send": {
@@ -18368,7 +18323,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
       "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "type-fest": "^0.8.0"
@@ -18564,6 +18518,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1"
       }
@@ -18762,6 +18717,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -18770,12 +18726,14 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -18784,7 +18742,8 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
     },
     "specificity": {
       "version": "0.4.1",
@@ -18795,7 +18754,8 @@
     "speedometer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -18816,6 +18776,7 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -19150,6 +19111,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -19338,7 +19300,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringify-entities": {
       "version": "1.3.2",
@@ -19364,6 +19327,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
       }
@@ -19383,14 +19347,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
       "requires": {
         "get-stdin": "^4.0.1"
       }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-search": {
       "version": "0.1.0",
@@ -20027,14 +19987,6 @@
         "postcss": "^7.0.2"
       }
     },
-    "sumchecker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
-      "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
-      "requires": {
-        "debug": "^2.2.0"
-      }
-    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -20320,7 +20272,8 @@
     "throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -20332,6 +20285,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "dev": true,
       "requires": {
         "readable-stream": "~1.1.9",
         "xtend": "~2.1.1"
@@ -20447,8 +20401,7 @@
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "dev": true
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",
@@ -20482,6 +20435,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
       "requires": {
         "punycode": "^1.4.1"
       }
@@ -20512,7 +20466,8 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
@@ -20536,7 +20491,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "dev": true,
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -20676,13 +20630,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "optional": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -20691,6 +20645,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -20711,8 +20666,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typed-styles": {
       "version": "0.0.7",
@@ -21291,7 +21245,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -21315,8 +21268,7 @@
     "utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-      "dev": true
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util": {
       "version": "0.11.1",
@@ -21344,7 +21296,8 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -21375,6 +21328,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -21390,6 +21344,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -21706,6 +21661,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dev": true,
       "requires": {
         "object-keys": "~0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   "dependencies": {
     "@blueprintjs/core": "^3.24.0",
     "@blueprintjs/select": "^3.12.0",
+    "@electron/get": "^1.9.0",
     "@octokit/rest": "^16.43.1",
     "@sentry/electron": "^1.2.1",
     "classnames": "^2.2.6",
     "electron-default-menu": "^1.0.1",
     "electron-devtools-installer": "^2.2.4",
-    "electron-download": "^4.1.1",
     "electron-squirrel-startup": "^1.0.0",
     "extract-zip": "^1.6.7",
     "fix-path": "^3.0.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,13 +4,13 @@ export type Files = Map<string, string>;
 
 export type FileTransform = (files: Files) => Promise<Files>;
 
-export enum ElectronVersionState {
+export enum VersionState {
   ready = 'ready',
   downloading = 'downloading',
   unknown = 'unknown'
 }
 
-export enum ElectronVersionSource {
+export enum VersionSource {
   remote = 'remote',
   local = 'local'
 }
@@ -29,9 +29,9 @@ export interface EditorValues {
   package?: string;
 }
 
-export interface ElectronVersion extends Version {
-  state: ElectronVersionState;
-  source: ElectronVersionSource;
+export interface RunnableVersion extends Version {
+  state: VersionState;
+  source: VersionSource;
 }
 
 export interface SetFiddleOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export type FileTransform = (files: Files) => Promise<Files>;
 export enum VersionState {
   ready = 'ready',
   downloading = 'downloading',
+  unzipping = 'unzipping',
   unknown = 'unknown'
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,7 @@ export interface EditorValues {
 export interface RunnableVersion extends Version {
   state: VersionState;
   source: VersionSource;
+  downloadProgress?: number;
 }
 
 export interface SetFiddleOptions {

--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -75,8 +75,6 @@ export class BinaryManager {
   public async setup(iVersion: string): Promise<void> {
     const version = normalizeVersion(iVersion);
     const fs = await fancyImport<typeof fsType>('fs-extra');
-    const { promisify } = await import('util');
-    const eDownload = promisify(require('electron-download'));
 
     await fs.mkdirp(this.getDownloadPath(version));
 
@@ -94,7 +92,7 @@ export class BinaryManager {
     console.log(`BinaryManager: Electron ${version} not present, downloading`);
     this.state[version] = 'downloading';
 
-    const zipPath = await eDownload({ version });
+    const zipPath = await this.download({ version });
     const extractPath = this.getDownloadPath(version);
     console.log(`BinaryManager: Electron ${version} downloaded, now unpacking to ${extractPath}`);
 
@@ -238,5 +236,9 @@ export class BinaryManager {
         resolve();
       });
     });
+  }
+
+  private download({ version }: { version: string }): Promise<string> {
+
   }
 }

--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -5,7 +5,7 @@ import { VersionState } from '../interfaces';
 import { fancyImport } from '../utils/import';
 import { normalizeVersion } from '../utils/normalize-version';
 import { USER_DATA_PATH } from './constants';
-import { getOfflineTypeDefinitionPath } from './fetch-types';
+import { removeTypeDefsForVersion } from './fetch-types';
 import { AppState } from './state';
 
 /**
@@ -147,24 +147,6 @@ export function getDownloadingVersions(appState: AppState) {
     .map(([version, _]) => version);
 }
 
-/**
- * Removes the type definition for a given version
- *
- * @param version
- */
-export async function removeTypeDefsForVersion(version: string) {
-  const fs = await fancyImport<typeof fsType>('fs-extra');
-  const _version = normalizeVersion(version);
-  const typeDefsDir = path.dirname(getOfflineTypeDefinitionPath(_version));
-
-  if (fs.existsSync(typeDefsDir)) {
-    try {
-      await fs.remove(typeDefsDir);
-    } catch (error) {
-      throw error;
-    }
-  }
-}
 
 /**
  * Returns an array of all versions downloaded to disk

--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -1,244 +1,273 @@
 import * as fsType from 'fs-extra';
 import * as path from 'path';
 
+import { VersionState } from '../interfaces';
 import { fancyImport } from '../utils/import';
 import { normalizeVersion } from '../utils/normalize-version';
 import { USER_DATA_PATH } from './constants';
 import { getOfflineTypeDefinitionPath } from './fetch-types';
+import { AppState } from './state';
 
 /**
- * The binary manager takes care of downloading Electron versions
+ * General setup, called with a version. Is called during construction
+ * to ensure that we always have or download at least one version.
  *
- * @export
- * @class BinaryManager
+ * @param {string} iVersion
+ * @returns {Promise<void>}
  */
-export class BinaryManager {
-  public state: Record<string, 'ready' | 'downloading'> = {};
+export async function setupBinary(appState: AppState, iVersion: string): Promise<void> {
+  const version = normalizeVersion(iVersion);
+  const fs = await fancyImport<typeof fsType>('fs-extra');
 
-  /**
-   * Remove a version from disk. Does not update state. We'll try up to
-   * four times before giving up if an error occurs.
-   *
-   * @param {string} iVersion
-   * @returns {Promise<void>}
-   */
-  public async remove(iVersion: string): Promise<void> {
-    const version = normalizeVersion(iVersion);
-    const fs = await fancyImport<typeof fsType>('fs-extra');
-    let isDeleted = false;
+  await fs.mkdirp(getDownloadPath(version));
 
-    // utility to re-run removal functions upon failure
-    // due to windows filesystem lockfile jank
-    const rerunner = async (func: () => Promise<void>, counter: number = 1) => {
-      try {
-        await func();
-      } catch (error) {
-        console.warn(`Binary Manager: failed to run ${func.name} for ${version}, but failed`, error);
-        if (counter < 4) {
-          console.log(`Binary Manager: Trying again to run ${func.name}`);
-          await rerunner(func, counter + 1);
-        }
-      }
-    };
-
-    const binaryCleaner = async () => {
-      if (await this.getIsDownloaded(version)) {
-        // This is necessary since we're messing with .asar files inside
-        // the Electron binaries. Electron, powering Fiddle, will try to
-        // "correct" our calls, but we don't want that right here.
-        process.noAsar = true;
-        await fs.remove(this.getDownloadPath(version));
-        process.noAsar = false;
-
-        isDeleted = true;
-      }
-    };
-
-    const typeDefsCleaner = async () => {
-      await this.removeTypeDefsForVersion(version);
-    };
-
-    await rerunner(binaryCleaner);
-
-    if (isDeleted) {
-      await rerunner(typeDefsCleaner);
-    }
+  if (appState.versions[version].state === VersionState.downloading) {
+    console.log(`Binary: Electron ${version} already downloading.`);
+    return;
   }
 
-  /**
-   * General setup, called with a version. Is called during construction
-   * to ensure that we always have or download at least one version.
-   *
-   * @param {string} iVersion
-   * @returns {Promise<void>}
-   */
-  public async setup(iVersion: string): Promise<void> {
-    const version = normalizeVersion(iVersion);
-    const fs = await fancyImport<typeof fsType>('fs-extra');
+  if (await getIsDownloaded(version)) {
+    console.log(`Binary: Electron ${version} already downloaded.`);
+    appState.versions[version].state = VersionState.ready;
+    return;
+  }
 
-    await fs.mkdirp(this.getDownloadPath(version));
+  console.log(`Binary: Electron ${version} not present, downloading`);
+  appState.versions[version].state = VersionState.downloading;
 
-    if (this.state[version] === 'downloading') {
-      console.log(`BinaryManager: Electron ${version} already downloading.`);
-      return;
-    }
+  const zipPath = await download(appState, version);
+  const extractPath = getDownloadPath(version);
+  console.log(`Binary: Electron ${version} downloaded, now unpacking to ${extractPath}`);
 
-    if (await this.getIsDownloaded(version)) {
-      console.log(`BinaryManager: Electron ${version} already downloaded.`);
-      this.state[version] = 'ready';
-      return;
-    }
+  try {
+    // Ensure the target path is empty
+    await fs.emptyDir(extractPath);
 
-    console.log(`BinaryManager: Electron ${version} not present, downloading`);
-    this.state[version] = 'downloading';
+    const electronFiles = await unzip(zipPath, extractPath);
+    console.log(`Unzipped ${version}`, electronFiles);
+  } catch (error) {
+    console.warn(`Failure while unzipping ${version}`, error);
 
-    const zipPath = await this.download({ version });
-    const extractPath = this.getDownloadPath(version);
-    console.log(`BinaryManager: Electron ${version} downloaded, now unpacking to ${extractPath}`);
+    // TODO: Handle this case
+  }
 
+  appState.versions[version].state = VersionState.ready;
+}
+
+/**
+ * Remove a version from disk. Does not update state. We'll try up to
+ * four times before giving up if an error occurs.
+ *
+ * @param {string} iVersion
+ * @returns {Promise<void>}
+ */
+export async function removeBinary(iVersion: string) {
+  const version = normalizeVersion(iVersion);
+  const fs = await fancyImport<typeof fsType>('fs-extra');
+  let isDeleted = false;
+
+  // utility to re-run removal functions upon failure
+  // due to windows filesystem lockfile jank
+  const rerunner = async (func: () => Promise<void>, counter: number = 1) => {
     try {
-      // Ensure the target path is empty
-      await fs.emptyDir(extractPath);
-
-      const electronFiles = await this.unzip(zipPath, extractPath);
-      console.log(`Unzipped ${version}`, electronFiles);
+      await func();
     } catch (error) {
-      console.warn(`Failure while unzipping ${version}`, error);
-
-      // TODO: Handle this case
-    }
-
-    this.state[version] = 'ready';
-  }
-
-  /**
-   * Gets the expected path for the binary of a given Electron version
-   *
-   * @param {string} version
-   * @param {string} dir
-   * @returns {string}
-   */
-  public getElectronBinaryPath(
-    version: string,
-    dir: string = this.getDownloadPath(version),
-  ): string {
-    switch (process.platform) {
-      case 'darwin':
-        return path.join(dir, 'Electron.app/Contents/MacOS/Electron');
-      case 'freebsd':
-      case 'linux':
-        return path.join(dir, 'electron');
-      case 'win32':
-        return path.join(dir, 'electron.exe');
-      default:
-        throw new Error(`Electron builds are not available for ${process.platform}`);
-    }
-  }
-
-  /**
-   * Returns an array of all versions downloaded to disk
-   *
-   * @returns {Promise<Array<string>>}
-   */
-  public async getDownloadedVersions(): Promise<Array<string>> {
-    const fs = await fancyImport<typeof fsType>('fs-extra');
-    const downloadPath = path.join(USER_DATA_PATH, 'electron-bin');
-    console.log(`BinaryManager: Checking for downloaded versions`);
-
-    try {
-      const directories = await fs.readdir(downloadPath);
-      const knownVersions: Array<string> = [];
-
-      for (const directory of directories) {
-        if (await this.getIsDownloaded(directory)) {
-          knownVersions.push(directory);
-        }
-      }
-
-      return knownVersions;
-    } catch (error) {
-      console.warn(`Could not read known Electron versions`);
-      return [];
-    }
-  }
-
-  public getDownloadingVersions() {
-    return Object.entries(this.state)
-      .filter(([_, state]) => state === 'downloading')
-      .map(([version, _]) => version);
-  }
-
-  /**
-   * Did we already download a given version?
-   *
-   * @param {string} version
-   * @param {string} dir
-   * @returns {boolean}
-   */
-  public async getIsDownloaded(version: string, dir?: string): Promise<boolean> {
-    const expectedPath = this.getElectronBinaryPath(version, dir);
-    const fs = await fancyImport<typeof fsType>('fs-extra');
-
-    return fs.existsSync(expectedPath);
-  }
-
-  public async removeTypeDefsForVersion(version: string) {
-    const fs = await fancyImport<typeof fsType>('fs-extra');
-    const _version = normalizeVersion(version);
-    const typeDefsDir = path.dirname(getOfflineTypeDefinitionPath(_version));
-
-    if (fs.existsSync(typeDefsDir)) {
-      try {
-        await fs.remove(typeDefsDir);
-      } catch (error) {
-        throw error;
+      console.warn(`Binary Manager: failed to run ${func.name} for ${version}, but failed`, error);
+      if (counter < 4) {
+        console.log(`Binary Manager: Trying again to run ${func.name}`);
+        await rerunner(func, counter + 1);
       }
     }
-  }
+  };
 
-  /**
-   * Gets the expected path for a given Electron version
-   *
-   * @param {string} version
-   * @returns {string}
-   */
-  private getDownloadPath(version: string): string {
-    return path.join(USER_DATA_PATH, 'electron-bin', version);
-  }
-
-
-  /**
-   * Unzips an electron package so that we can actually use it.
-   *
-   * @param {string} zipPath
-   * @param {string} extractPath
-   * @returns {Promise<void>}
-   */
-  private unzip(zipPath: string, extractPath: string): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      const extract = (await fancyImport<any>('extract-zip')).default;
-
+  const binaryCleaner = async () => {
+    if (await getIsDownloaded(version)) {
+      // This is necessary since we're messing with .asar files inside
+      // the Electron binaries. Electron, powering Fiddle, will try to
+      // "correct" our calls, but we don't want that right here.
       process.noAsar = true;
+      await fs.remove(getDownloadPath(version));
+      process.noAsar = false;
 
-      const options = {
-        dir: extractPath,
-      };
+      isDeleted = true;
+    }
+  };
 
-      extract(zipPath, options, (error: Error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
+  const typeDefsCleaner = async () => {
+    await removeTypeDefsForVersion(version);
+  };
 
-        console.log(`BinaryManager: Unpacked!`);
-        process.noAsar = false;
+  await rerunner(binaryCleaner);
 
-        resolve();
-      });
+  if (isDeleted) {
+    await rerunner(typeDefsCleaner);
+  }
+}
+
+/* Did we already download a given version?
+*
+* @param {string} version
+* @param {string} dir
+* @returns {boolean}
+*/
+export async function getIsDownloaded(version: string, dir?: string): Promise<boolean> {
+ const expectedPath = getElectronBinaryPath(version, dir);
+ const fs = await fancyImport<typeof fsType>('fs-extra');
+
+ return fs.existsSync(expectedPath);
+}
+
+/**
+ * Gets the expected path for the binary of a given Electron version
+ *
+ * @param {string} version
+ * @param {string} dir
+ * @returns {string}
+ */
+export function getElectronBinaryPath(
+  version: string,
+  dir: string = getDownloadPath(version),
+): string {
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(dir, 'Electron.app/Contents/MacOS/Electron');
+    case 'freebsd':
+    case 'linux':
+      return path.join(dir, 'electron');
+    case 'win32':
+      return path.join(dir, 'electron.exe');
+    default:
+      throw new Error(`Electron builds are not available for ${process.platform}`);
+  }
+}
+
+export function getDownloadingVersions(appState: AppState) {
+  return Object.entries(appState.versions)
+    .filter(([_, { state }]) => state === 'downloading')
+    .map(([version, _]) => version);
+}
+
+/**
+ * Removes the type definition for a given version
+ *
+ * @param version
+ */
+export async function removeTypeDefsForVersion(version: string) {
+  const fs = await fancyImport<typeof fsType>('fs-extra');
+  const _version = normalizeVersion(version);
+  const typeDefsDir = path.dirname(getOfflineTypeDefinitionPath(_version));
+
+  if (fs.existsSync(typeDefsDir)) {
+    try {
+      await fs.remove(typeDefsDir);
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Returns an array of all versions downloaded to disk
+ *
+ * @returns {Promise<Array<string>>}
+ */
+export async function getDownloadedVersions(): Promise<Array<string>> {
+  const fs = await fancyImport<typeof fsType>('fs-extra');
+  const downloadPath = path.join(USER_DATA_PATH, 'electron-bin');
+  console.log(`Binary: Checking for downloaded versions`);
+
+  try {
+    const directories = await fs.readdir(downloadPath);
+    const knownVersions: Array<string> = [];
+
+    for (const directory of directories) {
+      if (await getIsDownloaded(directory)) {
+        knownVersions.push(directory);
+      }
+    }
+
+    return knownVersions;
+  } catch (error) {
+    console.warn(`Could not read known Electron versions`);
+    return [];
+  }
+}
+
+/**
+ * Download an Electron version.
+ *
+ * @param {AppState} appState
+ * @param {string} version
+ * @returns {Promise<string>}
+ */
+async function download(appState: AppState, version: string): Promise<string> {
+  const { download: electronDownload } = await import('@electron/get');
+  const getProgressCallback = (progress: Progress) => {
+    const roundedProgress = Math.round(progress.percent * 100) / 100;
+
+    if (roundedProgress !== appState.versions[version].downloadProgress) {
+      console.debug(`Binary: Version ${version} download progress: ${progress.percent}`);
+      appState.versions[version].downloadProgress = roundedProgress;
+    }
+  };
+
+  if (!appState.versions[version]) {
+    throw new Error(`Version ${version} does not exist in state, cannot download`);
+  }
+
+  const zipFilePath = await electronDownload(version, {
+    downloadOptions: {
+      quiet: true,
+      getProgressCallback
+    }
+  });
+
+  return zipFilePath;
+}
+
+/**
+ * Gets the expected path for a given Electron version
+ *
+ * @param {string} version
+ * @returns {string}
+ */
+function getDownloadPath(version: string): string {
+  return path.join(USER_DATA_PATH, 'electron-bin', version);
+}
+
+/**
+ * Unzips an electron package so that we can actually use it.
+ *
+ * @param {string} zipPath
+ * @param {string} extractPath
+ * @returns {Promise<void>}
+ */
+function unzip(zipPath: string, extractPath: string): Promise<void> {
+  return new Promise(async (resolve, reject) => {
+    const extract = (await fancyImport<any>('extract-zip')).default;
+
+    process.noAsar = true;
+
+    const options = {
+      dir: extractPath,
+    };
+
+    extract(zipPath, options, (error: Error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      console.log(`Binary: Unpacked!`);
+      process.noAsar = false;
+
+      resolve();
     });
-  }
+  });
+}
 
-  private download({ version }: { version: string }): Promise<string> {
-
-  }
+interface Progress {
+  percent: number;
+  transferred: number;
+  total: number;
 }

--- a/src/renderer/bisect.ts
+++ b/src/renderer/bisect.ts
@@ -1,12 +1,12 @@
-import { ElectronVersion } from '../interfaces';
+import { RunnableVersion } from '../interfaces';
 
 export class Bisector {
-  public revList: Array<ElectronVersion>;
+  public revList: Array<RunnableVersion>;
   public minRev: number;
   public maxRev: number;
   private pivot: number;
 
-  constructor(revList: Array<ElectronVersion>) {
+  constructor(revList: Array<RunnableVersion>) {
     this.getCurrentVersion = this.getCurrentVersion.bind(this);
     this.continue = this.continue.bind(this);
     this.calculatePivot = this.calculatePivot.bind(this);

--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -2,7 +2,7 @@ import { Button } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersionState, GenericDialogType } from '../../../src/interfaces';
+import { GenericDialogType, VersionState } from '../../../src/interfaces';
 import { AppState } from '../state';
 
 interface BisectHandlerProps {
@@ -51,7 +51,7 @@ export class BisectHandler extends React.Component<BisectHandlerProps> {
   public render() {
     const { appState } = this.props;
     if (!!appState.Bisector) {
-      const isDownloading = appState.currentElectronVersion.state === ElectronVersionState.downloading;
+      const isDownloading = appState.currentElectronVersion.state === VersionState.downloading;
       return (
         <>
           <Button

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -2,7 +2,7 @@ import { Button, IButtonProps, Spinner } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersionState } from '../../interfaces';
+import { VersionState } from '../../interfaces';
 import { AppState } from '../state';
 
 export interface RunnerState {
@@ -27,11 +27,11 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
     const state = currentElectronVersion && currentElectronVersion.state;
     const props: IButtonProps = { className: 'button-run' };
 
-    if (state === ElectronVersionState.downloading) {
+    if (state === VersionState.downloading) {
       props.text = 'Downloading';
       props.disabled = true;
       props.icon = <Spinner size={16} />;
-    } else if (state === ElectronVersionState.ready) {
+    } else if (state === VersionState.ready) {
       if (isRunning) {
         props.active = true;
         props.text = 'Stop';

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -25,13 +25,17 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
     const { isRunning, currentElectronVersion } = this.props.appState;
 
     const state = currentElectronVersion && currentElectronVersion.state;
-    const props: IButtonProps = { className: 'button-run' };
+    const props: IButtonProps = { className: 'button-run', disabled: true };
 
     if (state === VersionState.downloading) {
       props.text = 'Downloading';
-      props.disabled = true;
+      props.icon = <Spinner size={16} value={currentElectronVersion?.downloadProgress} />;
+    } else if (state === VersionState.unzipping) {
+      props.text = 'Unzipping';
       props.icon = <Spinner size={16} />;
     } else if (state === VersionState.ready) {
+      props.disabled = false;
+
       if (isRunning) {
         props.active = true;
         props.text = 'Stop';
@@ -44,7 +48,6 @@ export class Runner extends React.Component<RunnerProps, RunnerState> {
       }
     } else {
       props.text = 'Checking status';
-      props.disabled = true;
       props.icon = <Spinner size={16} />;
     }
 

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -8,6 +8,7 @@ import * as semver from 'semver';
 import { Version } from '../../interfaces';
 import { IpcEvents } from '../../ipc-events';
 import { getElectronNameForPlatform } from '../../utils/electron-name';
+import { getIsDownloaded } from '../binary';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
 
@@ -58,8 +59,7 @@ export class AddVersionDialog extends React.Component<AddVersionDialogProps, Add
    * @param {React.ChangeEvent<HTMLInputElement>} event
    */
   public async setFolderPath(folderPath: string) {
-    const { binaryManager } = this.props.appState;
-    const isValidElectron = !!await binaryManager.getIsDownloaded('custom', folderPath);
+    const isValidElectron = !!await getIsDownloaded('custom', folderPath);
 
     this.setState({ folderPath, isValidElectron });
   }

--- a/src/renderer/components/dialog-bisect.tsx
+++ b/src/renderer/components/dialog-bisect.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, Callout, Dialog, Label } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersion } from '../../interfaces';
+import { RunnableVersion } from '../../interfaces';
 import { Bisector } from '../bisect';
 import { AppState } from '../state';
 import { VersionSelect } from './version-select';
@@ -14,7 +14,7 @@ export interface BisectDialogProps {
 export interface BisectDialogState {
   startIndex: number;
   endIndex: number;
-  allVersions: Array<ElectronVersion>;
+  allVersions: Array<RunnableVersion>;
   showHelp?: boolean;
 }
 
@@ -44,11 +44,11 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
     };
   }
 
-  public onBeginSelect(version: ElectronVersion) {
+  public onBeginSelect(version: RunnableVersion) {
     this.setState({ startIndex: this.state.allVersions.indexOf(version) });
   }
 
-  public onEndSelect(version: ElectronVersion) {
+  public onEndSelect(version: RunnableVersion) {
     this.setState({ endIndex: this.state.allVersions.indexOf(version) });
   }
 
@@ -208,10 +208,10 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
   /**
    * Should an item in the "earliest version" dropdown be disabled?
    *
-   * @param {ElectronVersion} version
+   * @param {RunnableVersion} version
    * @returns {boolean}
    */
-  public isEarliestItemDisabled(version: ElectronVersion): boolean {
+  public isEarliestItemDisabled(version: RunnableVersion): boolean {
     const { allVersions, endIndex } = this.state;
 
     // In the array, "newer" versions will have a lower index.
@@ -225,10 +225,10 @@ export class BisectDialog extends React.Component<BisectDialogProps, BisectDialo
   /**
    * Should an item in the "latest version" dropdown be disabled?
    *
-   * @param {ElectronVersion} version
+   * @param {RunnableVersion} version
    * @returns {boolean}
    */
-  public isLatestItemDisabled(version: ElectronVersion): boolean {
+  public isLatestItemDisabled(version: RunnableVersion): boolean {
     const { allVersions, startIndex } = this.state;
 
     return allVersions.indexOf(version) > startIndex - 1;

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -13,7 +13,7 @@ import {
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../interfaces';
+import { RunnableVersion, VersionSource, VersionState } from '../../interfaces';
 import { normalizeVersion } from '../../utils/normalize-version';
 import { sortedElectronMap } from '../../utils/sorted-electron-map';
 import { AppState } from '../state';
@@ -70,7 +70,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
     if (!checked) {
       appState.statesToShow = appState.statesToShow.filter((s) => s !== id);
     } else {
-      appState.statesToShow.push(id as ElectronVersionState);
+      appState.statesToShow.push(id as VersionState);
     }
   }
 
@@ -203,7 +203,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
    */
   private renderVersionStateOptions(): JSX.Element {
     const { appState } = this.props;
-    const getIsChecked = (state: ElectronVersionState) => {
+    const getIsChecked = (state: VersionState) => {
       return appState.statesToShow.includes(state);
     };
 
@@ -217,7 +217,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
           intent='primary'
         >
           <Checkbox
-            checked={getIsChecked(ElectronVersionState.ready)}
+            checked={getIsChecked(VersionState.ready)}
             label='Ready'
             id='ready'
             onChange={this.handleStateChange}
@@ -226,14 +226,14 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
           />
         </Tooltip>
         <Checkbox
-          checked={getIsChecked(ElectronVersionState.downloading)}
+          checked={getIsChecked(VersionState.downloading)}
           label='Downloading'
           id='downloading'
           onChange={this.handleStateChange}
           inline={true}
         />
         <Checkbox
-          checked={getIsChecked(ElectronVersionState.unknown)}
+          checked={getIsChecked(VersionState.unknown)}
           label='Not Downloaded'
           id='unknown'
           onChange={this.handleStateChange}
@@ -355,18 +355,18 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
   /**
    * Returns a human-readable state indicator for an Electron version
    *
-   * @param {ElectronVersion} item
+   * @param {RunnableVersion} item
    * @returns {JSX.Element}
    */
-  private renderHumanState(item: ElectronVersion): JSX.Element {
+  private renderHumanState(item: RunnableVersion): JSX.Element {
     const { state } = item;
     let icon: IconName = 'box';
     let humanState = 'Downloaded';
 
-    if (state === ElectronVersionState.downloading) {
+    if (state === VersionState.downloading) {
       icon = 'cloud-download';
       humanState = 'Downloading';
-    } else if (state === ElectronVersionState.unknown) {
+    } else if (state === VersionState.unknown) {
       icon = 'cloud';
       humanState = 'Not downloaded';
     }
@@ -383,10 +383,10 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
    *
    * @private
    * @param {string} key
-   * @param {ElectronVersion} item
+   * @param {RunnableVersion} item
    * @returns {JSX.Element}
    */
-  private renderAction(key: string, item: ElectronVersion): JSX.Element {
+  private renderAction(key: string, item: RunnableVersion): JSX.Element {
     const { state, source } = item;
     const { appState } = this.props;
     const buttonProps: IButtonProps = {
@@ -398,7 +398,7 @@ export class ElectronSettings extends React.Component<ElectronSettingsProps, Ele
     if (state === 'ready') {
       buttonProps.onClick = () => appState.removeVersion(key);
       buttonProps.icon = 'trash';
-      buttonProps.text = source === ElectronVersionSource.local
+      buttonProps.text = source === VersionSource.local
         ? 'Remove'
         : 'Delete';
     } else if (state === 'downloading') {

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -19,7 +19,7 @@ const ThemeSelect = Select.ofType<LoadedFiddleTheme>();
  * version.
  *
  * @param {string} query
- * @param {ElectronVersion} { version }
+ * @param {RunnableVersion} { version }
  * @returns
  */
 export const filterItem: ItemPredicate<LoadedFiddleTheme> = (query, { name }) => {
@@ -31,7 +31,7 @@ export const filterItem: ItemPredicate<LoadedFiddleTheme> = (query, { name }) =>
  * Helper method: Returns the <Select /> <MenuItem /> for Electron
  * versions.
  *
- * @param {ElectronVersion} item
+ * @param {RunnableVersion} item
  * @param {IItemRendererProps} { handleClick, modifiers, query }
  * @returns
  */

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -3,30 +3,30 @@ import { ItemPredicate, ItemRenderer, Select } from '@blueprintjs/select';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../interfaces';
+import { RunnableVersion, VersionSource, VersionState } from '../../interfaces';
 import { highlightText } from '../../utils/highlight-text';
 import { AppState } from '../state';
 
-const ElectronVersionSelect = Select.ofType<ElectronVersion>();
+const ElectronVersionSelect = Select.ofType<RunnableVersion>();
 
 /**
  * Helper method: Returns the <Select /> label for an Electron
  * version.
  *
- * @param {ElectronVersion} { source, state }
+ * @param {RunnableVersion} { source, state }
  * @returns {string}
  */
-export function getItemLabel({ source, state, name }: ElectronVersion): string {
+export function getItemLabel({ source, state, name }: RunnableVersion): string {
   let label = '';
 
-  if (source === ElectronVersionSource.local) {
+  if (source === VersionSource.local) {
     label = name || 'Local';
   } else {
-    if (state === ElectronVersionState.unknown) {
+    if (state === VersionState.unknown) {
       label = `Not downloaded`;
-    } else if (state === ElectronVersionState.ready) {
+    } else if (state === VersionState.ready) {
       label = `Downloaded`;
-    } else if (state === ElectronVersionState.downloading) {
+    } else if (state === VersionState.downloading) {
       label = `Downloading`;
     }
   }
@@ -38,10 +38,10 @@ export function getItemLabel({ source, state, name }: ElectronVersion): string {
  * Helper method: Returns the <Select /> icon for an Electron
  * version.
  *
- * @param {ElectronVersion} { state }
+ * @param {RunnableVersion} { state }
  * @returns
  */
-export function getItemIcon({ state }: ElectronVersion) {
+export function getItemIcon({ state }: RunnableVersion) {
   return state === 'ready'
     ? 'saved'
     : state === 'downloading' ? 'cloud-download' : 'cloud';
@@ -52,10 +52,10 @@ export function getItemIcon({ state }: ElectronVersion) {
  * version.
  *
  * @param {string} query
- * @param {ElectronVersion} { version }
+ * @param {RunnableVersion} { version }
  * @returns
  */
-export const filterItem: ItemPredicate<ElectronVersion> = (query, { version }) => {
+export const filterItem: ItemPredicate<RunnableVersion> = (query, { version }) => {
   return version.toLowerCase().includes(query.toLowerCase());
 };
 
@@ -63,11 +63,11 @@ export const filterItem: ItemPredicate<ElectronVersion> = (query, { version }) =
  * Helper method: Returns the <Select /> <MenuItem /> for Electron
  * versions.
  *
- * @param {ElectronVersion} item
+ * @param {RunnableVersion} item
  * @param {IItemRendererProps} { handleClick, modifiers, query }
  * @returns
  */
-export const renderItem: ItemRenderer<ElectronVersion> = (item, { handleClick, modifiers, query }) => {
+export const renderItem: ItemRenderer<RunnableVersion> = (item, { handleClick, modifiers, query }) => {
   if (!modifiers.matchesPredicate) {
     return null;
   }
@@ -92,10 +92,10 @@ export interface VersionSelectState {
 export interface VersionSelectProps {
   appState: AppState;
   disabled?: boolean;
-  currentVersion: ElectronVersion;
-  onVersionSelect: (version: ElectronVersion) => void;
+  currentVersion: RunnableVersion;
+  onVersionSelect: (version: RunnableVersion) => void;
   buttonGroupProps?: IButtonGroupProps;
-  itemDisabled?: keyof ElectronVersion | ((item: ElectronVersion, index: number) => boolean);
+  itemDisabled?: keyof RunnableVersion | ((item: RunnableVersion, index: number) => boolean);
 }
 
 /**

--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { RunnableVersion, VersionSource } from '../interfaces';
 import { callIn } from '../utils/call-in';
 import { fancyImport } from '../utils/import';
+import { normalizeVersion } from '../utils/normalize-version';
 import { USER_DATA_PATH } from './constants';
 
 const definitionPath = path.join(USER_DATA_PATH, 'electron-typedef');
@@ -35,6 +36,26 @@ export async function fetchTypeDefinitions(version: string): Promise<string> {
     return text;
   }
 }
+
+/**
+ * Removes the type definition for a given version
+ *
+ * @param version
+ */
+export async function removeTypeDefsForVersion(version: string) {
+  const fs = await fancyImport<typeof fsType>('fs-extra');
+  const _version = normalizeVersion(version);
+  const typeDefsDir = path.dirname(getOfflineTypeDefinitionPath(_version));
+
+  if (fs.existsSync(typeDefsDir)) {
+    try {
+      await fs.remove(typeDefsDir);
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
 
 /**
  * Get the path for offline TypeScript definitions

--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -2,7 +2,7 @@ import * as fsType from 'fs-extra';
 import * as MonacoType from 'monaco-editor';
 import * as path from 'path';
 
-import { ElectronVersion, ElectronVersionSource } from '../interfaces';
+import { RunnableVersion, VersionSource } from '../interfaces';
 import { callIn } from '../utils/call-in';
 import { fancyImport } from '../utils/import';
 import { USER_DATA_PATH } from './constants';
@@ -64,7 +64,7 @@ export async function getOfflineTypeDefinitions(version: string): Promise<boolea
  * @param {string} version
  * @returns {void}
  */
-export async function getDownloadedVersionTypeDefs(version: ElectronVersion): Promise<string | null> {
+export async function getDownloadedVersionTypeDefs(version: RunnableVersion): Promise<string | null> {
   const fs = await fancyImport<typeof fsType>('fs-extra');
     await fs.mkdirp(definitionPath);
     const offlinePath = getOfflineTypeDefinitionPath(version.version);
@@ -91,8 +91,8 @@ export async function getDownloadedVersionTypeDefs(version: ElectronVersion): Pr
   }
 }
 
-export async function getLocalVersionTypeDefs(version: ElectronVersion) {
-  if (version.source === ElectronVersionSource.local && !!version.localPath) {
+export async function getLocalVersionTypeDefs(version: RunnableVersion) {
+  if (version.source === VersionSource.local && !!version.localPath) {
     const fs = await fancyImport<typeof fsType>('fs-extra');
     const typesPath = getLocalTypePathForVersion(version);
     if (!!typesPath && fs.existsSync(typesPath)) {
@@ -107,7 +107,7 @@ export async function getLocalVersionTypeDefs(version: ElectronVersion) {
  *
  * @param {string} version
  */
-export async function updateEditorTypeDefinitions(version: ElectronVersion, i: number = 0): Promise<void> {
+export async function updateEditorTypeDefinitions(version: RunnableVersion, i: number = 0): Promise<void> {
   const defer = async (): Promise<void> => {
     if (i > 10) {
       console.warn(`Fetch Types: Failed, dependencies do not exist`);
@@ -125,7 +125,7 @@ export async function updateEditorTypeDefinitions(version: ElectronVersion, i: n
   const monaco: typeof MonacoType = app.monaco!;
   const typeDefDisposable: MonacoType.IDisposable = app.typeDefDisposable!;
 
-  const getTypeDefs = (version.source === ElectronVersionSource.local) ?
+  const getTypeDefs = (version.source === VersionSource.local) ?
     getLocalVersionTypeDefs : getDownloadedVersionTypeDefs;
 
   const typeDefs = await getTypeDefs(version);
@@ -143,7 +143,7 @@ export async function updateEditorTypeDefinitions(version: ElectronVersion, i: n
   }
 }
 
-export function getLocalTypePathForVersion(version: ElectronVersion) {
+export function getLocalTypePathForVersion(version: RunnableVersion) {
   if (version.localPath) {
     return path.join(
       version.localPath,

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -6,6 +6,7 @@ import { IpcEvents } from '../ipc-events';
 import { getAppDataDir } from '../utils/app-data-dir';
 import { PackageJsonOptions } from '../utils/get-package';
 import { maybePlural } from '../utils/plural-maybe';
+import { getElectronBinaryPath, getIsDownloaded } from './binary';
 import { ipcRendererManager } from './ipc';
 import { findModulesInEditors, getIsNpmInstalled, installModules, npmRun } from './npm';
 import { AppState } from './state';
@@ -44,7 +45,7 @@ export class Runner {
   public async run(): Promise<boolean> {
     const { fileManager, getEditorValues } = window.ElectronFiddle.app;
     const options = { includeDependencies: false, includeElectron: false };
-    const { binaryManager, currentElectronVersion } = this.appState;
+    const { currentElectronVersion } = this.appState;
     const { version, localPath } = currentElectronVersion;
 
     if (this.appState.isClearingConsoleOnRun) {
@@ -65,7 +66,7 @@ export class Runner {
       return false;
     }
 
-    const isReady = await binaryManager.getIsDownloaded(version, localPath);
+    const isReady = await getIsDownloaded(version, localPath);
 
     if (!isReady) {
       console.warn(`Runner: Binary ${version} not ready`);
@@ -184,9 +185,9 @@ export class Runner {
    * @memberof Runner
    */
   public async execute(dir: string): Promise<void> {
-    const { currentElectronVersion, pushOutput, binaryManager } = this.appState;
+    const { currentElectronVersion, pushOutput } = this.appState;
     const { version, localPath } = currentElectronVersion;
-    const binaryPath = binaryManager.getElectronBinaryPath(version, localPath);
+    const binaryPath = getElectronBinaryPath(version, localPath);
     console.log(`Runner: Binary ${binaryPath} ready, launching`);
 
     const env = { ...process.env };

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -221,7 +221,7 @@ export class AppState {
   }
 
   /**
-   * Returns the current ElectronVersion or the first
+   * Returns the current RunnableVersion or the first
    * one that can be found.
    */
   @computed get currentElectronVersion(): RunnableVersion {

--- a/src/renderer/touch-bar-manager.ts
+++ b/src/renderer/touch-bar-manager.ts
@@ -5,7 +5,7 @@ import {
 } from 'electron';
 import { autorun } from 'mobx';
 
-import { ElectronVersion, ElectronVersionState } from '../interfaces';
+import { RunnableVersion, VersionState } from '../interfaces';
 import { getNiceGreeting } from '../utils/nice-greeting';
 import { sortedElectronMap } from '../utils/sorted-electron-map';
 import { AppState } from './state';
@@ -22,11 +22,11 @@ const {
  * Helper method: Returns an icon (emoji, lol) for an Electron
  * version.
  *
- * @param {Partial<ElectronVersion>} { state }
+ * @param {Partial<RunnableVersion>} { state }
  * @returns {string}
  */
 export function getItemIcon(
-  { state }: Partial<ElectronVersion> = { state: ElectronVersionState.unknown }
+  { state }: Partial<RunnableVersion> = { state: VersionState.unknown }
 ) {
   return state === 'ready'
     ? '💾'

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState, Version } from '../interfaces';
+import { RunnableVersion, Version, VersionSource, VersionState } from '../interfaces';
 import { normalizeVersion } from '../utils/normalize-version';
 
 export const enum ElectronReleaseChannel {
@@ -12,11 +12,11 @@ export const enum ElectronReleaseChannel {
 /**
  * Returns a sensible default version string.
  *
- * @param {Array<ElectronVersion>} knownVersions
+ * @param {Array<RunnableVersion>} knownVersions
  * @returns {string}
  */
 export function getDefaultVersion(
-  knownVersions: Array<ElectronVersion> = []
+  knownVersions: Array<RunnableVersion> = []
 ): string {
   const ls = localStorage.getItem('version');
 
@@ -52,7 +52,6 @@ export function getDefaultVersion(
 export function getReleaseChannel(
   input: Version | string
 ): ElectronReleaseChannel {
-
   const tag = (typeof input === 'string') ? input : (input.version || '');
 
   if (tag.includes('beta')) {
@@ -128,20 +127,20 @@ function saveVersions(key: VersionKeys, versions: Array<Version>) {
  *
  * @returns {Array<Version>}
  */
-export function getElectronVersions(): Array<ElectronVersion> {
-  const known: Array<ElectronVersion> = getKnownVersions().map((version) => {
+export function getElectronVersions(): Array<RunnableVersion> {
+  const known: Array<RunnableVersion> = getKnownVersions().map((version) => {
     return {
       ...version,
-      source: ElectronVersionSource.remote,
-      state: ElectronVersionState.unknown
+      source: VersionSource.remote,
+      state: VersionState.unknown
     };
   });
 
-  const local: Array<ElectronVersion> = getLocalVersions().map((version) => {
+  const local: Array<RunnableVersion> = getLocalVersions().map((version) => {
     return {
       ...version,
-      source: ElectronVersionSource.local,
-      state: ElectronVersionState.ready
+      source: VersionSource.local,
+      state: VersionState.ready
     };
   });
 
@@ -182,10 +181,10 @@ export function getLocalVersions(): Array<Version> {
  *
  * @param {Array<Version>} versions
  */
-export function saveLocalVersions(versions: Array<Version | ElectronVersion>) {
+export function saveLocalVersions(versions: Array<Version | RunnableVersion>) {
   const filteredVersions = versions.filter((v) => {
     if (isElectronVersion(v)) {
-      return v.source === ElectronVersionSource.local;
+      return v.source === VersionSource.local;
     }
 
     return true;
@@ -218,10 +217,10 @@ export function saveKnownVersions(versions: Array<Version>) {
  * saved after.
  *
  * @export
- * @returns {Promise<Array<ElectronVersion>>}
+ * @returns {Promise<Array<RunnableVersion>>}
  */
 export async function getUpdatedElectronVersions(
-): Promise<Array<ElectronVersion>> {
+): Promise<Array<RunnableVersion>> {
   try {
     await fetchVersions();
   } catch (error) {
@@ -290,7 +289,7 @@ export function migrateVersions(input: Array<any> = []): Array<Version> {
 }
 
 export function isElectronVersion(
-  input: Version | ElectronVersion
-): input is ElectronVersion {
-  return (input as ElectronVersion).source !== undefined;
+  input: Version | RunnableVersion
+): input is RunnableVersion {
+  return (input as RunnableVersion).source !== undefined;
 }

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -240,7 +240,7 @@ export async function fetchVersions() {
   const data = await response.json();
 
   // pre-0.24.0 versions were technically 'atom-shell' and cannot
-  // be downloaded with electron-download
+  // be downloaded with @electron/get
   const MIN_DOWNLOAD_VERSION = '0.24.0';
 
   const output = data

--- a/src/utils/array-to-stringmap.ts
+++ b/src/utils/array-to-stringmap.ts
@@ -1,16 +1,16 @@
-import { ElectronVersion } from '../interfaces';
+import { RunnableVersion } from '../interfaces';
 import { normalizeVersion } from './normalize-version';
 
 /**
  * Takes an array of GitHub releases and returns a StringMap of
  * Electron releases.
  *
- * @param {Array<ElectronVersion>} input
- * @returns {Record<string, ElectronVersion>}
+ * @param {Array<RunnableVersion>} input
+ * @returns {Record<string, RunnableVersion>}
  */
 export function arrayToStringMap(
-  input: Array<ElectronVersion>
-): Record<string, ElectronVersion> {
+  input: Array<RunnableVersion>
+): Record<string, RunnableVersion> {
   const output = {};
 
   input.forEach((version) => {

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -1,18 +1,18 @@
 import * as semver from 'semver';
 
-import { ElectronVersion } from '../interfaces';
+import { RunnableVersion } from '../interfaces';
 
 /**
  * Sorts Electron versions and returns the result of a
  * map function.
  *
- * @param {Record<string, ElectronVersion>} versions
- * @param {(key: string, version: ElectronVersion) => void} mapFn
+ * @param {Record<string, RunnableVersion>} versions
+ * @param {(key: string, version: RunnableVersion) => void} mapFn
  * @returns {Array<T>}
  */
 export function sortedElectronMap<T>(
-  versions: Record<string, ElectronVersion>,
-  mapFn: (key: string, version: ElectronVersion) => T
+  versions: Record<string, RunnableVersion>,
+  mapFn: (key: string, version: RunnableVersion) => T
 ) {
   return Object.keys(versions)
     .sort((a, b) => {

--- a/tests/mocks/binary.ts
+++ b/tests/mocks/binary.ts
@@ -1,6 +1,4 @@
-export class MockBinaryManager {
-  public remove = jest.fn();
-  public setup = jest.fn();
-  public getDownloadedVersions = jest.fn();
-  public getDownloadingVersions = jest.fn();
-}
+export const removeBinary = jest.fn();
+export const setupBinary = jest.fn();
+export const getDownloadedVersions = jest.fn();
+export const getDownloadingVersions = jest.fn();

--- a/tests/mocks/binary.ts
+++ b/tests/mocks/binary.ts
@@ -1,4 +1,0 @@
-export const removeBinary = jest.fn();
-export const setupBinary = jest.fn();
-export const getDownloadedVersions = jest.fn();
-export const getDownloadingVersions = jest.fn();

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -1,20 +1,20 @@
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
+import { RunnableVersion, VersionSource, VersionState } from '../../src/interfaces';
 import { arrayToStringMap } from '../../src/utils/array-to-stringmap';
 
 export const mockVersionsArray = [
   {
-    state: ElectronVersionState.ready,
+    state: VersionState.ready,
     version: '2.0.2',
-    source: ElectronVersionSource.remote
+    source: VersionSource.remote
   }, {
-    state: ElectronVersionState.ready,
+    state: VersionState.ready,
     version: '2.0.1',
-    source: ElectronVersionSource.remote
+    source: VersionSource.remote
   }, {
-    state: ElectronVersionState.ready,
+    state: VersionState.ready,
     version: '1.8.7',
-    source: ElectronVersionSource.remote
+    source: VersionSource.remote
   }
 ];
 
-export const mockVersions: Record<string, ElectronVersion> = arrayToStringMap(mockVersionsArray);
+export const mockVersions: Record<string, RunnableVersion> = arrayToStringMap(mockVersionsArray);

--- a/tests/renderer/bisect-spec.ts
+++ b/tests/renderer/bisect-spec.ts
@@ -1,11 +1,11 @@
-import { ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
+import { VersionSource, VersionState } from '../../src/interfaces';
 import { Bisector } from '../../src/renderer/bisect';
 
 const generateVersionRange = (rangeLength: number) =>
   (new Array(rangeLength)).fill(0).map((_, i) => ({
-    state: ElectronVersionState.ready,
+    state: VersionState.ready,
     version: `${i + 1}.0.0`,
-    source: ElectronVersionSource.local
+    source: VersionSource.local
   }));
 
 describe('bisect', () => {

--- a/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`Runner component renders "checking status" 1`] = `
 exports[`Runner component renders default 1`] = `
 <Blueprint3.Button
   className="button-run"
+  disabled={false}
   icon="play"
   onClick={[MockFunction]}
   text="Run"
@@ -39,6 +40,7 @@ exports[`Runner component renders running 1`] = `
 <Blueprint3.Button
   active={true}
   className="button-run"
+  disabled={false}
   icon="stop"
   onClick={[MockFunction]}
   text="Stop"

--- a/tests/renderer/components/commands-bisect-spec.tsx
+++ b/tests/renderer/components/commands-bisect-spec.tsx
@@ -1,6 +1,6 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
-import { ElectronVersionState } from '../../../src/interfaces';
+import { VersionState } from '../../../src/interfaces';
 import { BisectHandler } from '../../../src/renderer/components/commands-bisect';
 
 describe('Bisect commands component', () => {
@@ -13,7 +13,7 @@ describe('Bisect commands component', () => {
         getCurrentVersion: jest.fn()
       },
       currentElectronVersion: {
-        state: ElectronVersionState.ready
+        state: VersionState.ready
       },
       setVersion: jest.fn(),
       version: '1.0.0',
@@ -29,7 +29,7 @@ describe('Bisect commands component', () => {
   });
 
   it('disables helper buttons if Electron binary is downloading', () => {
-    store.currentElectronVersion.state = ElectronVersionState.downloading;
+    store.currentElectronVersion.state = VersionState.downloading;
     const wrapper = shallow(<BisectHandler appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -54,7 +54,7 @@ describe('EditorDropdown component', () => {
     const wrapper = mount(<EditorDropdown appState={store} />);
     const instance = wrapper.instance() as EditorDropdown;
     const menu = instance.renderMenuItems();
-  
+
     expect(menu).toMatchSnapshot();
   });
 });

--- a/tests/renderer/components/commands-runner-spec.tsx
+++ b/tests/renderer/components/commands-runner-spec.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ElectronVersionState } from '../../../src/interfaces';
+import { VersionState } from '../../../src/interfaces';
 import { Runner } from '../../../src/renderer/components/commands-runner';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { ElectronFiddleMock } from '../../mocks/electron-fiddle';
@@ -42,13 +42,13 @@ describe('Runner component', () => {
   });
 
   it('renders downloading', () => {
-    store.versions['2.0.2'].state = ElectronVersionState.downloading;
+    store.versions['2.0.2'].state = VersionState.downloading;
     const wrapper = shallow(<Runner appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders "checking status"', () => {
-    store.versions['2.0.2'].state = ElectronVersionState.unknown;
+    store.versions['2.0.2'].state = VersionState.unknown;
     const wrapper = shallow(<Runner appState={store} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -1,13 +1,13 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { VersionSource, VersionState } from '../../../src/interfaces';
 import { VersionChooser } from '../../../src/renderer/components/commands-version-chooser';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
 
-const { unknown } = ElectronVersionState;
-const { remote } = ElectronVersionSource;
+const { unknown } = VersionState;
+const { remote } = VersionSource;
 
 describe('VersionSelect component', () => {
   let store: any;
@@ -37,7 +37,7 @@ describe('VersionSelect component', () => {
       versionsToShow: Object.values(versions).filter((v) => !!v),
       versions,
       channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
-      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
+      statesToShow: [ VersionState.ready, VersionState.downloading ],
       setVersion: jest.fn(),
       get currentElectronVersion() {
         return mockVersions['2.0.2'];

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -2,10 +2,13 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { IpcEvents } from '../../../src/ipc-events';
+import { getIsDownloaded } from '../../../src/renderer/binary';
 import { AddVersionDialog } from '../../../src/renderer/components/dialog-add-version';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { overridePlatform, resetPlatform } from '../../utils';
+
 jest.mock('../../../src/renderer/ipc');
+jest.mock('../../../src/renderer/binary');
 
 describe('AddVersionDialog component', () => {
   let store: any;
@@ -66,7 +69,7 @@ describe('AddVersionDialog component', () => {
 
   describe('setFolderPath()', () => {
     it('does something', async () => {
-      store.binaryManager.getIsDownloaded.mockResolvedValue(true);
+      (getIsDownloaded as jest.Mock).mockResolvedValue(true);
       const wrapper = shallow(<AddVersionDialog appState={store} />);
       await (wrapper.instance() as any).setFolderPath('/test/');
 

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { VersionSource, VersionState } from '../../../src/interfaces';
 import { Bisector } from '../../../src/renderer/bisect';
 import { BisectDialog } from '../../../src/renderer/components/dialog-bisect';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
@@ -12,9 +12,9 @@ describe('BisectDialog component', () => {
 
   const generateVersionRange = (rangeLength: number) =>
     (new Array(rangeLength)).fill(0).map((_, i) => ({
-      state: ElectronVersionState.ready,
+      state: VersionState.ready,
       version: `${i + 1}.0.0`,
-      source: ElectronVersionSource.local
+      source: VersionSource.local
     }));
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe('BisectDialog component', () => {
       versions,
       versionsToShow: versions,
       channelsToShow: [ElectronReleaseChannel.stable],
-      statesToShow: [ElectronVersionState.ready],
+      statesToShow: [VersionState.ready],
       setVersion: jest.fn()
     };
   });

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -1,7 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { VersionSource, VersionState } from '../../../src/interfaces';
 import { ElectronSettings } from '../../../src/renderer/components/settings-electron';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
@@ -14,7 +14,7 @@ describe('ElectronSettings component', () => {
       version: '2.0.1',
       versions: { ...mockVersions },
       channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
-      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
+      statesToShow: [ VersionState.ready, VersionState.downloading ],
       downloadVersion: jest.fn(),
       removeVersion: jest.fn(),
       updateElectronVersions: jest.fn(),
@@ -29,15 +29,15 @@ describe('ElectronSettings component', () => {
 
   it('renders', () => {
     store.versions['3.0.0-nightly.1'] = {
-      state: ElectronVersionState.ready,
+      state: VersionState.ready,
       version: '3.0.0-nightly.1',
-      source: ElectronVersionSource.local
+      source: VersionSource.local
     };
 
     store.versions['3.0.0'] = {
-      state: ElectronVersionState.ready,
+      state: VersionState.ready,
       version: '3.0.0',
-      source: ElectronVersionSource.local
+      source: VersionSource.local
     };
 
     const wrapper = shallow(<ElectronSettings appState={store} />);
@@ -47,15 +47,15 @@ describe('ElectronSettings component', () => {
 
   it('handles removing a version', async () => {
     store.versions['3.0.0-nightly.1'] = {
-      state: ElectronVersionState.ready,
+      state: VersionState.ready,
       version: '3.0.0-nightly.1',
-      source: ElectronVersionSource.local
+      source: VersionSource.local
     };
 
     store.versions['3.0.0'] = {
-      state: ElectronVersionState.ready,
+      state: VersionState.ready,
       version: '3.0.0',
-      source: ElectronVersionSource.local
+      source: VersionSource.local
     };
 
     const wrapper = mount(<ElectronSettings appState={store} />);
@@ -71,13 +71,13 @@ describe('ElectronSettings component', () => {
   it('handles downloading a version', async () => {
     store.versions = {
       '3.0.0': {
-        state: ElectronVersionState.unknown,
+        state: VersionState.unknown,
         version: '3.0.0',
-        source: ElectronVersionSource.remote
+        source: VersionSource.remote
       }
     };
 
-    store.statesToShow.push(ElectronVersionState.unknown);
+    store.statesToShow.push(VersionState.unknown);
 
     const wrapper = mount(<ElectronSettings appState={store} />);
 
@@ -139,21 +139,21 @@ describe('ElectronSettings component', () => {
       const instance = wrapper.instance() as any;
       await instance.handleStateChange({
         currentTarget: {
-          id: ElectronVersionState.ready,
+          id: VersionState.ready,
           checked: false
         }
       });
 
       await instance.handleStateChange({
         currentTarget: {
-          id: ElectronVersionState.unknown,
+          id: VersionState.unknown,
           checked: true
         }
       });
 
       expect(store.statesToShow).toEqual([
-        ElectronVersionState.downloading,
-        ElectronVersionState.unknown
+        VersionState.downloading,
+        VersionState.unknown
       ]);
     });
   });

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -1,13 +1,13 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ElectronVersion, ElectronVersionSource, ElectronVersionState } from '../../../src/interfaces';
+import { RunnableVersion, VersionSource, VersionState } from '../../../src/interfaces';
 import { filterItem, getItemIcon, getItemLabel, renderItem, VersionSelect } from '../../../src/renderer/components/version-select';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
 
-const { ready, unknown, downloading } = ElectronVersionState;
-const { remote, local } = ElectronVersionSource;
+const { ready, unknown, downloading } = VersionState;
+const { remote, local } = VersionSource;
 
 describe('VersionSelect component', () => {
   let store: any;
@@ -34,15 +34,15 @@ describe('VersionSelect component', () => {
         '3.0.0-unsupported': { ...mockVersion2 }
       },
       channelsToShow: [ ElectronReleaseChannel.stable, ElectronReleaseChannel.beta ],
-      statesToShow: [ ElectronVersionState.ready, ElectronVersionState.downloading ],
+      statesToShow: [ VersionState.ready, VersionState.downloading ],
       setVersion: jest.fn(),
-      get currentElectronVersion() {
+      get currentRunnableVersion() {
         return mockVersions['2.0.2'];
       }
     };
   });
 
-  const onVersionSelect = () => ({});
+const onVersionSelect = () => ({});
 
   it('renders', () => {
     const wrapper = shallow(
@@ -77,7 +77,7 @@ describe('VersionSelect component', () => {
 
   describe('getItemLabel()', () => {
     it('returns the correct label for a local version', () => {
-      const input: ElectronVersion = {
+      const input: RunnableVersion = {
         ...mockVersion1,
         source: local,
       };
@@ -87,7 +87,7 @@ describe('VersionSelect component', () => {
     });
 
     it('returns the correct label for a version not downloaded', () => {
-      const input: ElectronVersion = {
+      const input: RunnableVersion = {
         ...mockVersion1,
         state: unknown
       };
@@ -96,7 +96,7 @@ describe('VersionSelect component', () => {
     });
 
     it('returns the correct label for a version downloaded', () => {
-      const input: ElectronVersion = {
+      const input: RunnableVersion = {
         ...mockVersion1,
         state: ready
       };
@@ -105,7 +105,7 @@ describe('VersionSelect component', () => {
     });
 
     it('returns the correct label for a version downloading', () => {
-      const input: ElectronVersion = {
+      const input: RunnableVersion = {
         ...mockVersion1,
         state: downloading
       };

--- a/tests/renderer/touch-bar-manager-spec.ts
+++ b/tests/renderer/touch-bar-manager-spec.ts
@@ -1,4 +1,4 @@
-import { ElectronVersionSource, ElectronVersionState } from '../../src/interfaces';
+import { VersionSource, VersionState } from '../../src/interfaces';
 import { AppState } from '../../src/renderer/state';
 import { TouchBarManager } from '../../src/renderer/touch-bar-manager';
 import { mockVersions } from '../mocks/electron-versions';
@@ -21,7 +21,7 @@ describe('TouchBarManager', () => {
     appState.versions = mockVersions;
     appState.isRunning = false;
 
-    appState.versions['2.0.1'].state = ElectronVersionState.unknown;
+    appState.versions['2.0.1'].state = VersionState.unknown;
   });
 
   it('creates a touch bar with versions', () => {
@@ -38,8 +38,8 @@ describe('TouchBarManager', () => {
   it('updates the versions when the versions change', () => {
     const touchBarMgr = new TouchBarManager(appState);
     appState.versions['3.3.3'] = {
-      state: ElectronVersionState.downloading,
-      source: ElectronVersionSource.remote,
+      state: VersionState.downloading,
+      source: VersionSource.remote,
       version: '3.3.3'
     };
 

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import semver from 'semver';
-import { ElectronVersion, ElectronVersionSource } from '../../src/interfaces';
+import { RunnableVersion, VersionSource } from '../../src/interfaces';
 import {
   addLocalVersion,
   ElectronReleaseChannel,
@@ -18,7 +18,7 @@ import { mockFetchOnce } from '../utils';
 
 const { expectedVersionCount } = require('../fixtures/releases-metadata.json');
 
-const mockVersions: Array<Partial<ElectronVersion>> = [
+const mockVersions: Array<Partial<RunnableVersion>> = [
   { version: 'test-0', localPath: '/test/path/0' },
   { version: 'test-1', localPath: '/test/path/1' },
   { version: 'test-2', localPath: '/test/path/2' },
@@ -114,11 +114,11 @@ describe('versions', () => {
   describe('saveLocalVersions()', () => {
     it('saves local versions', () => {
       const mockLocalVersions = mockVersions.map((v) => {
-        v.source = ElectronVersionSource.local;
+        v.source = VersionSource.local;
         return v;
       });
 
-      saveLocalVersions(mockLocalVersions as Array<ElectronVersion>);
+      saveLocalVersions(mockLocalVersions as Array<RunnableVersion>);
 
       const key = (window.localStorage.setItem as jest.Mock).mock.calls[0][0];
       const value = (window.localStorage.setItem as jest.Mock).mock.calls[0][1];

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -11,7 +11,7 @@ jest.spyOn(global.console, 'log').mockImplementation(() => jest.fn());
 jest.spyOn(global.console, 'warn').mockImplementation(() => jest.fn());
 jest.mock('electron', () => require('./mocks/electron'));
 jest.mock('fs-extra');
-jest.mock('electron-download');
+jest.mock('@electron/get');
 
 expect.addSnapshotSerializer(createSerializer({mode: 'deep'}));
 


### PR DESCRIPTION
This is a fairly big refactor of what used to be `BinaryManager`. Instead of being a class, I've turned into a collection of methods, allowing a bit more flexibility and removing one more class that keeps internal state about Electron versions. This makes the code a bit more flexible and enabled me to replace `electron-download` with `@electron/get` - with the end goal of providing visual feedback for download progress. A picture probably says more, so here it is:

![progress](https://user-images.githubusercontent.com/1426799/76915930-2d17f680-687c-11ea-831f-35eb200a807e.gif)
