### PR TITLE
feat: add ability to change electron download binary path

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -8,9 +8,12 @@ import {
   IButtonProps,
   Icon,
   IconName,
+  InputGroup,
   Tooltip,
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
+import { remote } from 'electron';
+import * as path from 'path';
 import * as React from 'react';
 
 import { RunnableVersion, VersionSource, VersionState } from '../../interfaces';
@@ -144,6 +147,8 @@ export class ElectronSettings extends React.Component<
           {this.renderVersionStateOptions()}
         </Callout>
         <br />
+        <Callout>{this.renderDownloadBinaryOptions()}</Callout>
+        <br />
         <Callout>
           {this.renderAdvancedButtons()}
           {this.renderTable()}
@@ -151,6 +156,43 @@ export class ElectronSettings extends React.Component<
       </div>
     );
   }
+
+  private renderDownloadBinaryOptions = () => {
+    const { downloadBinaryPath } = this.props.appState;
+
+    return (
+      <FormGroup>
+        <p>You can setup the download directory for Electron binary files.</p>
+        <InputGroup
+          readOnly={true}
+          value={downloadBinaryPath}
+          rightElement={
+            <Button
+              icon="folder-open"
+              onClick={this.handleDownloadBinaryChanging}
+            >
+              Select
+            </Button>
+          }
+        />
+      </FormGroup>
+    );
+  };
+
+  private handleDownloadBinaryChanging = async () => {
+    const { filePaths } = await remote.dialog.showOpenDialog({
+      title: 'Select Folder',
+      properties: ['openDirectory'],
+    });
+
+    if (!filePaths || filePaths.length < 1 || filePaths.length > 1) {
+      return;
+    }
+
+    this.props.appState.downloadBinaryPath = path.join(filePaths[0]);
+    this.props.appState.updateDownloadedVersionState();
+    this.props.appState.updateElectronVersions();
+  };
 
   /**
    * Renders the various buttons for advanced operations

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -49,7 +49,7 @@ export class Runner {
   public async run(): Promise<boolean> {
     const { fileManager, getEditorValues } = window.ElectronFiddle.app;
     const options = { includeDependencies: false, includeElectron: false };
-    const { currentElectronVersion } = this.appState;
+    const { currentElectronVersion, downloadBinaryPath } = this.appState;
     const { version, localPath } = currentElectronVersion;
 
     if (this.appState.isClearingConsoleOnRun) {
@@ -71,7 +71,11 @@ export class Runner {
       return false;
     }
 
-    const isReady = await getIsDownloaded(version, localPath);
+    const isReady = await getIsDownloaded(
+      downloadBinaryPath,
+      version,
+      localPath,
+    );
 
     if (!isReady) {
       console.warn(`Runner: Binary ${version} not ready`);
@@ -209,9 +213,17 @@ export class Runner {
    * @memberof Runner
    */
   public async execute(dir: string): Promise<void> {
-    const { currentElectronVersion, pushOutput } = this.appState;
+    const {
+      currentElectronVersion,
+      pushOutput,
+      downloadBinaryPath,
+    } = this.appState;
     const { version, localPath } = currentElectronVersion;
-    const binaryPath = getElectronBinaryPath(version, localPath);
+    const binaryPath = getElectronBinaryPath(
+      downloadBinaryPath,
+      version,
+      localPath,
+    );
     console.log(`Runner: Binary ${binaryPath} ready, launching`);
 
     const env = { ...process.env };

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -126,6 +126,25 @@ exports[`ElectronSettings component renders 1`] = `
   </Blueprint3.Callout>
   <br />
   <Blueprint3.Callout>
+    <Blueprint3.FormGroup>
+      <p>
+        You can setup the download directory for Electron binary files.
+      </p>
+      <Blueprint3.InputGroup
+        readOnly={true}
+        rightElement={
+          <Blueprint3.Button
+            icon="folder-open"
+            onClick={[Function]}
+          >
+            Select
+          </Blueprint3.Button>
+        }
+      />
+    </Blueprint3.FormGroup>
+  </Blueprint3.Callout>
+  <br />
+  <Blueprint3.Callout>
     <Blueprint3.ButtonGroup
       fill={true}
     >

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -340,7 +340,7 @@ describe('AppState', () => {
       appState.versions['2.0.2'].state = VersionState.ready;
       await appState.removeVersion('v2.0.2');
 
-      expect(removeBinary).toHaveBeenCalledWith('2.0.2');
+      expect(removeBinary).toHaveBeenCalledWith(expect.any(String), '2.0.2');
     });
 
     it('does not remove it if not necessary', async () => {


### PR DESCRIPTION
This PR adds the ability to change the download directory for launching binary files from the default directory to any.

### Screenshot of the settings menu

![image](https://user-images.githubusercontent.com/24681191/94953176-c395c780-04ef-11eb-9915-cdcb5eda4fb5.png)

Fixes #310