### PR TITLE
refactor: remove unnecessary code in renderer/state.ts

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -397,9 +397,7 @@ export class AppState {
   @action public toggleSettings() {
     // We usually don't lose editor focus,
     // so you can still type. Let's force-blur.
-    if ((document.activeElement as HTMLInputElement).blur) {
-      (document.activeElement as HTMLInputElement).blur();
-    }
+    (document.activeElement as HTMLInputElement).blur();
 
     this.resetView({ isSettingsShowing: !this.isSettingsShowing });
   }
@@ -425,7 +423,6 @@ export class AppState {
 
   @action public setGenericDialogOptions(opts: GenericDialogOptions) {
     this.genericDialogOptions = {
-      type: GenericDialogType.warning,
       ok: 'Okay',
       cancel: 'Cancel',
       ...opts,


### PR DESCRIPTION
Two small fixes that TypeScript was complaining about. Shouldn't have any change on how things work.