### PR TITLE
chore: only enable Sentry in production

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/electron';
+import { isDevMode } from './utils/devmode';
 
 export function initSentry() {
-  if (!(global as any).__JEST__) {
+  if (!(global as any).__JEST__ && !isDevMode()) {
     Sentry.init({
       dsn: 'https://966a5b01ac8d4941b81e4ebd0ab4c991@sentry.io/1882540',
     });


### PR DESCRIPTION
This PR makes it so that Sentry doesn't activate on developer builds. Of course, one technically _could_ revert this change in their local repo and `npm start` anyways, but it should cut down Sentry alerts from people testing changes locally.