### PR TITLE
feat: add ability to update gist instead of publishing

### DIFF
--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -1,8 +1,9 @@
-import { Button, ButtonGroup, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
+import { Button, ButtonGroup, IToastProps, Menu, MenuItem, Popover, Position, Toaster } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { when } from 'mobx';
+import { EditorValues } from '../../interfaces';
 import { IpcEvents } from '../../ipc-events';
 import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLES_CSS_NAME } from '../../shared-constants';
 import { getOctokit } from '../../utils/octokit';
@@ -13,6 +14,10 @@ export interface PublishButtonProps {
   appState: AppState;
 }
 
+interface IPublishButtonState {
+  readonly isUpdating: boolean;
+}
+
 /**
  * The "publish" button takes care of logging you in.
  *
@@ -21,14 +26,23 @@ export interface PublishButtonProps {
  * @extends {React.Component<PublishButtonProps, PublishButtonState>}
  */
 @observer
-export class PublishButton extends React.Component<PublishButtonProps> {
-  constructor(props: PublishButtonProps) {
+export class PublishButton extends React.Component<PublishButtonProps, IPublishButtonState> {
+  public constructor(props: PublishButtonProps) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
-    this.publishFiddle = this.publishFiddle.bind(this);
+    this.publishOrUpdateFiddle = this.publishOrUpdateFiddle.bind(this);
     this.setPrivate = this.setPrivate.bind(this);
     this.setPublic = this.setPublic.bind(this);
+
+    this.state = {
+      isUpdating: false
+    };
   }
+
+  private toaster: Toaster;
+  private refHandlers = {
+    toaster: (ref: Toaster) => this.toaster = ref,
+  };
 
   public componentDidMount() {
     ipcRendererManager.on(IpcEvents.FS_SAVE_FIDDLE_GIST, this.handleClick);
@@ -60,7 +74,7 @@ export class PublishButton extends React.Component<PublishButtonProps> {
     await when(() => !!appState.gitHubToken || !appState.isTokenDialogShowing);
 
     if (appState.gitHubToken) {
-      return this.publishFiddle();
+      return this.publishOrUpdateFiddle();
     }
   }
 
@@ -68,50 +82,51 @@ export class PublishButton extends React.Component<PublishButtonProps> {
    * Connect with GitHub, publish the current Fiddle as a gist,
    * and update all related properties in the app state.
    */
-  public async publishFiddle(): Promise<void> {
+  public async publishOrUpdateFiddle(): Promise<void> {
     const { appState } = this.props;
     appState.isPublishing = true;
 
     const octo = await getOctokit(this.props.appState);
-    const { gitHubPublishAsPublic } = this.props.appState;
+    const { gitHubPublishAsPublic, gistId } = this.props.appState;
     const options = { includeDependencies: true, includeElectron: true };
     const values = await window.ElectronFiddle.app.getEditorValues(options);
 
-    try {
-      const gist = await octo.gists.create({
-        public: !!gitHubPublishAsPublic,
-        description: 'Electron Fiddle Gist',
-        files: {
-          [INDEX_HTML_NAME]: {
-            content: values.html || '<!-- Empty -->',
-          },
-          [MAIN_JS_NAME]: {
-            content: values.main || '// Empty',
-          },
-          [RENDERER_JS_NAME]: {
-            content: values.renderer || '// Empty',
-          },
-          [PRELOAD_JS_NAME]: {
-            content: values.preload || '// Empty',
-          },
-          [STYLES_CSS_NAME]: {
-            content: values.css || '/* Empty */',
-          },
-        },
-      } as any); // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface
+    if (gistId) {
+      this.setState({
+        isUpdating: true
+      });
+      const gist = await octo.gists.update({
+        gist_id: appState.gistId,
+        files: this.gistFilesList(values) as any,
+      });
 
-      appState.gistId = gist.data.id;
+      console.log('Updating: Updating done', { gist });
+      this.renderToast({ message: 'Successfully updated gist!' });
+      this.setState({
+        isUpdating: false
+      });
+    } else {
+      try {
+        const gist = await octo.gists.create({
+          public: !!gitHubPublishAsPublic,
+          description: 'Electron Fiddle Gist',
+          files: this.gistFilesList(values) as any, // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface
+        });
 
-      console.log(`Publish Button: Publishing done`, { gist });
-    } catch (error) {
-      console.warn(`Could not publish gist`, { error });
+        appState.gistId = gist.data.id;
 
-      const messageBoxOptions: Electron.MessageBoxOptions = {
-        message: 'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
-        detail: `GitHub encountered the following error: ${error.message}`
-      };
+        console.log(`Publish Button: Publishing done`, { gist });
+        this.renderToast({ message: 'Publishing done successfully!' });
+      } catch (error) {
+        console.warn(`Could not publish gist`, { error });
 
-      ipcRendererManager.send(IpcEvents.SHOW_WARNING_DIALOG, messageBoxOptions);
+        const messageBoxOptions: Electron.MessageBoxOptions = {
+          message: 'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
+          detail: `GitHub encountered the following error: ${error.message}`
+        };
+
+        ipcRendererManager.send(IpcEvents.SHOW_WARNING_DIALOG, messageBoxOptions);
+      }
     }
 
     appState.isPublishing = false;
@@ -136,8 +151,41 @@ export class PublishButton extends React.Component<PublishButtonProps> {
   }
 
   public render() {
-    const { gitHubPublishAsPublic } = this.props.appState;
-    const { isPublishing } = this.props.appState;
+    const { isPublishing, gistId } = this.props.appState;
+    const { isUpdating } = this.state;
+
+    const getTextForButton = gistId
+      ? 'Update'
+      : isUpdating
+      ? 'Updating...'
+      : isPublishing
+      ? 'Publishing...'
+      : 'Publish';
+
+    return (
+      <>
+        <fieldset disabled={isPublishing}>
+          <ButtonGroup className='button-publish'>
+              {this.renderPrivaryMenu()}
+              <Button
+                onClick={this.handleClick}
+                loading={isPublishing}
+                icon='upload'
+                text={getTextForButton}
+              />
+          </ButtonGroup>
+        </fieldset>
+        <Toaster position={Position.BOTTOM_RIGHT} ref={this.refHandlers.toaster} />
+      </>
+    );
+  }
+
+  private renderPrivaryMenu = () => {
+    const { gitHubPublishAsPublic, gistId } = this.props.appState;
+
+    if (gistId) {
+      return null;
+    }
 
     const privacyIcon = gitHubPublishAsPublic ? 'unlock' : 'lock';
     const privacyMenu = (
@@ -158,28 +206,42 @@ export class PublishButton extends React.Component<PublishButtonProps> {
     );
 
     return (
-      <fieldset disabled={isPublishing}>
-        <ButtonGroup className='button-publish'>
-            <Popover
-              content={privacyMenu}
-              position={Position.BOTTOM}
-            >
-              <Button
-                icon={privacyIcon}
-              />
-            </Popover>
-            <Button
-              onClick={this.handleClick}
-              loading={isPublishing}
-              icon='upload'
-              text={isPublishing ? 'Publishing...' : 'Publish'}
-            />
-        </ButtonGroup>
-      </fieldset>
+      <Popover
+        content={privacyMenu}
+        position={Position.BOTTOM}
+      >
+        <Button
+          icon={privacyIcon}
+        />
+      </Popover>
     );
   }
 
   private setPrivacy(publishAsPublic: boolean) {
     this.props.appState.gitHubPublishAsPublic = publishAsPublic;
+  }
+
+  private renderToast = (toast: IToastProps) => {
+    this.toaster.show(toast);
+  }
+
+  private gistFilesList = (values: EditorValues) => {
+    return {
+      [INDEX_HTML_NAME]: {
+        content: values.html || '<!-- Empty -->',
+      },
+      [MAIN_JS_NAME]: {
+        content: values.main || '// Empty',
+      },
+      [RENDERER_JS_NAME]: {
+        content: values.renderer || '// Empty',
+      },
+      [PRELOAD_JS_NAME]: {
+        content: values.preload || '// Empty',
+      },
+      [STYLES_CSS_NAME]: {
+        content: values.css || '/* Empty */',
+      },
+    };
   }
 }

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -1,63 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Publish button component renders 1`] = `
-<fieldset>
-  <Blueprint3.ButtonGroup
-    className="button-publish"
-  >
-    <Blueprint3.Popover
-      boundary="scrollParent"
-      captureDismiss={false}
-      content={
-        <Blueprint3.Menu>
-          <Blueprint3.MenuItem
-            active={false}
-            disabled={false}
-            icon="lock"
-            multiline={false}
-            onClick={[Function]}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="Private"
-          />
-          <Blueprint3.MenuItem
-            active={true}
-            disabled={false}
-            icon="unlock"
-            multiline={false}
-            onClick={[Function]}
-            popoverProps={Object {}}
-            shouldDismissPopover={true}
-            text="Public"
-          />
-        </Blueprint3.Menu>
-      }
-      defaultIsOpen={false}
-      disabled={false}
-      fill={false}
-      hasBackdrop={false}
-      hoverCloseDelay={300}
-      hoverOpenDelay={150}
-      inheritDarkTheme={true}
-      interactionKind="click"
-      minimal={false}
-      modifiers={Object {}}
-      openOnTargetFocus={true}
-      position="bottom"
-      targetTagName="span"
-      transitionDuration={300}
-      usePortal={true}
-      wrapperTagName="span"
+<Fragment>
+  <fieldset>
+    <Blueprint3.ButtonGroup
+      className="button-publish"
     >
+      <Blueprint3.Popover
+        boundary="scrollParent"
+        captureDismiss={false}
+        content={
+          <Blueprint3.Menu>
+            <Blueprint3.MenuItem
+              active={false}
+              disabled={false}
+              icon="lock"
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={Object {}}
+              shouldDismissPopover={true}
+              text="Private"
+            />
+            <Blueprint3.MenuItem
+              active={true}
+              disabled={false}
+              icon="unlock"
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={Object {}}
+              shouldDismissPopover={true}
+              text="Public"
+            />
+          </Blueprint3.Menu>
+        }
+        defaultIsOpen={false}
+        disabled={false}
+        fill={false}
+        hasBackdrop={false}
+        hoverCloseDelay={300}
+        hoverOpenDelay={150}
+        inheritDarkTheme={true}
+        interactionKind="click"
+        minimal={false}
+        modifiers={Object {}}
+        openOnTargetFocus={true}
+        position="bottom"
+        targetTagName="span"
+        transitionDuration={300}
+        usePortal={true}
+        wrapperTagName="span"
+      >
+        <Blueprint3.Button
+          icon="unlock"
+        />
+      </Blueprint3.Popover>
       <Blueprint3.Button
-        icon="unlock"
+        icon="upload"
+        onClick={[Function]}
+        text="Publish"
       />
-    </Blueprint3.Popover>
-    <Blueprint3.Button
-      icon="upload"
-      onClick={[Function]}
-      text="Publish"
-    />
-  </Blueprint3.ButtonGroup>
-</fieldset>
+    </Blueprint3.ButtonGroup>
+  </fieldset>
+  <Blueprint3.Toaster
+    autoFocus={false}
+    canEscapeKeyClear={true}
+    position="bottom-right"
+    usePortal={true}
+  />
+</Fragment>
 `;

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -47,10 +47,10 @@ describe('Publish button component', () => {
 
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
-    instance.publishFiddle = jest.fn();
+    instance.publishOrUpdateFiddle = jest.fn();
     await instance.handleClick();
 
-    expect(instance.publishFiddle).toHaveBeenCalled();
+    expect(instance.publishOrUpdateFiddle).toHaveBeenCalled();
   });
 
   it('attempts to publish to Gist', async () => {
@@ -66,7 +66,7 @@ describe('Publish button component', () => {
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
 
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       description: 'Electron Fiddle Gist',
@@ -96,7 +96,7 @@ describe('Publish button component', () => {
 
     (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
 
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       description: 'Electron Fiddle Gist',
@@ -126,7 +126,7 @@ describe('Publish button component', () => {
     const wrapper = shallow(<PublishButton appState={store} />);
     const instance: PublishButton = wrapper.instance() as any;
 
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
 
     expect(store.isPublishing).toBe(false);
   });
@@ -147,7 +147,7 @@ describe('Publish button component', () => {
     const instance: PublishButton = wrapper.instance() as any;
 
     instance.setPrivate();
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       ...expectedGistCreateOpts,
@@ -155,7 +155,7 @@ describe('Publish button component', () => {
     });
 
     instance.setPublic();
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       ...expectedGistCreateOpts,
@@ -170,7 +170,7 @@ describe('Publish button component', () => {
 
     expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
 
-    instance.publishFiddle = jest.fn().mockImplementationOnce(() => {
+    instance.publishOrUpdateFiddle = jest.fn().mockImplementationOnce(() => {
       return new Promise((resolve) => {
         wrapper.setProps({ appState: { store, isPublishing: true } }, () => {
           expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
@@ -182,7 +182,7 @@ describe('Publish button component', () => {
       });
     });
 
-    await instance.publishFiddle();
+    await instance.publishOrUpdateFiddle();
   });
 
   describe('privacy menu', () => {


### PR DESCRIPTION
This PR adds the ability to update the existing Gist instead of publishing the new one. Also added toasts notifications when the gist published or updated.

GIFS 😃😃

### Publishing

![publish the gist](https://user-images.githubusercontent.com/24681191/80540689-764a8280-89b2-11ea-90b4-1331b1058c87.gif)

### Updating

![updating the gist](https://user-images.githubusercontent.com/24681191/80540693-777baf80-89b2-11ea-8fb6-55aa8466e204.gif)

Fixes #290

