### PR TITLE
chore: clear action button listeners on constructor

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -65,6 +65,8 @@ export class GistActionButton extends React.Component<
       isDeleting: false,
       actionType: GistActionType.publish,
     };
+
+    ipcRendererManager.removeAllListeners(IpcEvents.FS_SAVE_FIDDLE_GIST);
   }
 
   private toaster: Toaster;


### PR DESCRIPTION
Similar to https://github.com/electron/fiddle/pull/329

Avoids `(node:12337) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 FS_SAVE_FIDDLE_GIST listeners added to [IpcRendererManager]. Use emitter.setMaxListeners() to increase limit` on tests.