### PR TITLE
fix: version prerelease sorting

### DIFF
--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -20,12 +20,28 @@ export function sortedElectronMap<T>(
         return a.localeCompare(b);
       }
 
-      if (!semver.valid(a)) {
-        return -1;
-      }
+      if (!semver.valid(a)) return -1;
+      if (!semver.valid(b)) return 1;
 
-      if (!semver.valid(b)) {
-        return 1;
+      // Handle prerelease tag sorting - semver does not handle this.
+      // See https://www.npmjs.com/package/semver#prerelease-tags for more.
+      const bothPre = semver.prerelease(a) && semver.prerelease(b);
+      const sameCoerced =
+        semver.valid(semver.coerce(a)) === semver.valid(semver.coerce(b));
+      if (bothPre && sameCoerced) {
+        const [tagA, valueA] = semver.prerelease(a)!;
+        const [tagB, valueB] = semver.prerelease(b)!;
+
+        if (tagA === 'beta' && tagA === tagB) {
+          // Both are betas - compare beta number.
+          return valueA > valueB ? -1 : 1;
+        } else if (tagA === 'nightly' && tagA === tagB) {
+          // Both are nightlies - compare nightly dates strings.
+          return -`${valueA}`.localeCompare(`${valueB}`);
+        } else {
+          // beta > nightly for the same major version.
+          return tagA === 'beta' ? -1 : 1;
+        }
       }
 
       return semver.gt(a, b, true) ? -1 : 1;

--- a/tests/utils/sorted-electron-map-spec.ts
+++ b/tests/utils/sorted-electron-map-spec.ts
@@ -1,6 +1,6 @@
 import { sortedElectronMap } from '../../src/utils/sorted-electron-map';
 
-describe('sorted-eletron-map', () => {
+describe('sorted-electron-map', () => {
   it('sorts a record of electron versions', () => {
     const map: any = {
       '1.0.0': {
@@ -13,11 +13,58 @@ describe('sorted-eletron-map', () => {
         version: 'v2.0.0',
       },
     };
-    const result = sortedElectronMap(map, (_k, e) => e);
 
-    expect(result[0]).toEqual({ version: 'v3.0.0' });
-    expect(result[1]).toEqual({ version: 'v2.0.0' });
-    expect(result[2]).toEqual({ version: 'v1.0.0' });
+    const result = sortedElectronMap(map, (_k, e) => e);
+    expect(result).toStrictEqual([
+      { version: 'v3.0.0' },
+      { version: 'v2.0.0' },
+      { version: 'v1.0.0' },
+    ]);
+  });
+
+  it('sorts nightly and beta versions correctly', () => {
+    const map: any = {
+      '2.0.0-nightly.20200101': {
+        version: 'v2.0.0-nightly.20200101',
+      },
+      '2.0.0-nightly.20200102': {
+        version: 'v2.0.0-nightly.20200102',
+      },
+      '2.0.0': {
+        version: 'v2.0.0',
+      },
+      '3.0.0-nightly.20200105': {
+        version: 'v3.0.0-nightly.20200105',
+      },
+      '3.0.0': {
+        version: 'v3.0.0',
+      },
+      '3.0.0-beta.1': {
+        version: 'v3.0.0-beta.1',
+      },
+      '2.0.0-beta.1': {
+        version: 'v2.0.0-beta.1',
+      },
+      '2.0.0-beta.2': {
+        version: 'v2.0.0-beta.2',
+      },
+      '2.0.0-beta.3': {
+        version: 'v2.0.0-beta.3',
+      },
+    };
+
+    const result = sortedElectronMap(map, (_k, e) => e);
+    expect(result).toStrictEqual([
+      { version: 'v3.0.0' },
+      { version: 'v3.0.0-beta.1' },
+      { version: 'v3.0.0-nightly.20200105' },
+      { version: 'v2.0.0' },
+      { version: 'v2.0.0-beta.3' },
+      { version: 'v2.0.0-beta.2' },
+      { version: 'v2.0.0-beta.1' },
+      { version: 'v2.0.0-nightly.20200102' },
+      { version: 'v2.0.0-nightly.20200101' },
+    ]);
   });
 
   it('handles invalid versions', () => {
@@ -35,11 +82,13 @@ describe('sorted-eletron-map', () => {
         version: 'garbage',
       },
     };
-    const result = sortedElectronMap(map, (_k, e) => e);
 
-    expect(result[0]).toEqual({ version: 'garbage' });
-    expect(result[1]).toEqual({ version: 'moreGarbage' });
-    expect(result[2]).toEqual({ version: 'v3.0.0' });
-    expect(result[3]).toEqual({ version: 'v1.0.0' });
+    const result = sortedElectronMap(map, (_k, e) => e);
+    expect(result).toStrictEqual([
+      { version: 'garbage' },
+      { version: 'moreGarbage' },
+      { version: 'v3.0.0' },
+      { version: 'v1.0.0' },
+    ]);
   });
 });


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/482.

The issue opened by @nornagon exposed a greater issue, which was that we weren't previously sorting prerelease tags at all in our logic. This meant that for a given major version the stable tags would correctly show at the top, but they would be followed by nightly tags instead of beta tagged version, which is incorrect since beta are strictly newer than nightlies. 

Semver does not handle this on its own: https://www.npmjs.com/package/semver#prerelease-tags

As such this PR seeks to address that by adding extra logic to `sortedElectronMap` to ensure prerelease tags sort properly as well as a test to ensure that's the case. Also tested with @nornagon's repro.

<details>
<summary>Before</summary>
<img width="616" alt="Screen Shot 2020-09-17 at 11 10 03 PM" src="https://user-images.githubusercontent.com/2036040/93558603-09249300-f93b-11ea-8bda-c3920ce05d1d.png">
</details>

<details>
<summary>After</summary>
<img width="595" alt="Screen Shot 2020-09-17 at 11 11 53 PM" src="https://user-images.githubusercontent.com/2036040/93558683-33765080-f93b-11ea-8cd2-d190751b4643.png">
</details>

cc @HashimotoYT @felixrieseberg 