### PR TITLE
fix: cleaner unsaved dialog logic

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -45,16 +45,7 @@ export async function onReady() {
  */
 export function onBeforeQuit() {
   ipcMainManager.send(IpcEvents.BEFORE_QUIT);
-  ipcMainManager.on(IpcEvents.CONFIRM_QUIT, quitAppIfConfirmed);
-}
-
-export function quitAppIfConfirmed(
-  _: Electron.IpcMainEvent,
-  quitConfirmed: boolean,
-) {
-  if (quitConfirmed) {
-    app.quit();
-  }
+  ipcMainManager.on(IpcEvents.CONFIRM_QUIT, app.quit);
 }
 
 export function setupMenuHandler() {

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -176,6 +176,7 @@ export class GistActionButton extends React.Component<
 
     if (description) {
       await this.publishGist(description);
+      appState.isUnsaved = false;
     }
 
     appState.genericDialogLastInput = null;
@@ -199,6 +200,7 @@ export class GistActionButton extends React.Component<
         files: this.gistFilesList(values) as any,
       });
 
+      appState.isUnsaved = false;
       console.log('Updating: Updating done', { gist });
       this.renderToast({ message: 'Successfully updated gist!' });
     } catch (error) {
@@ -231,6 +233,7 @@ export class GistActionButton extends React.Component<
         gist_id: appState.gistId!,
       });
 
+      appState.isUnsaved = true;
       console.log('Deleting: Deleting done', { gist });
       this.renderToast({ message: 'Successfully deleted gist!' });
     } catch (error) {

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -11,7 +11,6 @@ import {
   onBeforeQuit,
   onReady,
   onWindowsAllClosed,
-  quitAppIfConfirmed,
   setupMenuHandler,
 } from '../../src/main/main';
 import { shouldQuit } from '../../src/main/squirrel';
@@ -78,20 +77,8 @@ describe('main', () => {
       expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.BEFORE_QUIT);
       expect(ipcMainManager.on).toHaveBeenCalledWith(
         IpcEvents.CONFIRM_QUIT,
-        quitAppIfConfirmed,
+        app.quit,
       );
-    });
-  });
-
-  describe('quitAppIfConfirmed()', () => {
-    it('quits app if passed a truthy value', () => {
-      quitAppIfConfirmed({} as any, true);
-      expect(app.quit).toHaveBeenCalledTimes(1);
-    });
-
-    it('does nothing if passed a value', () => {
-      quitAppIfConfirmed({} as any, false);
-      expect(app.quit).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -115,7 +115,6 @@ describe('AppState', () => {
         expect(window.close).toHaveBeenCalledTimes(1);
         expect(ipcRendererManager.send).toHaveBeenCalledWith(
           IpcEvents.CONFIRM_QUIT,
-          true,
         );
         done();
       });
@@ -135,9 +134,8 @@ describe('AppState', () => {
       appState.isQuitting = true;
       process.nextTick(() => {
         expect(window.close).toHaveBeenCalledTimes(0);
-        expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        expect(ipcRendererManager.send).not.toHaveBeenCalledWith(
           IpcEvents.CONFIRM_QUIT,
-          false,
         );
         done();
       });


### PR DESCRIPTION
This fixes two problems that I've noticed with the unsaved warning handler.

### Not always exiting the app

Commit 595af93 cleans up the logic for differentiating between quitting and closing Fiddle windows. Nests the "quit app" logic within the "close window" logic, reason being that there's no way to quit the app without already closing the window.

Incidentally, this fixes a bug where attempting to quit with an unsaved Fiddle, cancelling the quit, and quitting a second time led to the window closing but not the app (on macOS). I'm guessing this had to do with a problem between `window.close()` happening before we could tell the Main process to quit.

### Gist actions not counting towards Unsaved state

Commit 7e1edcd changes the app's `isUnsaved` state when publishing, updating, or deleting a Gist.

Publishing and updating now makes the state "saved".
Deleting makes the state "unsaved".

cc @codebytere 