### PR TITLE
fix: re-work output dom to remove whitespace when copying

### DIFF
--- a/src/less/components/output.less
+++ b/src/less/components/output.less
@@ -1,4 +1,4 @@
-@import "../variables.less";
+@import '../variables.less';
 
 .output {
   font-size: 12px;
@@ -16,10 +16,7 @@
   overflow-y: scroll;
   -webkit-app-region: no-drag;
 
-  p {
-    margin-bottom: 0;
+  .output-message {
     white-space: pre;
-    padding-left: 5.6em;
-    text-indent: -5.6em;
   }
 }

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -88,10 +88,12 @@ export class Output extends React.Component<CommandsProps> {
       : {};
 
     return lines.map((text, lineIndex) => (
-      <p style={style} key={`${entry.timestamp}--${index}--${lineIndex}`}>
-        {timestamp}
-        {text}
-      </p>
+      <div key={`${entry.timestamp}--${index}--${lineIndex}`}>
+        <span style={style} className="output-message">
+          {timestamp}
+          {text}
+        </span>
+      </div>
     ));
   }
 

--- a/tests/renderer/components/__snapshots__/output-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/output-spec.tsx.snap
@@ -4,31 +4,39 @@ exports[`Output component renders with output 1`] = `
 <div
   className="output"
 >
-  <p
+  <div
     key="1532704073130--0--0"
-    style={Object {}}
   >
     <span
-      className="timestamp"
+      className="output-message"
+      style={Object {}}
     >
-      1532704073130
+      <span
+        className="timestamp"
+      >
+        1532704073130
+      </span>
+      Hi!
     </span>
-    Hi!
-  </p>
-  <p
+  </div>
+  <div
     key="1532704073130--1--0"
-    style={
-      Object {
-        "whiteSpace": "initial",
-      }
-    }
   >
     <span
-      className="timestamp"
+      className="output-message"
+      style={
+        Object {
+          "whiteSpace": "initial",
+        }
+      }
     >
-      1532704073130
+      <span
+        className="timestamp"
+      >
+        1532704073130
+      </span>
+      Hi!
     </span>
-    Hi!
-  </p>
+  </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #480 

This PR moves the console from `<p>` elements per row, to `<span>`s wrapped in `<div>` to avoid additional newlines when copy pasting. I modeled this very loosely around the structure used by the chrome inspector console.

![copy-paste](https://user-images.githubusercontent.com/44379112/98295986-e3e5f580-1f77-11eb-958a-c37e3726bf20.gif)
