### PR TITLE
fix: theme select popover closing settings when pressing escape

### DIFF
--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -59,6 +59,7 @@ export const renderItem: ItemRenderer<LoadedFiddleTheme> = (
 
 export interface AppearanceSettingsProps {
   appState: AppState;
+  toggleHasPopoverOpen: () => void;
 }
 
 export interface AppearanceSettingsState {
@@ -185,14 +186,15 @@ export class AppearanceSettings extends React.Component<
             itemPredicate={filterItem}
             onItemSelect={this.handleChange}
             popoverProps={{
-              onClosed: () => this.toggleThemeSelectorOpened(),
+              onClosed: () => this.props.toggleHasPopoverOpen(),
             }}
             noResults={<MenuItem disabled={true} text="No results." />}
           >
             <Button
+              id="open-theme-selector"
               text={selectedName}
               icon="tint"
-              onClick={() => this.toggleThemeSelectorOpened()}
+              onClick={() => this.props.toggleHasPopoverOpen()}
             />
           </ThemeSelect>
         </FormGroup>
@@ -229,12 +231,5 @@ export class AppearanceSettings extends React.Component<
    */
   public handleAddTheme(): void {
     this.props.appState.toggleAddMonacoThemeDialog();
-  }
-
-  /**
-   * Toggles the state to update if the theme selector is visible
-   */
-  public toggleThemeSelectorOpened(): void {
-    this.props.appState.toggleThemeSelector();
   }
 }

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -232,7 +232,7 @@ export class AppearanceSettings extends React.Component<
   }
 
   /**
-   * Toggles checking if the theme selector popover is visible or not
+   * Toggles the state to update if the theme selector is visible
    */
   public toggleThemeSelectorOpened(): void {
     this.props.appState.toggleThemeSelector();

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -184,9 +184,16 @@ export class AppearanceSettings extends React.Component<
             itemRenderer={renderItem}
             itemPredicate={filterItem}
             onItemSelect={this.handleChange}
+            popoverProps={{
+              onClosed: () => this.toggleThemeSelectorOpened(),
+            }}
             noResults={<MenuItem disabled={true} text="No results." />}
           >
-            <Button text={selectedName} icon="tint" />
+            <Button
+              text={selectedName}
+              icon="tint"
+              onClick={() => this.toggleThemeSelectorOpened()}
+            />
           </ThemeSelect>
         </FormGroup>
         <Callout>
@@ -222,5 +229,12 @@ export class AppearanceSettings extends React.Component<
    */
   public handleAddTheme(): void {
     this.props.appState.toggleAddMonacoThemeDialog();
+  }
+
+  /**
+   * Toggles checking if the theme selector popover is visible or not
+   */
+  public toggleThemeSelectorOpened(): void {
+    this.props.appState.toggleThemeSelector();
   }
 }

--- a/src/renderer/components/settings-general.tsx
+++ b/src/renderer/components/settings-general.tsx
@@ -9,6 +9,7 @@ import { GitHubSettings } from './settings-general-github';
 
 export interface GeneralSettingsProps {
   appState: AppState;
+  toggleHasPopoverOpen: () => void;
 }
 
 /**
@@ -23,7 +24,10 @@ export class GeneralSettings extends React.Component<GeneralSettingsProps> {
     return (
       <div>
         <h2>General Settings</h2>
-        <AppearanceSettings appState={this.props.appState} />
+        <AppearanceSettings
+          appState={this.props.appState}
+          toggleHasPopoverOpen={() => this.props.toggleHasPopoverOpen()}
+        />
         <Divider />
         <ConsoleSettings appState={this.props.appState} />
         <Divider />

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -154,7 +154,7 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
    */
   private closeSettingsPanel(event: KeyboardEvent) {
     const { appState } = this.props;
-    if (event.code === 'Escape') {
+    if (event.code === 'Escape' && !appState.isThemeSelectorShowing) {
       appState.isSettingsShowing = false;
     }
   }

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -55,7 +55,7 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('keyup', this.closeSettingsPanel);
+    window.removeEventListener('keyup', this.closeSettingsPanel, true);
   }
 
   /**

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -28,6 +28,7 @@ export interface SettingsProps {
 
 export interface SettingsState {
   section: SettingsSections;
+  hasPopoverOpen: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
 
     this.state = {
       section: SettingsSections.General,
+      hasPopoverOpen: false,
     };
 
     this.closeSettingsPanel = this.closeSettingsPanel.bind(this);
@@ -67,7 +69,12 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
     const { appState } = this.props;
 
     if (section === SettingsSections.General) {
-      return <GeneralSettings appState={appState} />;
+      return (
+        <GeneralSettings
+          appState={appState}
+          toggleHasPopoverOpen={() => this.toggleHasPopoverOpen()}
+        />
+      );
     }
 
     if (section === SettingsSections.Electron) {
@@ -151,11 +158,22 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
 
   /**
    * Trigger closing of the settings panel upon Esc
+   * If hasPopoverOpen is set to true, settings will not close as only the popover should close
    */
   private closeSettingsPanel(event: KeyboardEvent) {
     const { appState } = this.props;
-    if (event.code === 'Escape' && !appState.isThemeSelectorShowing) {
+    if (event.code === 'Escape' && !this.state.hasPopoverOpen) {
       appState.isSettingsShowing = false;
     }
+  }
+
+  /**
+   * Toggles whether there is a popover open
+   */
+  public toggleHasPopoverOpen(): void {
+    this.setState({
+      ...this.state,
+      hasPopoverOpen: !this.state.hasPopoverOpen,
+    });
   }
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -167,6 +167,7 @@ export class AppState {
   @observable public isBisectDialogShowing = false;
   @observable public isAddVersionDialogShowing = false;
   @observable public isThemeDialogShowing = false;
+  @observable public isThemeSelectorShowing = false;
   @observable public isTourShowing = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
@@ -381,6 +382,10 @@ export class AppState {
 
   @action public toggleAddMonacoThemeDialog() {
     this.isThemeDialogShowing = !this.isThemeDialogShowing;
+  }
+
+  @action public toggleThemeSelector() {
+    this.isThemeSelectorShowing = !this.isThemeSelectorShowing;
   }
 
   @action public toggleAuthDialog() {
@@ -764,6 +769,7 @@ export class AppState {
     this.isConsoleShowing = false;
     this.isAddVersionDialogShowing = false;
     this.isThemeDialogShowing = false;
+    this.isThemeSelectorShowing = false;
 
     if (additionalOptions) {
       for (const key in additionalOptions) {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -167,7 +167,6 @@ export class AppState {
   @observable public isBisectDialogShowing = false;
   @observable public isAddVersionDialogShowing = false;
   @observable public isThemeDialogShowing = false;
-  @observable public isThemeSelectorShowing = false;
   @observable public isTourShowing = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
@@ -382,10 +381,6 @@ export class AppState {
 
   @action public toggleAddMonacoThemeDialog() {
     this.isThemeDialogShowing = !this.isThemeDialogShowing;
-  }
-
-  @action public toggleThemeSelector() {
-    this.isThemeSelectorShowing = !this.isThemeSelectorShowing;
   }
 
   @action public toggleAuthDialog() {
@@ -769,7 +764,6 @@ export class AppState {
     this.isConsoleShowing = false;
     this.isAddVersionDialogShowing = false;
     this.isThemeDialogShowing = false;
-    this.isThemeSelectorShowing = false;
 
     if (additionalOptions) {
       for (const key in additionalOptions) {

--- a/tests/renderer/components/__snapshots__/settings-general-appearance-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-appearance-spec.tsx.snap
@@ -51,6 +51,7 @@ exports[`AppearanceSettings component renders 1`] = `
     >
       <Blueprint3.Button
         icon="tint"
+        id="open-theme-selector"
         onClick={[Function]}
         text="Select a theme"
       />

--- a/tests/renderer/components/__snapshots__/settings-general-appearance-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-appearance-spec.tsx.snap
@@ -43,9 +43,15 @@ exports[`AppearanceSettings component renders 1`] = `
         />
       }
       onItemSelect={[Function]}
+      popoverProps={
+        Object {
+          "onClosed": [Function],
+        }
+      }
     >
       <Blueprint3.Button
         icon="tint"
+        onClick={[Function]}
         text="Select a theme"
       />
     </Blueprint3.Select>

--- a/tests/renderer/components/__snapshots__/settings-general-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`GeneralSettings component renders 1`] = `
   </h2>
   <settings-appearance
     appState={Object {}}
+    toggleHasPopoverOpen={[Function]}
   />
   <Blueprint3.Divider />
   <settings-console

--- a/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
@@ -304,6 +304,7 @@ exports[`Settings component renders the Electron page by default 1`] = `
           "isSettingsShowing": true,
         }
       }
+      toggleHasPopoverOpen={[Function]}
     />
   </div>
 </div>
@@ -462,6 +463,7 @@ exports[`Settings component renders the General page after a click 1`] = `
           "isSettingsShowing": true,
         }
       }
+      toggleHasPopoverOpen={[Function]}
     />
   </div>
 </div>

--- a/tests/renderer/components/settings-general-appearance-spec.tsx
+++ b/tests/renderer/components/settings-general-appearance-spec.tsx
@@ -17,6 +17,9 @@ const mockThemes = [
     file: 'defaultDark',
   },
 ];
+const doNothingFunc = () => {
+  // Do Nothing
+};
 
 jest.mock('fs-extra');
 jest.mock('../../../src/utils/import', () => ({
@@ -44,14 +47,24 @@ describe('AppearanceSettings component', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<AppearanceSettings appState={store} />);
+    const wrapper = shallow(
+      <AppearanceSettings
+        appState={store}
+        toggleHasPopoverOpen={doNothingFunc}
+      />,
+    );
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders the correct selected theme', (done) => {
     store.theme = 'defaultDark';
-    const wrapper = shallow(<AppearanceSettings appState={store} />);
+    const wrapper = shallow(
+      <AppearanceSettings
+        appState={store}
+        toggleHasPopoverOpen={doNothingFunc}
+      />,
+    );
 
     process.nextTick(() => {
       expect((wrapper.state() as any).selectedTheme.name).toBe('defaultDark');
@@ -60,16 +73,44 @@ describe('AppearanceSettings component', () => {
   });
 
   it('handles a theme change', () => {
-    const wrapper = shallow(<AppearanceSettings appState={store} />);
+    const wrapper = shallow(
+      <AppearanceSettings
+        appState={store}
+        toggleHasPopoverOpen={doNothingFunc}
+      />,
+    );
     const instance: AppearanceSettings = wrapper.instance() as any;
     instance.handleChange({ file: 'defaultLight' } as any);
 
     expect(store.setTheme).toHaveBeenCalledWith('defaultLight');
   });
 
+  it('toggles popover toggle event', () => {
+    const toggleFunc = jest.fn();
+    const wrapper = shallow(
+      <AppearanceSettings appState={store} toggleHasPopoverOpen={toggleFunc} />,
+    );
+
+    // Find the button
+    const button = wrapper.find('#open-theme-selector');
+
+    // Simulate opening the theme selector
+    button.simulate('click');
+    expect(toggleFunc).toHaveBeenCalledTimes(1);
+
+    // Simulate closing the theme selector
+    button.simulate('click');
+    expect(toggleFunc).toHaveBeenCalledTimes(2);
+  });
+
   describe('openThemeFolder()', () => {
     it('attempts to open the folder', async () => {
-      const wrapper = shallow(<AppearanceSettings appState={store} />);
+      const wrapper = shallow(
+        <AppearanceSettings
+          appState={store}
+          toggleHasPopoverOpen={doNothingFunc}
+        />,
+      );
       const instance: AppearanceSettings = wrapper.instance() as any;
       await instance.openThemeFolder();
 
@@ -77,7 +118,12 @@ describe('AppearanceSettings component', () => {
     });
 
     it('handles an error', async () => {
-      const wrapper = shallow(<AppearanceSettings appState={store} />);
+      const wrapper = shallow(
+        <AppearanceSettings
+          appState={store}
+          toggleHasPopoverOpen={doNothingFunc}
+        />,
+      );
       const instance: AppearanceSettings = wrapper.instance() as any;
       (shell as any).showItemInFolder.mockImplementationOnce(() => {
         throw new Error('Bwap');
@@ -90,7 +136,12 @@ describe('AppearanceSettings component', () => {
   describe('createNewThemeFromCurrent()', () => {
     it('creates a new file from the current theme', async () => {
       const fs = require('fs-extra');
-      const wrapper = shallow(<AppearanceSettings appState={store} />);
+      const wrapper = shallow(
+        <AppearanceSettings
+          appState={store}
+          toggleHasPopoverOpen={doNothingFunc}
+        />,
+      );
       const instance: AppearanceSettings = wrapper.instance() as any;
       await instance.createNewThemeFromCurrent();
 
@@ -114,7 +165,12 @@ describe('AppearanceSettings component', () => {
           arr.push(theme);
         },
       );
-      const wrapper = shallow(<AppearanceSettings appState={store} />);
+      const wrapper = shallow(
+        <AppearanceSettings
+          appState={store}
+          toggleHasPopoverOpen={doNothingFunc}
+        />,
+      );
       expect(wrapper.state('themes')).toHaveLength(0);
       const instance: AppearanceSettings = wrapper.instance() as any;
       await instance.createNewThemeFromCurrent();
@@ -122,7 +178,12 @@ describe('AppearanceSettings component', () => {
     });
 
     it('handles an error', async () => {
-      const wrapper = shallow(<AppearanceSettings appState={store} />);
+      const wrapper = shallow(
+        <AppearanceSettings
+          appState={store}
+          toggleHasPopoverOpen={doNothingFunc}
+        />,
+      );
       const instance: AppearanceSettings = wrapper.instance() as any;
       (shell as any).showItemInFolder.mockImplementationOnce(() => {
         throw new Error('Bwap');

--- a/tests/renderer/components/settings-general-spec.tsx
+++ b/tests/renderer/components/settings-general-spec.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 
 import { GeneralSettings } from '../../../src/renderer/components/settings-general';
 
+const doNothingFunc = () => {
+  // Do Nothing
+};
+
 jest.mock('../../../src/renderer/components/settings-general-github', () => ({
   GitHubSettings: 'settings-github',
 }));
@@ -22,7 +26,9 @@ describe('GeneralSettings component', () => {
   const store: any = {};
 
   it('renders', () => {
-    const wrapper = shallow(<GeneralSettings appState={store} />);
+    const wrapper = shallow(
+      <GeneralSettings appState={store} toggleHasPopoverOpen={doNothingFunc} />,
+    );
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/renderer/components/settings-spec.tsx
+++ b/tests/renderer/components/settings-spec.tsx
@@ -110,16 +110,19 @@ describe('Settings component', () => {
     });
 
     // Set the theme selector showing to true
-    store.isThemeSelectorShowing = true;
     const wrapper = shallow(<Settings appState={store} />);
+    const instance = wrapper.instance() as Settings;
+
+    // Toggle the state of the variable
+    instance.toggleHasPopoverOpen();
 
     // trigger mock 'keyup' event
     map.keyup({ code: 'Escape' });
     expect(Object.keys(map)).toHaveLength(1);
     expect(store.isSettingsShowing).toBe(true);
 
-    // Set the theme selector showing to false
-    store.isThemeSelectorShowing = false;
+    // Toggle the setting again as if it was closed
+    instance.toggleHasPopoverOpen();
 
     // trigger mock 'keyup' event
     map.keyup({ code: 'Escape' });

--- a/tests/renderer/components/settings-spec.tsx
+++ b/tests/renderer/components/settings-spec.tsx
@@ -96,4 +96,38 @@ describe('Settings component', () => {
     wrapper.unmount();
     expect(Object.keys(map)).toHaveLength(0);
   });
+
+  it('does not close when Escape key is pressed when theme selector is open', () => {
+    expect(store.isSettingsShowing).toBe(true);
+    // mock event listener API
+    const map: any = {};
+    window.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    window.removeEventListener = jest.fn().mockImplementation((event) => {
+      delete map[event];
+    });
+
+    // Set the theme selector showing to true
+    store.isThemeSelectorShowing = true;
+    const wrapper = shallow(<Settings appState={store} />);
+
+    // trigger mock 'keyup' event
+    map.keyup({ code: 'Escape' });
+    expect(Object.keys(map)).toHaveLength(1);
+    expect(store.isSettingsShowing).toBe(true);
+
+    // Set the theme selector showing to false
+    store.isThemeSelectorShowing = false;
+
+    // trigger mock 'keyup' event
+    map.keyup({ code: 'Escape' });
+    expect(Object.keys(map)).toHaveLength(1);
+    expect(store.isSettingsShowing).toBe(false);
+
+    // check if event listener is removed upon unmount
+    wrapper.unmount();
+    expect(Object.keys(map)).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/322

I added a state listener for when someone opens the theme selector. I could not figure out a way to stop the events from propagating and closing the settings besides this solution. It might be better to make this more generic of `prevenSettingsClose` or something, but I am not sure.

![ezgif com-optimize](https://user-images.githubusercontent.com/36998210/95143258-d3511e00-0732-11eb-9878-7d4c401182cb.gif)

I saw that this is a good first issue to test my OSS contributions on, I am mainly an Angular developer and have only dabbled a little in React so if there is a better way to make these changes, please let me know.