### PR TITLE
fix: installing modules with npm/yarn

### DIFF
--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -54,17 +54,19 @@ export async function getIsPackageManagerInstalled(
   try {
     await exec(process.cwd(), command);
     if (packageManager === 'npm') {
-      return (isNpmInstalled = true);
+      isNpmInstalled = true;
     } else {
-      return (isYarnInstalled = true);
+      isYarnInstalled = true;
     }
+    return true;
   } catch (error) {
     console.warn(`getIsPackageManagerInstalled: "${command}" failed.`, error);
     if (packageManager === 'npm') {
-      return (isNpmInstalled = false);
+      isNpmInstalled = false;
     } else {
-      return (isYarnInstalled = false);
+      isYarnInstalled = false;
     }
+    return false;
   }
 }
 

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -174,7 +174,7 @@ export class Runner {
     values: EditorValues,
     pmOptions: PMOperationOptions,
   ): Promise<void> {
-    const modules = findModulesInEditors(values);
+    const modules = await findModulesInEditors(values);
     const { pushOutput } = this.appState;
 
     if (modules && modules.length > 0) {


### PR DESCRIPTION
Refs https://github.com/electron/fiddle/commit/0bc8389c6c5ce43ca6eb58feaec77de7247d50af.

Fixes an issue where Node.js modules would never install and the UI would freeze because `getIsPackageManagerInstalled` would never resolve.

cc @felixrieseberg @erickzhao 