### PR TITLE
build: switch to use Electron Forge publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,12 @@ jobs:
           encodedString: ${{ secrets.WINDOWS_CODESIGN_P12 }}
       - name: Install
         run: yarn
+      - name: Make (ia32)
+        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
+        run: yarn make -- --arch=ia32
+        env:
+          WINDOWS_CODESIGN_FILE: ${{ steps.write_file.outputs.filePath }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
       - name: Make
         if: startsWith(github.ref, 'refs/tags/')
         run: yarn make
@@ -85,29 +91,13 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           WINDOWS_CODESIGN_FILE: ${{ steps.write_file.outputs.filePath }}
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
-      - name: Make (ia32)
-        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/')
-        run: yarn make -- --arch=ia32
-        env:
-          WINDOWS_CODESIGN_FILE: ${{ steps.write_file.outputs.filePath }}
-          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
       # - name: Archive production artifacts
       #   uses: actions/upload-artifact@v2
       #   with:
       #     name: ${{ matrix.os }}
       #     path: out/make/**/*
       - name: Release
-        uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: true
-          files: |
-            out/**/*.deb
-            out/**/*.dmg
-            out/**/*setup*.exe
-            out/**/*.nupkg
-            out/**/*.rpm
-            out/**/*.zip
-            out/**/RELEASES


### PR DESCRIPTION
This PR switches to using just Electron Forge to publish command instead of action. Also moved to build ia32 to before the building x64, this should help by publishing the right `nupkg` files for updating x64.