### PR TITLE
fix: add functioning Select All menu item

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -27,6 +27,7 @@ export enum IpcEvents {
   BEFORE_QUIT = 'BEFORE_QUIT',
   CONFIRM_QUIT = 'CONFIRM_QUIT',
   SET_APPDATA_DIR = 'SET_APPDATA_DIR',
+  SELECT_ALL_IN_EDITOR = 'SELECT_ALL_IN_EDITOR'
 }
 
 export const ipcMainEvents = [
@@ -61,6 +62,7 @@ export const ipcRendererEvents = [
   IpcEvents.BISECT_COMMANDS_TOGGLE,
   IpcEvents.BEFORE_QUIT,
   IpcEvents.SET_APPDATA_DIR,
+  IpcEvents.SELECT_ALL_IN_EDITOR
 ];
 
 export const WEBCONTENTS_READY_FOR_IPC_SIGNAL = 'WEBCONTENTS_READY_FOR_IPC_SIGNAL';

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -243,6 +243,15 @@ export function setupMenu() {
         item.submenu.splice(2, 0, ...getPreferencesItems());
       }
 
+      // Custom handler for "Select All" for Monaco
+      if (label === 'Edit' && isSubmenu(item.submenu)) {
+        const selectAll = item.submenu.find(i => i.label === 'Select All')!;
+        delete selectAll.role; // override default role
+        selectAll.click = () => {
+          ipcMainManager.send(IpcEvents.SELECT_ALL_IN_EDITOR);
+        }
+      }
+
       // Tweak "View" menu
       if (label === 'View' && isSubmenu(item.submenu)) {
         // remove "Reload" (has weird behaviour) and "Toggle Developer Tools"

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -92,6 +92,16 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
       this.toggleEditorOption(cmd);
     });
 
+    ipcRendererManager.on(IpcEvents.SELECT_ALL_IN_EDITOR, (_event) => {
+      // programmatically fetch all editor contents and set as selection
+      const editor = getFocusedEditor();
+      const range = editor?.getModel()?.getFullModelRange();
+
+      if (!!range) {
+        editor?.setSelection(range);
+      }
+    });
+
     this.setState({ isMounted: true });
     await this.loadMonaco();
     this.props.appState.isUnsaved = false;
@@ -103,6 +113,7 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     ipcRendererManager.removeAllListeners(IpcEvents.MONACO_EXECUTE_COMMAND);
     ipcRendererManager.removeAllListeners(IpcEvents.FS_NEW_FIDDLE);
     ipcRendererManager.removeAllListeners(IpcEvents.MONACO_TOGGLE_OPTION);
+    ipcRendererManager.removeAllListeners(IpcEvents.SELECT_ALL_IN_EDITOR);
   }
 
   /**

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -98,6 +98,17 @@ describe('menu', () => {
       expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.BISECT_COMMANDS_TOGGLE);
 
     });
+
+    it('overwrites Select All command', () => {
+      setupMenu();
+
+      const result = (electron.Menu.buildFromTemplate as any).mock.calls[0][0];
+      const submenu = result[2].submenu as Array<Electron.MenuItemConstructorOptions>;
+
+      const selectAll = submenu.find(({ label }) => label === 'Select All');
+      (selectAll as any).click();
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.SELECT_ALL_IN_EDITOR);
+    })
   });
 
   describe('menu groups', () => {

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -103,7 +103,8 @@ describe('menu', () => {
       setupMenu();
 
       const result = (electron.Menu.buildFromTemplate as any).mock.calls[0][0];
-      const submenu = result[2].submenu as Array<Electron.MenuItemConstructorOptions>;
+      // use find here because the index is platform-specific
+      const submenu = result.find((r: any) => r.label === 'Edit').submenu as Array<Electron.MenuItemConstructorOptions>;
 
       const selectAll = submenu.find(({ label }) => label === 'Select All');
       (selectAll as any).click();

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -138,8 +138,8 @@ describe('Editors component', () => {
     const wrapper = shallow(<Editors appState={store} />);
     const instance: Editors = wrapper.instance() as any;
     (instance as any).disposeLayoutAutorun = jest.fn();
-
-    instance.componentWillUnmount();
+    
+    wrapper.unmount();
 
     expect(instance.disposeLayoutAutorun).toHaveBeenCalledTimes(1);
   });
@@ -154,7 +154,7 @@ describe('Editors component', () => {
   });
 
   describe('IPC commands', () => {
-    it('handles an MONACO_EXECUTE_COMMAND command', () => {
+    it('handles a MONACO_EXECUTE_COMMAND command', () => {
       shallow(<Editors appState={store} />);
 
       const mockAction = {
@@ -182,6 +182,22 @@ describe('Editors component', () => {
         done();
       });
     });
+
+    it('handles a SELECT_ALL_IN_EDITOR command', (done) => {
+      shallow(<Editors appState={store} />);
+      const mockEditor = {
+        getModel: () => ({
+          getFullModelRange: jest.fn().mockReturnValue('range')
+        }),
+        setSelection: jest.fn()
+      };
+      (getFocusedEditor as any).mockReturnValueOnce(mockEditor);
+      ipcRendererManager.emit(IpcEvents.SELECT_ALL_IN_EDITOR, null);
+      process.nextTick(() => {
+        expect(mockEditor.setSelection).toHaveBeenCalledWith('range');
+        done();
+      });
+    })
 
     it('handles the monaco editor option commands', () => {
       shallow(<Editors appState={store} />);


### PR DESCRIPTION
Fixes #434 by overriding the default MenuItem role and programmatically selecting the entire contents of the currently focused editor.