### PR TITLE
fix: selectAll should work in text fields

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -271,6 +271,11 @@ export function setupMenu() {
       delete selectAll.role; // override default role
       selectAll.click = () => {
         ipcMainManager.send(IpcEvents.SELECT_ALL_IN_EDITOR);
+
+        // Allow selection to occur in text fields outside the editors.
+        if (process.platform === 'darwin') {
+          Menu.sendActionToFirstResponder('selectAll:');
+        }
       };
     }
 

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -26,6 +26,7 @@ class MockAutoUpdater extends EventEmitter {
 
 export class MockMenu {
   public static readonly setApplicationMenu = jest.fn();
+  public static readonly sendActionToFirstResponder = jest.fn();
   public static readonly getApplicationMenu = jest.fn();
   public static readonly buildFromTemplate = jest.fn();
   public readonly popup = jest.fn();


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/479.

Also sends the action to the first responder so that this also works in the version picker and gist text field.

cc @nornagon @erickzhao @HashimotoYT 