### PR TITLE
test: fix unhandled promise errors in state spec

### DIFF
--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -74,6 +74,7 @@ describe('AppState', () => {
 
   beforeEach(() => {
     appState = new AppState();
+    appState.updateDownloadedVersionState = jest.fn();
     ipcRendererManager.removeAllListeners();
   });
 
@@ -475,6 +476,8 @@ describe('AppState', () => {
 
   describe('updateDownloadedVersionState()', () => {
     beforeEach(() => {
+      appState = new AppState();
+      ipcRendererManager.removeAllListeners();
       (getDownloadingVersions as jest.Mock).mockReturnValue(['2.0.1']);
       (getDownloadedVersions as jest.Mock).mockReturnValue(
         Promise.resolve(['2.0.2']),


### PR DESCRIPTION
Seems like we were getting many `(node:2702) UnhandledPromiseRejectionWarning: TypeError: downloadingVersions is not iterable` errors when running `yarn test`, but these weren't picked up by Jest as test failures. I believe this snuck in PR #520.

See example: https://github.com/electron/fiddle/runs/1427245746?check_suite_focus=true

The root cause of this problem was that the Binary Manager's `getDownloadingVersions` and `getDownloadedVersions` were being used across the `state-spec.ts` file's `updateDownloadedVersionState` but weren't being mocked with each test.

For some reason, just added `mockReturnValue` in the initial mock doesn't work. Instead, I mock `updateDownloadedVersionState`and unmock it for the `updateDownloadedVersionState` tests.