### PR TITLE
fix: use `role: quit` for render exit button in menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -105,9 +105,7 @@ function getQuitItems(): Array<MenuItemConstructorOptions> {
     {
       type: 'separator'
     }, {
-      label: 'Exit',
-      accelerator: 'Ctrl+Q,',
-      click: app.quit
+      role: 'quit'
     }
   ];
 }


### PR DESCRIPTION
He does all the work for us.

Fixes #394 