### PR TITLE
feat: add unique icons for gist actions

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -245,18 +245,29 @@ export class GistActionButton extends React.Component<
       return text;
     };
 
+    const getActionIcon = () => {
+      switch (actionType) {
+        case GistActionType.publish:
+          return 'upload';
+        case GistActionType.update:
+          return 'refresh';
+        case GistActionType.delete:
+          return 'delete';
+      }
+    };
+
     return (
       <>
         <fieldset disabled={isPublishing}>
-          <ButtonGroup className="button-publish">
+          <ButtonGroup className="button-gist-action">
             {this.renderPrivacyMenu()}
             <Button
               onClick={this.handleClick}
               loading={isPublishing}
-              icon="upload"
+              icon={getActionIcon()}
               text={getTextForButton()}
             />
-            {this.renderMaybePublishMenu()}
+            {this.renderGistActionMenu()}
           </ButtonGroup>
         </fieldset>
         <Toaster
@@ -267,7 +278,7 @@ export class GistActionButton extends React.Component<
     );
   }
 
-  private renderMaybePublishMenu = () => {
+  private renderGistActionMenu = () => {
     const { gistId } = this.props.appState;
     const { actionType } = this.state;
 

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Publish button component renders 1`] = `
 <Fragment>
   <fieldset>
     <Blueprint3.ButtonGroup
-      className="button-publish"
+      className="button-gist-action"
     >
       <Blueprint3.Popover
         boundary="scrollParent"


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/486.

Adds unique icons for each of the publish, update, and delete actions. Will need rebase on https://github.com/electron/fiddle/pull/488 once it's merged.

<img width="102" alt="Screen Shot 2020-09-18 at 11 12 05 AM" src="https://user-images.githubusercontent.com/2036040/93625845-d496f280-f99f-11ea-87e6-1019ac4e3e5b.png">

<img width="97" alt="Screen Shot 2020-09-18 at 11 12 30 AM" src="https://user-images.githubusercontent.com/2036040/93625867-dbbe0080-f99f-11ea-9159-5a5ce5b80a75.png">

<img width="93" alt="Screen Shot 2020-09-18 at 11 12 43 AM" src="https://user-images.githubusercontent.com/2036040/93625889-e2e50e80-f99f-11ea-9dd3-75f7e778efaf.png">
