### PR TITLE
refactor: deserialize mobx when updating version list

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -1,5 +1,5 @@
 import * as fsType from 'fs-extra';
-import { action, autorun, computed, observable, when } from 'mobx';
+import { action, autorun, computed, observable, toJS, when } from 'mobx';
 import { MosaicNode } from 'react-mosaic-component';
 
 import {
@@ -583,22 +583,23 @@ export class AppState {
    * @returns {Promise<void>}
    */
   @action public async updateDownloadedVersionState(): Promise<void> {
-    const updatedVersions = { ...this.versions };
+    const updatedVersions = toJS(this.versions);
 
     // Keep state of currently downloading binaries first
     const downloadingVersions = getDownloadingVersions(this);
-    (downloadingVersions || []).forEach((version) => {
+    for (const version of downloadingVersions) {
       if (updatedVersions[version]) {
         updatedVersions[version].state = VersionState.downloading;
       }
-    });
+    }
 
     const downloadedVersions = await getDownloadedVersions();
-    (downloadedVersions || []).forEach((version) => {
+
+    for (const version of downloadedVersions) {
       if (updatedVersions[version]) {
         updatedVersions[version].state = VersionState.ready;
       }
-    });
+    }
 
     console.log(`State: Updated version state`, updatedVersions);
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -166,7 +166,7 @@ describe('AppState', () => {
         },
       );
 
-      await appState.updateDownloadedVersionState();
+      await appState.updateElectronVersions();
     });
   });
 
@@ -475,19 +475,23 @@ describe('AppState', () => {
   });
 
   describe('updateDownloadedVersionState()', () => {
+    beforeEach(() => {
+      (getDownloadingVersions as jest.Mock).mockReturnValue(['2.0.1']);
+      (getDownloadedVersions as jest.Mock).mockReturnValue(
+        Promise.resolve(['2.0.2']),
+      );
+    });
+
     it('downloads a version if necessary', async () => {
-      const mockResult = Promise.resolve(['2.0.2']);
-      (getDownloadedVersions as jest.Mock).mockReturnValueOnce(mockResult);
       await appState.updateDownloadedVersionState();
 
       expect(appState.versions['2.0.2'].state).toBe(VersionState.ready);
     });
 
     it('keeps downloading state intact', async () => {
-      (getDownloadingVersions as jest.Mock).mockReturnValueOnce(['2.0.2']);
       await appState.updateDownloadedVersionState();
 
-      expect(appState.versions['2.0.2'].state).toBe(VersionState.downloading);
+      expect(appState.versions['2.0.1'].state).toBe(VersionState.downloading);
     });
   });
 


### PR DESCRIPTION
### Description

Instead of shallow copying the `this.versions` object, we use the mobx `toJS` API to recursively deserialize the Observable objects inside `this.versions`.

Prior to this change, each version object  inside `this.versions` would remain a mobx observable, leading to a significant slowdown in operations when changing the version object state (this slowdown is linear with the amount of downloaded versions you have).

Since `updateDownloadedVersionState()` is run on app load and blocks the editors from loading, this change gives a significant decrease of the first meaningful paint time if you have many versions of Electron downloaded.

With ~40 versions downloaded (all of the 11 and 10 betas), I saw a decrease from 200ms to 30ms in the time spent on `updateDownloadedVersionState()`.

### Ancillary changes

* Refactored the function to use `for...of` rather than `forEach`
* Updated specs
* Fixed `appState.updateElectronVersions()` test to actually call that function rather than `appState.updateDownloadedVersionState()`.