### PR TITLE
fix: make hidden editors interact properly with remote content

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -24,6 +24,7 @@ import { Runner } from './runner';
 import { appState } from './state';
 import { getTheme } from './themes';
 import { TouchBarManager } from './touch-bar-manager';
+import { EMPTY_EDITOR_CONTENT } from './constants';
 
 /**
  * The top-level class controlling the whole app. This is *not* a React component,
@@ -68,8 +69,17 @@ export class App {
       }
     }
 
-    // set values once prompt approves
-    await this.setEditorValues(editorValues);
+    // display all editors that have content
+    const visibleEditors = [];
+    for (const id of Object.keys(editorValues)) {
+      const content = editorValues[id];
+
+      // if the gist content matches the empty file output, don't show it
+      if (!Object.values(EMPTY_EDITOR_CONTENT).includes(content)) {
+        visibleEditors.push(id as EditorId);
+      }
+    }
+
 
     document.title = getTitle(this.state);
     this.state.gistId = gistId || '';
@@ -77,6 +87,8 @@ export class App {
     this.state.templateName = templateName;
 
     // once loaded, we have a "saved" state
+    await this.state.setVisibleMosaics(visibleEditors);
+    await this.setEditorValues(editorValues);
     this.state.isUnsaved = false;
 
     return true;

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -18,13 +18,13 @@ import { getEditorValue } from '../utils/editor-value';
 import { getPackageJson, PackageJsonOptions } from '../utils/get-package';
 import { getTitle } from '../utils/get-title';
 import { isEditorBackup } from '../utils/type-checks';
+import { EMPTY_EDITOR_CONTENT } from './constants';
 import { FileManager } from './file-manager';
 import { RemoteLoader } from './remote-loader';
 import { Runner } from './runner';
 import { appState } from './state';
 import { getTheme } from './themes';
 import { TouchBarManager } from './touch-bar-manager';
-import { EMPTY_EDITOR_CONTENT } from './constants';
 
 /**
  * The top-level class controlling the whole app. This is *not* a React component,

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -9,6 +9,7 @@ import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLE
 import { getOctokit } from '../../utils/octokit';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
+import { EMPTY_EDITOR_CONTENT } from '../constants';
 
 export interface PublishButtonProps {
   appState: AppState;
@@ -228,19 +229,19 @@ export class PublishButton extends React.Component<PublishButtonProps, IPublishB
   private gistFilesList = (values: EditorValues) => {
     return {
       [INDEX_HTML_NAME]: {
-        content: values.html || '<!-- Empty -->',
+        content: values.html || EMPTY_EDITOR_CONTENT.html,
       },
       [MAIN_JS_NAME]: {
-        content: values.main || '// Empty',
+        content: values.main || EMPTY_EDITOR_CONTENT.js,
       },
       [RENDERER_JS_NAME]: {
-        content: values.renderer || '// Empty',
+        content: values.renderer || EMPTY_EDITOR_CONTENT.js,
       },
       [PRELOAD_JS_NAME]: {
-        content: values.preload || '// Empty',
+        content: values.preload || EMPTY_EDITOR_CONTENT.js,
       },
       [STYLES_CSS_NAME]: {
-        content: values.css || '/* Empty */',
+        content: values.css || EMPTY_EDITOR_CONTENT.css,
       },
     };
   }

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -7,9 +7,9 @@ import { EditorValues } from '../../interfaces';
 import { IpcEvents } from '../../ipc-events';
 import { INDEX_HTML_NAME, MAIN_JS_NAME, PRELOAD_JS_NAME, RENDERER_JS_NAME, STYLES_CSS_NAME } from '../../shared-constants';
 import { getOctokit } from '../../utils/octokit';
+import { EMPTY_EDITOR_CONTENT } from '../constants';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
-import { EMPTY_EDITOR_CONTENT } from '../constants';
 
 export interface PublishButtonProps {
   appState: AppState;

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { MosaicNode } from 'react-mosaic-component';
 
 import { EditorId, MosaicId } from '../interfaces';
-import { EditorBackup } from '../utils/editor-backup';
+import { EditorBackup, getEditorBackup } from '../utils/editor-backup';
 
 // Reminder: When testing, this file is mocked in tests/setup.js
 
@@ -21,8 +21,16 @@ export const DEFAULT_MOSAIC_ARRANGEMENT: MosaicNode<MosaicId> = {
 };
 
 export const DEFAULT_CLOSED_PANELS: Partial<Record<MosaicId, EditorBackup | true>> = {
-  docsDemo: true
+  docsDemo: true,
+  preload: getEditorBackup(EditorId.preload),
+  css: getEditorBackup(EditorId.css),
 };
+
+export const EMPTY_EDITOR_CONTENT = {
+  html: '<!-- Empty -->',
+  js: '// Empty',
+  css: '/* Empty */'
+}
 
 export const ELECTRON_ORG = 'electron';
 export const ELECTRON_REPO = 'electron';

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -30,7 +30,7 @@ export const EMPTY_EDITOR_CONTENT = {
   html: '<!-- Empty -->',
   js: '// Empty',
   css: '/* Empty */'
-}
+};
 
 export const ELECTRON_ORG = 'electron';
 export const ELECTRON_REPO = 'electron';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -604,6 +604,9 @@ export class AppState {
         this.closedPanels[id] = isEditorId(id)
           ? getEditorBackup(id)
           : true;
+
+        // if we have backup, remove active editor
+        delete window.ElectronFiddle.editors[id];
       }
 
       // Remove the backup for panels now. Editors will remove their

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -627,7 +627,7 @@ export class AppState {
 
     const waitForEditorsToMount = () => {
       let time = 0;
-      const maxTime = 10000;
+      const maxTime = 5000;
       const interval = 100;
       return new Promise((resolve, reject) => {
         (function checkMountedEditors() {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -627,7 +627,7 @@ export class AppState {
 
     const waitForEditorsToMount = () => {
       let time = 0;
-      const maxTime = 5000;
+      const maxTime = 4000;
       const interval = 100;
       return new Promise((resolve, reject) => {
         (function checkMountedEditors() {
@@ -637,7 +637,7 @@ export class AppState {
           }
           time += interval;
           if (time > maxTime) {
-            return reject();
+            return reject(`Timed out after ${maxTime}ms: can't mount editors onto mosaics.`);
           }
           setTimeout(checkMountedEditors, 100);
         })();

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -32,6 +32,7 @@ import { getLocalTypePathForVersion, updateEditorTypeDefinitions } from './fetch
 import { ipcRendererManager } from './ipc';
 import { activateTheme } from './themes';
 
+import { waitForEditorsToMount } from '../utils/editor-mounted';
 import { sortedElectronMap } from '../utils/sorted-electron-map';
 import {
   addLocalVersion,
@@ -625,26 +626,7 @@ export class AppState {
     // mount to ensure that we can load content into the editors as soon as they're
     // declared visible.
 
-    const waitForEditorsToMount = () => {
-      let time = 0;
-      const maxTime = 4000;
-      const interval = 100;
-      return new Promise((resolve, reject) => {
-        (function checkMountedEditors() {
-          const allMounted = visible.every((v) => !!window.ElectronFiddle.editors[v]);
-          if (allMounted) {
-            return resolve();
-          }
-          time += interval;
-          if (time > maxTime) {
-            return reject(`Timed out after ${maxTime}ms: can't mount editors onto mosaics.`);
-          }
-          setTimeout(checkMountedEditors, 100);
-        })();
-      });
-    };
-
-    await waitForEditorsToMount();
+    await waitForEditorsToMount(visible);
   }
 
   /**

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -629,9 +629,9 @@ export class AppState {
       let time = 0;
       const maxTime = 10000;
       const interval = 100;
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         (function checkMountedEditors() {
-          const allMounted = visible.every(v => !!window.ElectronFiddle.editors[v]);
+          const allMounted = visible.every((v) => !!window.ElectronFiddle.editors[v]);
           if (allMounted) {
             return resolve();
           }
@@ -642,7 +642,7 @@ export class AppState {
           setTimeout(checkMountedEditors, 100);
         })();
       });
-    }
+    };
 
     await waitForEditorsToMount();
   }

--- a/src/utils/editor-model.ts
+++ b/src/utils/editor-model.ts
@@ -12,7 +12,7 @@ export function getEditorModel(id: EditorId): editor.ITextModel  | null {
   const { ElectronFiddle: fiddle } = window;
 
   if (!fiddle) {
-    throw new Error('Fiddle not ready');
+    return null;
   }
 
   if (fiddle.editors[id] && fiddle.editors[id]!.getModel) {

--- a/src/utils/editor-mounted.ts
+++ b/src/utils/editor-mounted.ts
@@ -1,0 +1,24 @@
+import { MosaicId } from '../interfaces';
+
+/**
+ * Waits for editors to mount on a list of Mosaic IDs
+ * @param editors
+ */
+export function waitForEditorsToMount(editors: Array<MosaicId>) {
+  let time = 0;
+  const maxTime = 4000;
+  const interval = 100;
+  return new Promise((resolve, reject) => {
+    (function checkMountedEditors() {
+      const allMounted = editors.every((id) => !!window.ElectronFiddle.editors[id]);
+      if (allMounted) {
+        return resolve();
+      }
+      time += interval;
+      if (time > maxTime) {
+        return reject(`Timed out after ${maxTime}ms: can't mount editors onto mosaics.`);
+      }
+      setTimeout(checkMountedEditors, 100);
+    })();
+  });
+}

--- a/src/utils/editor-mounted.ts
+++ b/src/utils/editor-mounted.ts
@@ -6,7 +6,7 @@ import { MosaicId } from '../interfaces';
  */
 export function waitForEditorsToMount(editors: Array<MosaicId>) {
   let time = 0;
-  const maxTime = 4000;
+  const maxTime = 3000;
   const interval = 100;
   return new Promise((resolve, reject) => {
     (function checkMountedEditors() {

--- a/src/utils/editor-value.ts
+++ b/src/utils/editor-value.ts
@@ -1,4 +1,5 @@
 import { EditorId } from '../interfaces';
+import { EditorBackup } from './editor-backup';
 
 /**
  * Return the value for a given editor
@@ -13,8 +14,13 @@ export function getEditorValue(id: EditorId): string {
     return '';
   }
 
-  if (fiddle.editors[id] && fiddle.editors[id]!.getValue) {
+  const editor = fiddle.editors[id];
+  const backup = fiddle.app.state.closedPanels[id] as EditorBackup;
+
+  if (editor?.getValue) {
     return fiddle.editors[id]!.getValue();
+  } else if (backup?.value) {
+    return backup.value;
   }
 
   return '';

--- a/src/utils/editor-value.ts
+++ b/src/utils/editor-value.ts
@@ -10,7 +10,7 @@ export function getEditorValue(id: EditorId): string {
   const { ElectronFiddle: fiddle } = window;
 
   if (!fiddle) {
-    throw new Error('Fiddle not ready');
+    return '';
   }
 
   if (fiddle.editors[id] && fiddle.editors[id]!.getValue) {

--- a/src/utils/editor-value.ts
+++ b/src/utils/editor-value.ts
@@ -15,7 +15,7 @@ export function getEditorValue(id: EditorId): string {
   }
 
   const editor = fiddle.editors[id];
-  const backup = fiddle.app.state.closedPanels[id] as EditorBackup;
+  const backup = fiddle.app?.state?.closedPanels[id] as EditorBackup;
 
   if (editor?.getValue) {
     return fiddle.editors[id]!.getValue();

--- a/src/utils/editor-viewstate.ts
+++ b/src/utils/editor-viewstate.ts
@@ -13,7 +13,7 @@ export function getEditorViewState(id: EditorId): editor.ICodeEditorViewState | 
   const { ElectronFiddle: fiddle } = window;
 
   if (!fiddle) {
-    throw new Error('Fiddle not ready');
+    return null;
   }
 
   if (fiddle.editors[id] && fiddle.editors[id]!.saveViewState) {

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -114,6 +114,7 @@ describe('Editors component', () => {
       const app = new App();
       (app.state as Partial<AppState>) = new MockState();
       app.state.isUnsaved = false;
+      app.state.setVisibleMosaics = jest.fn();
       app.setEditorValues = jest.fn();
 
       const editorValues = {
@@ -143,6 +144,7 @@ describe('Editors component', () => {
       app.state.isUnsaved = true;
       app.state.localPath = '/fake/path';
       app.state.setGenericDialogOptions = jest.fn();
+      app.state.setVisibleMosaics = jest.fn();
       app.setEditorValues = jest.fn();
 
       const editorValues = {
@@ -172,6 +174,7 @@ describe('Editors component', () => {
       const app = new App();
       (app.state as Partial<AppState>) = new MockState();
       app.state.isUnsaved = false;
+      app.state.setVisibleMosaics = jest.fn();
       app.setEditorValues = jest.fn();
 
       const editorValues = {
@@ -195,6 +198,7 @@ describe('Editors component', () => {
         const app = new App();
         (app.state as Partial<AppState>) = new MockState();
         app.state.isUnsaved = true;
+        app.state.setVisibleMosaics = jest.fn();
         app.state.setGenericDialogOptions = jest.fn();
         app.setEditorValues = jest.fn();
 
@@ -226,6 +230,7 @@ describe('Editors component', () => {
         const app = new App();
         (app.state as Partial<AppState>) = new MockState();
         app.state.isUnsaved = true;
+        app.state.setVisibleMosaics = jest.fn();
         app.state.setGenericDialogOptions = jest.fn();
         app.setEditorValues = jest.fn();
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,3 +1,5 @@
+import * as MonacoType from 'monaco-editor';
+
 import { ALL_MOSAICS, EditorId, GenericDialogType, PanelId, VersionSource, VersionState } from '../../src/interfaces';
 import { getDownloadedVersions, getDownloadingVersions, removeBinary, setupBinary } from '../../src/renderer/binary';
 import { Bisector } from '../../src/renderer/bisect';
@@ -511,10 +513,12 @@ describe('AppState', () => {
   });
 
   describe('setVisibleMosaics()', () => {
-    it('updates the visible editors and creates a backup', () => {
+    it.only('updates the visible editors and creates a backup', async () => {
       appState.mosaicArrangement = createMosaicArrangement(ALL_MOSAICS);
       appState.closedPanels = {};
-      appState.setVisibleMosaics([EditorId.main]);
+      await appState.setVisibleMosaics([EditorId.main]);
+
+      window.ElectronFiddle.editors[EditorId.main] = ({} as MonacoType.editor.IStandaloneCodeEditor);
 
       expect(appState.mosaicArrangement).toEqual(EditorId.main);
       expect(appState.closedPanels[EditorId.renderer]).toBeTruthy();
@@ -522,10 +526,10 @@ describe('AppState', () => {
       expect(appState.closedPanels[EditorId.main]).toBeUndefined();
     });
 
-    it('removes the backup for a non-editor right away', () => {
+    it('removes the backup for a non-editor right away', async () => {
       appState.closedPanels = {};
       appState.closedPanels[PanelId.docsDemo] = true;
-      appState.setVisibleMosaics(ALL_MOSAICS);
+      await appState.setVisibleMosaics(ALL_MOSAICS);
 
       expect(appState.closedPanels[PanelId.docsDemo]).toBeUndefined();
     });

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -531,6 +531,11 @@ describe('AppState', () => {
     it('removes the backup for a non-editor right away', async () => {
       appState.closedPanels = {};
       appState.closedPanels[PanelId.docsDemo] = true;
+
+      for (const mosaic of ALL_MOSAICS) {
+        window.ElectronFiddle.editors[mosaic] = ({} as MonacoType.editor.IStandaloneCodeEditor);
+      }
+
       await appState.setVisibleMosaics(ALL_MOSAICS);
 
       expect(appState.closedPanels[PanelId.docsDemo]).toBeUndefined();

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -533,6 +533,8 @@ describe('AppState', () => {
       appState.closedPanels[PanelId.docsDemo] = true;
 
       for (const mosaic of ALL_MOSAICS) {
+        // we just need to mock something truthy here
+        // tslint:disable-next-line:no-object-literal-type-assertion
         window.ElectronFiddle.editors[mosaic] = ({} as MonacoType.editor.IStandaloneCodeEditor);
       }
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -542,6 +542,16 @@ describe('AppState', () => {
 
       expect(appState.closedPanels[PanelId.docsDemo]).toBeUndefined();
     });
+
+    it('times out if editors never get set on the visible mosaics', async () => {
+      delete window.ElectronFiddle.editors[EditorId.main];
+
+      try {
+        await appState.setVisibleMosaics([EditorId.main]);
+      } catch(e) {
+        expect(e).toMatch('Timed out')
+      }
+    })
   });
 
   describe('hideAndBackupMosaic()', () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -513,7 +513,7 @@ describe('AppState', () => {
   });
 
   describe('setVisibleMosaics()', () => {
-    it.only('updates the visible editors and creates a backup', async () => {
+    it('updates the visible editors and creates a backup', async () => {
       appState.mosaicArrangement = createMosaicArrangement(ALL_MOSAICS);
       appState.closedPanels = {};
       await appState.setVisibleMosaics([EditorId.main]);

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -548,10 +548,10 @@ describe('AppState', () => {
 
       try {
         await appState.setVisibleMosaics([EditorId.main]);
-      } catch(e) {
-        expect(e).toMatch('Timed out')
+      } catch (e) {
+        expect(e).toMatch('Timed out');
       }
-    })
+    });
   });
 
   describe('hideAndBackupMosaic()', () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -518,6 +518,8 @@ describe('AppState', () => {
       appState.closedPanels = {};
       await appState.setVisibleMosaics([EditorId.main]);
 
+      // we just need to mock something truthy here
+      // tslint:disable-next-line:no-object-literal-type-assertion
       window.ElectronFiddle.editors[EditorId.main] = ({} as MonacoType.editor.IStandaloneCodeEditor);
 
       expect(appState.mosaicArrangement).toEqual(EditorId.main);

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -542,16 +542,6 @@ describe('AppState', () => {
 
       expect(appState.closedPanels[PanelId.docsDemo]).toBeUndefined();
     });
-
-    it('times out if editors never get set on the visible mosaics', async () => {
-      delete window.ElectronFiddle.editors[EditorId.main];
-
-      try {
-        await appState.setVisibleMosaics([EditorId.main]);
-      } catch (e) {
-        expect(e).toMatch('Timed out');
-      }
-    });
   });
 
   describe('hideAndBackupMosaic()', () => {

--- a/tests/utils/editor-model-spec.ts
+++ b/tests/utils/editor-model-spec.ts
@@ -16,11 +16,11 @@ describe('getEditorModel()', () => {
     fiddle.editors[EditorId.html] = oldEditor;
   });
 
-  it('throws if window.Fiddle is not ready', () => {
+  it('returns null if window.Fiddle is not ready', () => {
     const { ElectronFiddle: fiddle } = window as any;
     (window as any).ElectronFiddle = undefined;
 
-    expect(() => getEditorModel(EditorId.html)).toThrow('Fiddle not ready');
+    expect(getEditorModel(EditorId.html)).toEqual(null);
 
     window.ElectronFiddle = fiddle;
   });

--- a/tests/utils/editor-mounted-spec.ts
+++ b/tests/utils/editor-mounted-spec.ts
@@ -20,4 +20,4 @@ describe('waitforEditorsToMount', () => {
       expect(error).toMatch('Timed out');
     }
   });
-})
+});

--- a/tests/utils/editor-mounted-spec.ts
+++ b/tests/utils/editor-mounted-spec.ts
@@ -1,0 +1,23 @@
+import { waitForEditorsToMount } from '../../src/utils/editor-mounted';
+
+import { EditorId } from '../../src/interfaces';
+
+describe('waitforEditorsToMount', () => {
+  it('resolves when editors match list', async () => {
+    // these editors should be mounted by default.
+    const { ElectronFiddle: fiddle } = window as any;
+    await waitForEditorsToMount([EditorId.html, EditorId.main, EditorId.renderer]);
+    expect(fiddle.editors).toHaveProperty(EditorId.html);
+    expect(fiddle.editors).toHaveProperty(EditorId.main);
+    expect(fiddle.editors).toHaveProperty(EditorId.renderer);
+  });
+
+  it('rejects if editors fail to match list', async () => {
+    try {
+      // css editor shouldn't be mounted by default.
+      await waitForEditorsToMount([EditorId.css]);
+    } catch (error) {
+      expect(error).toMatch('Timed out');
+    }
+  });
+})

--- a/tests/utils/editor-value-spec.ts
+++ b/tests/utils/editor-value-spec.ts
@@ -1,10 +1,33 @@
 import { EditorId } from '../../src/interfaces';
 import { getEditorValue } from '../../src/utils/editor-value';
+import { MockState } from '../mocks/state';
 
 describe('getEditorValue()', () => {
-  it('returns the value for an editor', () => {
+  it('returns the value for an editor if it exists', () => {
     expect(getEditorValue(EditorId.html)).toBe('editor-value');
   });
+
+  it('returns the value for the editor backup if it exists', () => {
+    // set up mock state that has the editor deleted and a backup
+    const oldEditor = window.ElectronFiddle.editors[EditorId.html];
+    window.ElectronFiddle.editors[EditorId.html] = null;
+
+    window.ElectronFiddle.app.state = (new MockState() as any);
+    const mockState = window.ElectronFiddle.app.state;
+
+    mockState.closedPanels = {
+      [EditorId.html]: {
+        value: 'editor-backup-value'
+      }
+    }
+  
+    // assert
+    expect(getEditorValue(EditorId.html)).toBe('editor-backup-value');
+    
+    // revert to initial state
+    delete window.ElectronFiddle.app.state;
+    window.ElectronFiddle.editors[EditorId.html] = oldEditor;
+  })
 
   it('returns an empty string if window.Fiddle is not ready', () => {
     const oldFiddle = window.ElectronFiddle;

--- a/tests/utils/editor-value-spec.ts
+++ b/tests/utils/editor-value-spec.ts
@@ -6,11 +6,11 @@ describe('getEditorValue()', () => {
     expect(getEditorValue(EditorId.html)).toBe('editor-value');
   });
 
-  it('throws if window.Fiddle is not ready', () => {
+  it('returns an empty string if window.Fiddle is not ready', () => {
     const oldFiddle = window.ElectronFiddle;
     (window as any).ElectronFiddle = undefined;
 
-    expect(() => getEditorValue(EditorId.html)).toThrow('Fiddle not ready');
+    expect(getEditorValue(EditorId.html)).toBe('');
 
     window.ElectronFiddle = oldFiddle;
   });

--- a/tests/utils/editor-value-spec.ts
+++ b/tests/utils/editor-value-spec.ts
@@ -19,15 +19,15 @@ describe('getEditorValue()', () => {
       [EditorId.html]: {
         value: 'editor-backup-value'
       }
-    }
-  
+    };
+
     // assert
     expect(getEditorValue(EditorId.html)).toBe('editor-backup-value');
-    
+
     // revert to initial state
     delete window.ElectronFiddle.app.state;
     window.ElectronFiddle.editors[EditorId.html] = oldEditor;
-  })
+  });
 
   it('returns an empty string if window.Fiddle is not ready', () => {
     const oldFiddle = window.ElectronFiddle;

--- a/tests/utils/editor-viewstate-spec.ts
+++ b/tests/utils/editor-viewstate-spec.ts
@@ -20,7 +20,7 @@ describe('getEditorViewState()', () => {
     const { ElectronFiddle: fiddle } = window as any;
     (window as any).ElectronFiddle = undefined;
 
-    expect(() => getEditorViewState(EditorId.html)).toThrow('Fiddle not ready');
+    expect(getEditorViewState(EditorId.html)).toBeNull();
 
     window.ElectronFiddle = fiddle;
   });


### PR DESCRIPTION
Fixes #387
Fixes #400

### Context

We didn't account for hidden editors when considering our interactions with publishing Gists. This presented itself in two ways:

1) Remote content (including Gists) would only load if the editor was loaded at some point. This is because we checked each editor for its corresponding remote content.
2) Published Gists would be missing content if an editor was hidden.

### Changes

1) When loading remote content, we now first open all editors that have non-placeholder content. This ensures that the content can load into the editors, and provides an all-around better experience since all the content from the Gist will be loaded on-screen.

2) When hiding an editor, we now delete it from the `editors` mapping before creating its backup in `appState.closedPanels`. We also now check the value of backups when calling `getEditorValue`. These two changes ensure that any hidden content gets properly published into the Gist.

3) We unfortunately didn't get the above two fixes for free. I had to make `setVisibleMosaics` asynchronous -- it now waits until all Monaco editors are loaded before resolving in order to avoid any race conditions with assuming editors are ready right after we open their panel. This is done in a hacky way by periodically polling the editors object until their contents match the mosaics that we've opened.