### PR TITLE
fix: ignore error when unable to watch typedefs

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -466,10 +466,14 @@ export class AppState {
       const fs = await fancyImport<typeof fsType>('fs-extra');
       const typePath = getLocalTypePathForVersion(versionObject);
       console.info(`TypeDefs: Watching file for local version ${version} at path ${typePath}`);
-      this.localTypeWatcher = fs.watch(typePath!, async () => {
-        console.info(`TypeDefs: Noticed file change at ${typePath}. Updating editor typedefs.`);
-        await updateEditorTypeDefinitions(versionObject);
-      });
+      try {
+        this.localTypeWatcher = fs.watch(typePath!, async () => {
+          console.info(`TypeDefs: Noticed file change at ${typePath}. Updating editor typedefs.`);
+          await updateEditorTypeDefinitions(versionObject);
+        });
+      } catch (err) {
+        console.info('TypeDefs: Unable to start watching.')
+      }
     } else {
       if (!!this.localTypeWatcher) {
         console.info(`TypeDefs: Switched to downloaded version ${version}. Unwatching local typedefs.`);


### PR DESCRIPTION
If the file doesn't exists just don't try to watch them.

Fixes #378 