### PR TITLE
fix: clearer document titles

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -54,6 +54,7 @@ export class App {
     editorValues: Partial<EditorValues>,
     { filePath, gistId, templateName }: Partial<SetFiddleOptions>
   ) {
+    console.warn('@@@@@', filePath, gistId, templateName)
     // if unsaved, prompt user to make sure they're okay with overwriting and changing directory
     if (this.state.isUnsaved) {
       this.state.setGenericDialogOptions({
@@ -81,7 +82,6 @@ export class App {
     }
 
 
-    document.title = getTitle(this.state);
     this.state.gistId = gistId || '';
     this.state.localPath = filePath;
     this.state.templateName = templateName;
@@ -90,6 +90,9 @@ export class App {
     await this.state.setVisibleMosaics(visibleEditors);
     await this.setEditorValues(editorValues);
     this.state.isUnsaved = false;
+
+
+    document.title = getTitle(this.state);
 
     return true;
   }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -54,7 +54,6 @@ export class App {
     editorValues: Partial<EditorValues>,
     { filePath, gistId, templateName }: Partial<SetFiddleOptions>
   ) {
-    console.warn('@@@@@', filePath, gistId, templateName)
     // if unsaved, prompt user to make sure they're okay with overwriting and changing directory
     if (this.state.isUnsaved) {
       this.state.setGenericDialogOptions({

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -30,7 +30,7 @@ export class AddressBar extends React.Component<AddressBarProps, AddressBarState
     this.submit = this.submit.bind(this);
 
     const { gistId } = this.props.appState;
-    const value = gistId ? urlFromId(gistId) : '';
+    const value = urlFromId(gistId);
 
     const { remoteLoader } = window.ElectronFiddle.app;
 

--- a/src/renderer/components/commands-publish-button.tsx
+++ b/src/renderer/components/commands-publish-button.tsx
@@ -100,7 +100,7 @@ export class PublishButton extends React.Component<PublishButtonProps, IPublishB
         isUpdating: true
       });
       const gist = await octo.gists.update({
-        gist_id: appState.gistId,
+        gist_id: appState.gistId!,
         files: this.gistFilesList(values) as any,
       });
 
@@ -118,6 +118,7 @@ export class PublishButton extends React.Component<PublishButtonProps, IPublishB
         });
 
         appState.gistId = gist.data.id;
+        appState.localPath = undefined;
 
         console.log(`Publish Button: Publishing done`, { gist });
         this.renderToast({ message: 'Publishing done successfully!' });

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -107,6 +107,7 @@ export class FileManager {
 
       if (pathToSave !== localPath) {
         this.appState.localPath = pathToSave;
+        this.appState.gistId = undefined;
       }
 
       this.appState.isUnsaved = false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -90,7 +90,7 @@ export class AppState {
       [] : this.retrieve('executionFlags') as Array<string>;
 
   // -- Various session-only state ------------------
-  @observable public gistId: string = '';
+  @observable public gistId: string | undefined;
   @observable public versions: Record<string, RunnableVersion> = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
   @observable public localPath: string | undefined;

--- a/src/utils/gist.ts
+++ b/src/utils/gist.ts
@@ -21,6 +21,6 @@ export function idFromUrl(input: string): string | null {
  * @param {string} input
  * @returns {string}
  */
-export function urlFromId(input: string): string {
-  return `https://gist.github.com/${input}`;
+export function urlFromId(input: string | undefined): string {
+  return input ? `https://gist.github.com/${input}` : '';
 }

--- a/src/utils/gist.ts
+++ b/src/utils/gist.ts
@@ -21,6 +21,6 @@ export function idFromUrl(input: string): string | null {
  * @param {string} input
  * @returns {string}
  */
-export function urlFromId(input: string | undefined): string {
+export function urlFromId(input?: string): string {
   return input ? `https://gist.github.com/${input}` : '';
 }

--- a/tests/utils/gist-spec.ts
+++ b/tests/utils/gist-spec.ts
@@ -33,7 +33,7 @@ describe('gist', () => {
     });
 
     it('returns an empty string if id is undefined', () => {
-      const result = urlFromId(undefined);
+      const result = urlFromId();
       expect(result).toBe('');
     });
   });

--- a/tests/utils/gist-spec.ts
+++ b/tests/utils/gist-spec.ts
@@ -31,5 +31,10 @@ describe('gist', () => {
       const result = urlFromId(mockId);
       expect(result).toBe(`https://gist.github.com/${mockId}`);
     });
+
+    it('returns an empty string if id is undefined', () => {
+      const result = urlFromId(undefined);
+      expect(result).toBe('');
+    });
   });
 });


### PR DESCRIPTION
Fixes #396 

This PR clears the `localPath` variable in the App State whenever a `gistId` is saved, and vice-versa. Although I do still think that the user experience here still has a lot of room for improvement, this change makes it slightly clearer because you only have one source of truth with each save/publish.

Caveat: if you save a Fiddle that was previously published as a Gist, the Gist ID disappears in the publish bar.