### PR TITLE
fix: re-order keys in replaceFiddle, fixing mosaic order

### DIFF
--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -96,9 +96,9 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
 
       await window.ElectronFiddle.app.replaceFiddle(
         {
-          html: await getContent(EditorId.html, version),
-          renderer: await getContent(EditorId.renderer, version),
           main: await getContent(EditorId.main, version),
+          renderer: await getContent(EditorId.renderer, version),
+          html: await getContent(EditorId.html, version),
         },
         {},
       );


### PR DESCRIPTION
Fixes #521 

This PR adjusts the order of the keys passed to `replaceFiddle`. Internally replace fiddle is using the order of `Object.keys()` to determine the mosaic (which for non-numeric keys will be insertion order). I'd be happy making this a bit more robust via specified `order` param or an object that includes mosiac position. This does fix the issue though.

![mosaic-order](https://user-images.githubusercontent.com/44379112/98576573-59a3d700-2280-11eb-8f87-bb3a4a4d1dcf.gif)
