### PR TITLE
build(deps): upgrade electron-default-menu to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6700,9 +6700,9 @@
       }
     },
     "electron-default-menu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/electron-default-menu/-/electron-default-menu-1.0.1.tgz",
-      "integrity": "sha1-MXPFAY61B0BP7GO987eMOO7bqAg="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/electron-default-menu/-/electron-default-menu-1.0.2.tgz",
+      "integrity": "sha512-YAL/UNR3kPG58wOOlmDpTG3i6+bzwhHx6NllIOaLuVrU7uYifeYGGdk5IH2Hap4wVEx2YTA8cqQ2PGSplYwDWQ=="
     },
     "electron-devtools-installer": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@octokit/rest": "^16.43.1",
     "@sentry/electron": "^1.2.1",
     "classnames": "^2.2.6",
-    "electron-default-menu": "^1.0.1",
+    "electron-default-menu": "1.0.2",
     "electron-devtools-installer": "^2.2.4",
     "electron-squirrel-startup": "^1.0.0",
     "extract-zip": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@octokit/rest": "^16.43.1",
     "@sentry/electron": "^1.2.1",
     "classnames": "^2.2.6",
-    "electron-default-menu": "1.0.2",
+    "electron-default-menu": "^1.0.2",
     "electron-devtools-installer": "^2.2.4",
     "electron-squirrel-startup": "^1.0.0",
     "extract-zip": "^1.6.7",


### PR DESCRIPTION
Closes #441

Updates to `^1.0.2`