### PR TITLE
fix: transparent BrowserWindow show-me on Windows

### DIFF
--- a/static/show-me/browserwindow/main.js
+++ b/static/show-me/browserwindow/main.js
@@ -23,15 +23,27 @@ app.on('ready', () => {
       y: 200
     })
   )
-
-  // A transparent window
-  windows.push(
-    new BrowserWindow({
-      transparent: true,
-      x: 300,
-      y: 300
-    })
-  )
+  
+  // A transparent window. On Windows OS, a transparent window must be frameless
+  if (process.platform != 'win32') {
+    windows.push(
+      new BrowserWindow({
+        transparent: true,
+        x: 300,
+        y: 300
+      })
+    )  
+  }
+  else {
+    windows.push(
+      new BrowserWindow({
+        transparent: true,
+        frame: false,
+        x: 300,
+        y: 300
+      })
+    )
+  }
 
   // A window that's fixed and always on top
   windows.push(

--- a/static/show-me/browserwindow/main.js
+++ b/static/show-me/browserwindow/main.js
@@ -30,7 +30,7 @@ app.on('ready', () => {
     x: 300,
     y: 300
   }
-  // On Windows OS, a transparent window must be frameless
+  // On Windows platforms, a transparent window must be frameless
   if (process.platform === 'win32') {
     windowOptions.frame = false
   }

--- a/static/show-me/browserwindow/main.js
+++ b/static/show-me/browserwindow/main.js
@@ -23,27 +23,18 @@ app.on('ready', () => {
       y: 200
     })
   )
-  
-  // A transparent window. On Windows OS, a transparent window must be frameless
-  if (process.platform != 'win32') {
-    windows.push(
-      new BrowserWindow({
-        transparent: true,
-        x: 300,
-        y: 300
-      })
-    )  
+
+  // A transparent window.
+  const windowOptions = {
+    transparent: true,
+    x: 300,
+    y: 300
   }
-  else {
-    windows.push(
-      new BrowserWindow({
-        transparent: true,
-        frame: false,
-        x: 300,
-        y: 300
-      })
-    )
+  // On Windows OS, a transparent window must be frameless
+  if (process.platform === 'win32') {
+    windowOptions.frame = false
   }
+  windows.push(new BrowserWindow(windowOptions))
 
   // A window that's fixed and always on top
   windows.push(


### PR DESCRIPTION
The `transparent` configuration on Windows OS requires the window to also be frameless. Updating the show-me to handle win32. 

The show-me now also demonstrates the `frame` configuration. 

This behavior is documented at the entry for `transparent` at the [BrowserWindow API doc](https://www.electronjs.org/docs/api/browser-window#new-browserwindowoptions).