### PR TITLE
refactor: clean up gist action states

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,13 @@ export enum GistActionType {
   delete = 'Delete',
 }
 
+export enum GistActionState {
+  publishing = 'publishing',
+  updating = 'updating',
+  deleting = 'deleting',
+  none = 'none',
+}
+
 export interface Version {
   version: string;
   name?: string;

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -130,6 +130,9 @@ export class GistActionButton extends React.Component<
 
       console.log(`Publish Button: Publishing complete`, { gist });
       this.renderToast({ message: 'Publishing completed successfully!' });
+
+      // Only set action type to update if publish completed successfully.
+      this.setActionType(GistActionType.update);
     } catch (error) {
       console.warn(`Could not publish gist`, { error });
 
@@ -143,7 +146,6 @@ export class GistActionButton extends React.Component<
     }
 
     appState.activeGistAction = GistActionState.none;
-    this.setActionType(GistActionType.update);
   }
 
   /**

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 
 import { IpcEvents } from '../../ipc-events';
+import { GistActionState } from '../../interfaces';
 import { idFromUrl, urlFromId } from '../../utils/gist';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
@@ -121,14 +122,15 @@ export class AddressBar extends React.Component<
   }
 
   public render() {
-    const { isUnsaved, isPublishing } = this.props.appState;
+    const { isUnsaved, activeGistAction } = this.props.appState;
     const { value } = this.state;
     const isCorrect = /https:\/\/gist\.github\.com\/(.+)$/.test(value);
     const className = classnames('address-bar', isUnsaved, { empty: !value });
 
+    const isPerformingAction = activeGistAction !== GistActionState.none;
     return (
       <form className={className} onSubmit={this.handleSubmit}>
-        <fieldset disabled={isPublishing}>
+        <fieldset disabled={isPerformingAction}>
           <InputGroup
             key="addressbar"
             leftIcon="geosearch"

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -8,6 +8,7 @@ import {
   EditorId,
   GenericDialogOptions,
   GenericDialogType,
+  GistActionState,
   MosaicId,
   OutputEntry,
   OutputOptions,
@@ -151,7 +152,7 @@ export class AppState {
   @observable public localTypeWatcher: fsType.FSWatcher | undefined;
   @observable public Bisector: Bisector | undefined;
 
-  @observable public isPublishing = false;
+  @observable public activeGistAction: GistActionState = GistActionState.none;
   @observable public isRunning = false;
   @observable public isUnsaved: boolean;
   @observable public isUpdatingElectronVersions = false;

--- a/tests/renderer/components/__snapshots__/commands-address-bar-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-address-bar-spec.tsx.snap
@@ -5,7 +5,9 @@ exports[`AddressBar component renders 1`] = `
   className="address-bar empty"
   onSubmit={[Function]}
 >
-  <fieldset>
+  <fieldset
+    disabled={true}
+  >
     <Blueprint3.InputGroup
       key="addressbar"
       leftIcon="geosearch"

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Publish button component renders 1`] = `
 <Fragment>
   <fieldset
-    disabled={false}
+    disabled={true}
   >
     <Blueprint3.ButtonGroup
       className="button-gist-action"
@@ -58,7 +58,7 @@ exports[`Publish button component renders 1`] = `
       </Blueprint3.Popover>
       <Blueprint3.Button
         icon="upload"
-        loading={false}
+        loading={true}
         onClick={[Function]}
         text="Publish"
       />

--- a/tests/renderer/components/commands-address-bar-spec.tsx
+++ b/tests/renderer/components/commands-address-bar-spec.tsx
@@ -5,6 +5,7 @@ import { observable } from 'mobx';
 import { AddressBar } from '../../../src/renderer/components/commands-address-bar';
 import { ElectronFiddleMock } from '../../mocks/electron-fiddle';
 import { MockState } from '../../mocks/state';
+import { GistActionState } from '../../../src/interfaces';
 
 jest.mock('../../../src/utils/octokit');
 
@@ -68,12 +69,54 @@ describe('AddressBar component', () => {
   it('disables during gist publishing', async () => {
     const wrapper = shallow(<AddressBar appState={store} />);
 
-    wrapper.setProps({ appState: { ...store, isPublishing: true } }, () => {
-      expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
-    });
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.publishing } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+      },
+    );
 
-    wrapper.setProps({ appState: { ...store, isPublishing: false } }, () => {
-      expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-    });
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.none } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+      },
+    );
+  });
+
+  it('disables during gist updating', async () => {
+    const wrapper = shallow(<AddressBar appState={store} />);
+
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.updating } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+      },
+    );
+
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.none } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+      },
+    );
+  });
+
+  it('disables during gist deleting', async () => {
+    const wrapper = shallow(<AddressBar appState={store} />);
+
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.deleting } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+      },
+    );
+
+    wrapper.setProps(
+      { appState: { ...store, activeGistAction: GistActionState.none } },
+      () => {
+        expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+      },
+    );
   });
 });

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { GistActionType } from '../../../src/interfaces';
+import { GistActionState, GistActionType } from '../../../src/interfaces';
 
 import { GistActionButton } from '../../../src/renderer/components/commands-action-button';
 import { getOctokit } from '../../../src/utils/octokit';
@@ -182,7 +182,7 @@ describe('Publish button component', () => {
 
     await instance.performGistAction();
 
-    expect(store.isPublishing).toBe(false);
+    expect(store.activeGistAction).toBe(GistActionState.none);
   });
 
   it('uses the privacy setting correctly', async () => {
@@ -218,7 +218,7 @@ describe('Publish button component', () => {
   });
 
   it('disables during gist publishing', async () => {
-    store.isPublishing = false;
+    store.activeGistAction = GistActionState.none;
     const wrapper = shallow(<GistActionButton appState={store} />);
     const instance: GistActionButton = wrapper.instance() as any;
 
@@ -226,12 +226,74 @@ describe('Publish button component', () => {
 
     instance.performGistAction = jest.fn().mockImplementationOnce(() => {
       return new Promise((resolve) => {
-        wrapper.setProps({ appState: { store, isPublishing: true } }, () => {
-          expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
-        });
-        wrapper.setProps({ appState: { store, isPublishing: false } }, () => {
-          expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-        });
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.publishing } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+          },
+        );
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.none } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+          },
+        );
+        resolve();
+      });
+    });
+
+    await instance.performGistAction();
+  });
+
+  it('disables during gist updating', async () => {
+    store.activeGistAction = GistActionState.none;
+    const wrapper = shallow(<GistActionButton appState={store} />);
+    const instance: GistActionButton = wrapper.instance() as any;
+
+    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+
+    instance.performGistAction = jest.fn().mockImplementationOnce(() => {
+      return new Promise((resolve) => {
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.updating } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+          },
+        );
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.none } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+          },
+        );
+        resolve();
+      });
+    });
+
+    await instance.performGistAction();
+  });
+
+  it('disables during gist deleting', async () => {
+    store.activeGistAction = GistActionState.none;
+    const wrapper = shallow(<GistActionButton appState={store} />);
+    const instance: GistActionButton = wrapper.instance() as any;
+
+    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+
+    instance.performGistAction = jest.fn().mockImplementationOnce(() => {
+      return new Promise((resolve) => {
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.deleting } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
+          },
+        );
+        wrapper.setProps(
+          { appState: { store, activeGistAction: GistActionState.none } },
+          () => {
+            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
+          },
+        );
         resolve();
       });
     });


### PR DESCRIPTION
Fiddle can't perform more than one action at a given time, so it makes more sense to place all potential actions in one state variable.

We also had some state variables in the Mobx store and some not, and as we should disable the command bar during _any_ action it makes the most sense to place this overarching state variable in the Mobx store.

cc @felixrieseberg 