### PR TITLE
fix: show privacy menu when in publish state

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -376,8 +376,9 @@ export class GistActionButton extends React.Component<
 
   private renderPrivacyMenu = () => {
     const { gitHubPublishAsPublic, gistId } = this.props.appState;
+    const { actionType } = this.state;
 
-    if (gistId) {
+    if (gistId && actionType !== GistActionType.publish) {
       return null;
     }
 


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/501.

Ensures the privacy menu is always visible if we are in a publish state.

cc @erickzhao @vhashimotoo 