### PR TITLE
fix: package nightlies correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6508,9 +6508,9 @@
       }
     },
     "electron-rebuild": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.10.1.tgz",
-      "integrity": "sha512-KSqp0Xiu7CCvKL2aEdPp/vNe2Rr11vaO8eM/wq9gQJTY02UjtAJ3l7WLV7Mf8oR+UJReJO8SWOWs/FozqK8ggA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.11.0.tgz",
+      "integrity": "sha512-cn6AqZBQBVtaEyj5jZW1/LOezZZ22PA1HvhEP7asvYPJ8PDF4i4UFt9be4i9T7xJKiSiomXvY5Fd+dSq3FXZxA==",
       "dev": true,
       "requires": {
         "colors": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chokidar": "^3.3.1",
     "coveralls": "^3.0.9",
     "electron": "8.0.2",
+    "electron-rebuild": "^1.11.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.4",


### PR DESCRIPTION
Fixes packaging nightly builds. 

Nightlies come from `electron-nightly` and not `electron`, so we need to change the name in package.json. We also need to force a new ABI number as none has been assigned for nightlies.