### PR TITLE
fix: repopulate URL bar on blur

### DIFF
--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -31,6 +31,7 @@ export class AddressBar extends React.Component<
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
     this.submit = this.submit.bind(this);
 
     const { gistId } = this.props.appState;
@@ -110,6 +111,15 @@ export class AddressBar extends React.Component<
     this.setState({ value: event.target.value });
   }
 
+  public handleBlur(_event: React.FocusEvent<HTMLInputElement>) {
+    const { gistId } = this.props.appState;
+    const url = urlFromId(gistId);
+
+    if (url) {
+      this.setState({ value: url });
+    }
+  }
+
   public renderLoadButton(isValueCorrect: boolean): JSX.Element {
     return (
       <Button
@@ -136,6 +146,7 @@ export class AddressBar extends React.Component<
             leftIcon="geosearch"
             intent={isCorrect || !value ? undefined : Intent.DANGER}
             onChange={this.handleChange}
+            onBlur={this.handleBlur}
             placeholder="https://gist.github.com/..."
             value={value}
             rightElement={this.renderLoadButton(isCorrect)}

--- a/tests/renderer/components/__snapshots__/commands-address-bar-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-address-bar-spec.tsx.snap
@@ -11,6 +11,7 @@ exports[`AddressBar component renders 1`] = `
     <Blueprint3.InputGroup
       key="addressbar"
       leftIcon="geosearch"
+      onBlur={[Function]}
       onChange={[Function]}
       placeholder="https://gist.github.com/..."
       rightElement={


### PR DESCRIPTION
Once the user manipulates the <code>address bar</code> value and publishes the fiddle again , the gist url is no longer available .

<strong>Fix</strong> :

Added a <code>onBlur</code> event to <code>address bar</code> , which loads back the original gist url if the user looses focus out of the bar .

Fixes #427

Would love an review @erickzhao :)