### PR TITLE
fix: don't modify state directly

### DIFF
--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -301,10 +301,10 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     }
 
     if (!this.state || !this.state.isMounted) {
-      this.state = {
+      this.setState({
         monaco,
         monacoOptions: defaultMonacoOptions
-      };
+      });
     } else {
       this.setState({ monaco });
     }


### PR DESCRIPTION
Fixes #383 

According to React State and Lifecycle docs, the only place where you can assign `this.state = {}` it's `constructor`. Ref [doc](https://reactjs.org/docs/state-and-lifecycle.html#do-not-modify-state-directly). Here we try to assign inside the `comonentDidMount` 🙈.