### PR TITLE
fix: gist action state management

### DIFF
--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Publish button component renders 1`] = `
 <Fragment>
-  <fieldset>
+  <fieldset
+    disabled={false}
+  >
     <Blueprint3.ButtonGroup
       className="button-gist-action"
     >
@@ -56,6 +58,7 @@ exports[`Publish button component renders 1`] = `
       </Blueprint3.Popover>
       <Blueprint3.Button
         icon="upload"
+        loading={false}
         onClick={[Function]}
         text="Publish"
       />


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/487.

Fixes an issue where if multiple gists are published on top of one another, the delete state is not properly updated. To clean this up a bit, i've also pulled out the various gist actions into their own functions. Also fixed several pre-existing issues with publishing state being persisted at the same time as updating state.

To test, I:
1. Published Fiddle 1 ✅ 
2. Edited and updated Fiddle 1 ✅
3. Published Fiddle 2 ✅ 
4. Deleted Fiddle 1 ✅ 
5. Updated Fiddle 2 ✅ 
6. Loaded and deleted Fiddle 2 ✅ 

Which i _believe_ should cover all state transitions.


cc @HashimotoYT 