### PR TITLE
fix: Update documentation link for user-provided flags

### DIFF
--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -110,7 +110,7 @@ export class ExecutionSettings extends React.Component<ExecutionSettingsProps, {
           <FormGroup>
           <p>
             Electron allows starting the executable with <a
-              href='https://electronjs.org/docs/api/chrome-command-line-switches'
+              href='https://www.electronjs.org/docs/api/command-line-switches'
             >
               user-provided flags
             </a>

--- a/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
@@ -40,7 +40,7 @@ exports[`ExecutionSettings component renders 1`] = `
       <p>
         Electron allows starting the executable with 
         <a
-          href="https://electronjs.org/docs/api/chrome-command-line-switches"
+          href="https://www.electronjs.org/docs/api/command-line-switches"
         >
           user-provided flags
         </a>


### PR DESCRIPTION
When editing execution parameters, there's a link to Electron's documentation for command line switches. However, it looks like that documentation page has moved recently (https://github.com/electron/electron/pull/20335).

Old link: https://www.electronjs.org/docs/api/chrome-command-line-switches
New link: https://www.electronjs.org/docs/api/command-line-switches