### PR TITLE
fix: set the window to null after destroying

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -5,7 +5,7 @@ import { ipcMainManager } from './ipc';
 
 // Keep a global reference of the window objects, if we don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-export let browserWindows: Array<BrowserWindow> = [];
+export let browserWindows: Array<BrowserWindow | null> = [];
 
 /**
  * Gets default options for the main window
@@ -37,13 +37,14 @@ export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions
  */
 export function createMainWindow(): Electron.BrowserWindow {
   console.log(`Creating main window`);
-  const browserWindow = new BrowserWindow(getMainWindowOptions());
+  let browserWindow: BrowserWindow | null
+  browserWindow = new BrowserWindow(getMainWindowOptions());
   browserWindow.loadFile('./dist/static/index.html');
 
   browserWindow.webContents.once('dom-ready', () => {
-    browserWindow.show();
-
     if (browserWindow) {
+      browserWindow.show();
+
       createContextMenu(browserWindow);
     }
   });
@@ -51,6 +52,8 @@ export function createMainWindow(): Electron.BrowserWindow {
   browserWindow.on('closed', () => {
     browserWindows = browserWindows
       .filter((bw) => browserWindow !== bw);
+
+    browserWindow = null
   });
 
   browserWindow.webContents.on('new-window', (event, url) => {
@@ -64,7 +67,9 @@ export function createMainWindow(): Electron.BrowserWindow {
   });
 
   ipcMainManager.on(IpcEvents.SHOW_INACTIVE, () => {
-    browserWindow.showInactive();
+    if (browserWindow) {
+      browserWindow.showInactive();
+    }
   });
 
   browserWindows.push(browserWindow);

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -37,7 +37,7 @@ export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions
  */
 export function createMainWindow(): Electron.BrowserWindow {
   console.log(`Creating main window`);
-  let browserWindow: BrowserWindow | null
+  let browserWindow: BrowserWindow | null;
   browserWindow = new BrowserWindow(getMainWindowOptions());
   browserWindow.loadFile('./dist/static/index.html');
 
@@ -53,7 +53,7 @@ export function createMainWindow(): Electron.BrowserWindow {
     browserWindows = browserWindows
       .filter((bw) => browserWindow !== bw);
 
-    browserWindow = null
+    browserWindow = null;
   });
 
   browserWindow.webContents.on('new-window', (event, url) => {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -472,7 +472,7 @@ export class AppState {
           await updateEditorTypeDefinitions(versionObject);
         });
       } catch (err) {
-        console.info('TypeDefs: Unable to start watching.')
+        console.info('TypeDefs: Unable to start watching.');
       }
     } else {
       if (!!this.localTypeWatcher) {


### PR DESCRIPTION
How Electron docs say for [`closed` event](https://www.electronjs.org/docs/api/browser-window#event-closed) after this event is fired we should remove the `browserWindow` and never use them. Previously we still can use these `browserWindow` if the window doesn't more exist. This PR makes `browserWindow` null after they removed.

Fixes #379 
/cc @erickzhao 