### PR TITLE
refactor: replace app.getName() with app.name

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -237,7 +237,7 @@ export function setupMenu() {
       // Append the "Settings" item
       if (
         process.platform === 'darwin'
-        && label === app.getName()
+        && label === app.name
         && isSubmenu(item.submenu)
       ) {
         item.submenu.splice(2, 0, ...getPreferencesItems());

--- a/static/show-me/app/main.js
+++ b/static/show-me/app/main.js
@@ -13,5 +13,5 @@ app.on('browser-window-created', () => console.log('A window was created!'))
 app.on('browser-window-focus', () => console.log('...and focused!'))
 
 console.log(`The app lives at: ${app.getAppPath()}`)
-console.log(`It's named: ${app.getName()}`)
+console.log(`It's named: ${app.name}`)
 console.log(`It has the version: ${app.getVersion()}`)

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -15,6 +15,8 @@ jest.mock('../../src/main/ipc');
 
 describe('menu', () => {
   beforeEach(() => {
+    electron.app.name = 'Electron Fiddle';
+    // need to keep this deprecated API for electron-default-menu mock as well
     (electron.app.getName as any).mockReturnValue('Electron Fiddle');
     (electron.dialog.showOpenDialog as any).mockReturnValue(Promise.resolve({}));
   });


### PR DESCRIPTION
As `app.getName` is deprecated, this PR replaces it with the `app.name` property.