### PR TITLE
feat: allow setting gist description

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,7 +71,9 @@ export interface GenericDialogOptions {
   type: GenericDialogType;
   ok?: string;
   cancel?: string;
+  wantsInput?: boolean;
   label: string | JSX.Element;
+  placeholder?: string;
 }
 
 export interface Templates {

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -115,8 +115,9 @@ export class GistActionButton extends React.Component<
     appState.setGenericDialogOptions({
       type: GenericDialogType.confirm,
       label: 'Please provide a brief description for your Fiddle Gist',
-      cancel: 'Skip',
       wantsInput: true,
+      ok: 'Publish',
+      cancel: undefined,
       placeholder: 'Electron Fiddle Gist',
     });
 

--- a/src/renderer/components/dialog-generic.tsx
+++ b/src/renderer/components/dialog-generic.tsx
@@ -1,4 +1,4 @@
-import { Alert, IconName, Intent } from '@blueprintjs/core';
+import { Alert, IconName, InputGroup, Intent } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -25,6 +25,10 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
   }
 
   public onClose(result: boolean) {
+    const input = document.getElementById('input') as HTMLInputElement;
+
+    this.props.appState.genericDialogLastInput =
+      input && input.value !== '' ? input.value : null;
     this.props.appState.genericDialogLastResult = result;
     this.props.appState.toggleGenericDialog();
   }
@@ -34,8 +38,16 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
       isGenericDialogShowing,
       genericDialogOptions,
     } = this.props.appState;
-    const { type, ok, cancel, label } = genericDialogOptions;
+    const {
+      type,
+      ok,
+      cancel,
+      label,
+      wantsInput,
+      placeholder,
+    } = genericDialogOptions;
 
+    const shouldShowInput = wantsInput && placeholder;
     let intent: Intent;
     let icon: IconName;
     switch (type) {
@@ -56,6 +68,7 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
         icon = 'help';
         break;
     }
+
     return (
       <Alert
         isOpen={isGenericDialogShowing}
@@ -66,6 +79,7 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
         intent={intent}
       >
         <p>{label}</p>
+        {shouldShowInput && <InputGroup id="input" placeholder={placeholder} />}
       </Alert>
     );
   }

--- a/src/renderer/components/dialog-generic.tsx
+++ b/src/renderer/components/dialog-generic.tsx
@@ -47,7 +47,6 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
       placeholder,
     } = genericDialogOptions;
 
-    const shouldShowInput = wantsInput && placeholder;
     let intent: Intent;
     let icon: IconName;
     switch (type) {
@@ -69,6 +68,15 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
         break;
     }
 
+    let dialogInput;
+    if (wantsInput) {
+      dialogInput = placeholder ? (
+        <InputGroup id="input" placeholder={placeholder} />
+      ) : (
+        <InputGroup id="input" />
+      );
+    }
+
     return (
       <Alert
         isOpen={isGenericDialogShowing}
@@ -79,7 +87,7 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
         intent={intent}
       >
         <p>{label}</p>
-        {shouldShowInput && <InputGroup id="input" placeholder={placeholder} />}
+        {wantsInput && dialogInput}
       </Alert>
     );
   }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -137,13 +137,16 @@ export class AppState {
   > = arrayToStringMap(knownVersions);
   @observable public output: Array<OutputEntry> = [];
   @observable public localPath: string | undefined;
-  @observable public genericDialogOptions = {
+  @observable public genericDialogOptions: GenericDialogOptions = {
     type: GenericDialogType.warning,
     label: '' as string | JSX.Element,
     ok: 'Okay',
     cancel: 'Cancel',
+    wantsInput: false,
+    placeholder: '',
   };
   @observable public genericDialogLastResult: boolean | null = null;
+  @observable public genericDialogLastInput: string | null = null;
   @observable public mosaicArrangement: MosaicNode<
     MosaicId
   > | null = DEFAULT_MOSAIC_ARRANGEMENT;
@@ -430,6 +433,8 @@ export class AppState {
     this.genericDialogOptions = {
       ok: 'Okay',
       cancel: 'Cancel',
+      wantsInput: false,
+      placeholder: '',
       ...opts,
     };
   }

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -67,6 +67,9 @@ describe('Publish button component', () => {
     const wrapper = shallow(<GistActionButton appState={store} />);
     const instance: GistActionButton = wrapper.instance() as any;
 
+    instance.getFiddleDescriptionFromUser = jest
+      .fn()
+      .mockReturnValue('Electron Fiddle Gist');
     await instance.performGistAction();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
@@ -148,12 +151,48 @@ describe('Publish button component', () => {
     const wrapper = shallow(<GistActionButton appState={store} />);
     const instance: GistActionButton = wrapper.instance() as any;
 
+    instance.getFiddleDescriptionFromUser = jest
+      .fn()
+      .mockReturnValue('Electron Fiddle Gist');
     (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
 
     await instance.performGistAction();
 
     expect(mockOctokit.gists.create).toHaveBeenCalledWith({
       description: 'Electron Fiddle Gist',
+      files: {
+        'index.html': { content: '<!-- Empty -->' },
+        'renderer.js': { content: '// Empty' },
+        'main.js': { content: '// Empty' },
+        'preload.js': { content: '// Empty' },
+        'styles.css': { content: '/* Empty */' },
+      },
+      public: true,
+    });
+  });
+
+  it('handles a custom description', async () => {
+    const mockOctokit = {
+      authenticate: jest.fn(),
+      gists: {
+        create: jest.fn(async () => ({ data: { id: '123' } })),
+      },
+    };
+
+    (getOctokit as any).mockReturnValue(mockOctokit);
+
+    const wrapper = shallow(<GistActionButton appState={store} />);
+    const instance: GistActionButton = wrapper.instance() as any;
+
+    instance.getFiddleDescriptionFromUser = jest
+      .fn()
+      .mockReturnValue('My Custom Description');
+    (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
+
+    await instance.performGistAction();
+
+    expect(mockOctokit.gists.create).toHaveBeenCalledWith({
+      description: 'My Custom Description',
       files: {
         'index.html': { content: '<!-- Empty -->' },
         'renderer.js': { content: '// Empty' },
@@ -179,6 +218,9 @@ describe('Publish button component', () => {
 
     const wrapper = shallow(<GistActionButton appState={store} />);
     const instance: GistActionButton = wrapper.instance() as any;
+    instance.getFiddleDescriptionFromUser = jest
+      .fn()
+      .mockReturnValue('Electron Fiddle Gist');
 
     await instance.performGistAction();
 
@@ -199,6 +241,10 @@ describe('Publish button component', () => {
 
     const wrapper = shallow(<GistActionButton appState={store} />);
     const instance: GistActionButton = wrapper.instance() as any;
+
+    instance.getFiddleDescriptionFromUser = jest
+      .fn()
+      .mockReturnValue('Electron Fiddle Gist');
 
     instance.setPrivate();
     await instance.performGistAction();

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -446,7 +446,9 @@ describe('AppState', () => {
         type: GenericDialogType.warning,
         label: 'foo',
         ok: 'Okay',
+        placeholder: '',
         cancel: 'Cancel',
+        wantsInput: false,
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/477.

This introduces a means to set a custom description for each Gist that's published to GitHub. This is useful when creating many gists since they're hard to differentiate with the same name.

<img width="1312" alt="Screen Shot 2020-09-29 at 8 01 29 PM" src="https://user-images.githubusercontent.com/2036040/94638361-a1e9d580-028e-11eb-826a-d02fe4215684.png">
