### PR TITLE
fix: reset github token when authentication failed

### DIFF
--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -69,6 +69,7 @@ export class TokenDialog extends React.Component<TokenDialogProps, TokenDialogSt
     } catch (error) {
       console.warn(`Authenticating against GitHub failed`, error);
       this.setState({ verifying: false, error: true });
+      this.props.appState.gitHubToken = null;
       return;
     }
 

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -181,6 +181,7 @@ describe('TokenDialog component', () => {
       await instance.onSubmitToken();
 
       expect(wrapper.state('error')).toBe(true);
+      expect(store.gitHubToken).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
Currently when GitHub authentication failed we give the user error and ability to exit, but with that, we also save the invalid token to the state, and that token is used for any authenticated things like publishing Gist.

This PR reset token to `null` when the authentication is not completed correctly.