### PR TITLE
fix: spin while installing modules

### DIFF
--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -19,7 +19,7 @@ export interface RunnerProps {
 @observer
 export class Runner extends React.Component<RunnerProps> {
   public render() {
-    const { isRunning, currentElectronVersion } = this.props.appState;
+    const { isRunning, isInstallingModules, currentElectronVersion } = this.props.appState;
 
     const state = currentElectronVersion && currentElectronVersion.state;
     const props: IButtonProps = { className: 'button-run', disabled: true };
@@ -40,6 +40,9 @@ export class Runner extends React.Component<RunnerProps> {
         props.text = 'Stop';
         props.onClick = window.ElectronFiddle.app.runner.stop;
         props.icon = 'stop';
+      } else if (isInstallingModules) {
+        props.text = 'Installing modules';
+        props.icon = <Spinner size={16} />;
       } else {
         props.text = 'Run';
         props.onClick = window.ElectronFiddle.app.runner.run;

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -178,6 +178,7 @@ export class Runner {
     const { pushOutput } = this.appState;
 
     if (modules && modules.length > 0) {
+      this.appState.isInstallingModules = true;
       const packageManager = pmOptions.packageManager;
       const pmInstalled = await getIsPackageManagerInstalled(packageManager);
       if (!pmInstalled) {
@@ -190,6 +191,7 @@ export class Runner {
         message += `and npm, or https://classic.yarnpkg.com/lang/en/ to install Yarn`;
 
         pushOutput(message, { isNotPre: true });
+        this.appState.isInstallingModules = false;
         return;
       }
 
@@ -200,6 +202,7 @@ export class Runner {
         { isNotPre: true },
       );
       pushOutput(await installModules(pmOptions, ...modules));
+      this.appState.isInstallingModules = false;
     }
   }
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -159,6 +159,7 @@ export class AppState {
 
   @observable public activeGistAction: GistActionState = GistActionState.none;
   @observable public isRunning = false;
+  @observable public isInstallingModules = false;
   @observable public isUnsaved: boolean;
   @observable public isUpdatingElectronVersions = false;
   @observable public isQuitting = false;


### PR DESCRIPTION
Depends on https://github.com/electron/fiddle/pull/526 - should be rebased/merged only after that PR is merged.

Adds a spinner animation for Node.js module installs so it doesn't just freeze on run and give the user no UI indication of what's happening beyond console output.

cc @erickzhao @felixrieseberg 