### PR TITLE
fix: audio/video entitlements crash

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -16,12 +16,11 @@ const config = {
     executableName: 'electron-fiddle',
     asar: true,
     icon: path.resolve(__dirname, 'assets', 'icons', 'fiddle'),
-    // TODO: FIXME?
-    // ignore: [
-    //   /^\/\.vscode\//,
-    //   /^\/tools\//
-    // ],
     appBundleId: 'com.electron.fiddle',
+    usageDescription: {
+      Camera: 'Access is needed by certain built-in fiddles in addition to any custom fiddles that use the Camera',
+      Microphone: 'Access is needed by certain built-in fiddles in addition to any custom fiddles that use the Microphone'
+    },
     appCategoryType: 'public.app-category.developer-tools',
     protocols: [{
       name: 'Electron Fiddle Launch Protocol',

--- a/static/entitlements.plist
+++ b/static/entitlements.plist
@@ -8,5 +8,9 @@
     <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Fiddle was blowing up spectacularly when i tried to test 

```
const { systemPreferences } = require('electron')

const microphone = systemPreferences.askForMediaAccess("microphone")
```

and a journey into the Console app informed me:

```
This app has crashed because it has a hardened runtime and attempted to access privacy-sensitive data without an entitlement indicating its intent to access this data.  The app must have the 'com.apple.security.device.audio-input' entitlement.
```

and so this adds relevant entitlements to fiddle to fix said crash.

cc @felixrieseberg @erickzhao