### PR TITLE
fix: improve Mosaic behaviour on Fiddle load

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -71,11 +71,28 @@ export class App {
 
     // display all editors that have content
     const visibleEditors = [];
-    for (const id of Object.keys(editorValues)) {
+
+    // ensure consistent sorting of mosaics
+    const sortedEditors = Object.keys(editorValues).sort((a, b) => {
+      const order: Array<string> = [
+        'main',
+        'renderer',
+        'html',
+        'preload',
+        'css',
+      ];
+
+      return order.indexOf(a) - order.indexOf(b);
+    });
+
+    for (const id of sortedEditors) {
       const content = editorValues[id];
 
-      // if the gist content matches the empty file output, don't show it
-      if (!Object.values(EMPTY_EDITOR_CONTENT).includes(content)) {
+      // if the gist content is empty or matches the empty file output, don't show it
+      if (
+        content.length > 0 &&
+        !Object.values(EMPTY_EDITOR_CONTENT).includes(content)
+      ) {
         visibleEditors.push(id as EditorId);
       }
     }


### PR DESCRIPTION
Couple changes here. To see examples of expected behaviour, see added tests for `replaceFiddle()`.

### Don't show empty mosaics

Previously, we would only avoid showing mosaics that had "empty" values according to what we published to Gist:

https://github.com/electron/fiddle/blob/445e17361ce3dcf4a3334bb9948f383bbcf3b711/src/renderer/constants.ts#L35-L39

This was problematic for Show Me demos and local Fiddles, which would have actual empty strings instead. This is fixed with an additional guard against the length of the content string.

### Enforced mosaic arrangements

Following the work done in #525, I decided to nip this problem at the bud and load our mosaic in some exact order. The `replaceFiddle()` function now sorts the `Object.keys` result of the editorValues being passed in the exact order of Main, Renderer, HTML, Preload, CSS.

### Test cleanup

Added some `replaceFiddle` specs. Noticed that there was a lot of boilerplate setup in each test. Moved that code to a `beforeEach()` block.

cc @issacgerges 