### PR TITLE
refactor: make save dialog synchronous

### DIFF
--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -43,13 +43,13 @@ export async function showOpenDialog() {
  */
 export async function showSaveDialog(event?: IpcEvents, as?: string) {
   // We want to save to a folder, so we'll use an open dialog here
-  const { filePaths } = await dialog.showOpenDialog({
+  const filePaths = dialog.showOpenDialogSync({
     buttonLabel: 'Save here',
     properties: ['openDirectory', 'createDirectory'],
     title: `Save Fiddle${as ? ` as ${as}` : ''}`,
   });
 
-  if (!filePaths || filePaths.length < 1) {
+  if (!Array.isArray(filePaths) || filePaths.length === 0) {
     return;
   }
 

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -27,10 +27,10 @@ const mockTarget = {
 
 describe('files', () => {
   beforeEach(() => {
-    (dialog.showOpenDialog as jest.Mock<any>).mockResolvedValue({
+    (dialog.showOpenDialog as jest.Mock).mockResolvedValue({
       filePaths: ['my/fake/path'],
     });
-    (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
+    (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
 
     ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
   });
@@ -52,7 +52,7 @@ describe('files', () => {
     it('tries to open an "open" dialog', async () => {
       await showOpenDialog();
 
-      const call = (dialog.showOpenDialog as jest.Mock<any>).mock.calls[0];
+      const call = (dialog.showOpenDialog as jest.Mock).mock.calls[0];
 
       expect(dialog.showOpenDialog).toHaveBeenCalled();
       expect(call[0]).toEqual({
@@ -62,7 +62,7 @@ describe('files', () => {
     });
 
     it('notifies the main window of the event', async () => {
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
 
       await showOpenDialog();
 
@@ -111,10 +111,7 @@ describe('files', () => {
     });
 
     it('ensures that the target is empty on save', async () => {
-      (dialog.showMessageBox as jest.Mock<any>).mockImplementation(
-        async () => true,
-      );
-      (fs.existsSync as jest.Mock<any>).mockReturnValue(true);
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
       ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
 
       await showSaveDialog();
@@ -124,11 +121,8 @@ describe('files', () => {
     });
 
     it('does not overwrite files without consent', async () => {
-      (dialog.showMessageBox as jest.Mock<any>).mockImplementation(
-        async () => false,
-      );
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
-      (fs.existsSync as jest.Mock<any>).mockReturnValue(true);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
 
       await showSaveDialog();
 
@@ -140,8 +134,8 @@ describe('files', () => {
       (dialog.showMessageBox as jest.Mock<any>).mockImplementation(async () => {
         throw new Error('Nope');
       });
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
-      (fs.existsSync as jest.Mock<any>).mockReturnValue(true);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
 
       let errored = false;
 

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -17,11 +17,7 @@ jest.mock('../../src/main/ipc');
 describe('menu', () => {
   beforeEach(() => {
     electron.app.name = 'Electron Fiddle';
-    // need to keep this deprecated API for electron-default-menu mock as well
-    (electron.app.getName as any).mockReturnValue('Electron Fiddle');
-    (electron.dialog.showOpenDialog as any).mockReturnValue(
-      Promise.resolve({}),
-    );
+    (electron.dialog.showOpenDialog as jest.Mock).mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -307,7 +303,7 @@ describe('menu', () => {
 
       it('saves a Fiddle as', () => {
         file.submenu[6].click();
-        expect(electron.dialog.showOpenDialog).toHaveBeenCalled();
+        expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
 
       it('saves a Fiddle as a gist', () => {
@@ -319,7 +315,7 @@ describe('menu', () => {
 
       it('saves a Fiddle as a forge project', () => {
         file.submenu[9].click();
-        expect(electron.dialog.showOpenDialog).toHaveBeenCalled();
+        expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
 
       it('saves a Fiddle with blocked accelerator', () => {
@@ -333,7 +329,7 @@ describe('menu', () => {
       it('saves as a Fiddle with blocked accelerator', () => {
         setupMenu([BlockableAccelerator.saveAs]);
         file.submenu[6].click();
-        expect(electron.dialog.showOpenDialog).toHaveBeenCalled();
+        expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
     });
   });

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -167,8 +167,9 @@ const electronMock = {
     start: jest.fn(),
   },
   dialog: {
-    showOpenDialog: jest.fn(() => Promise.resolve({})),
-    showMessageBox: jest.fn(() => Promise.resolve({})),
+    showOpenDialog: jest.fn().mockResolvedValue({}),
+    showOpenDialogSync: jest.fn().mockReturnValue(['path']),
+    showMessageBox: jest.fn().mockResolvedValue({}),
   },
   ipcMain: new MockIPC(),
   ipcRenderer: new MockIPC(),


### PR DESCRIPTION
Fixes #551 by avoiding the offending API.

Swaps out `openDialog` for `openDialogSync` for saving local Fiddles.


Commits:
* cc84422 contains the code itself.
* c897f79 updates the tests so they pass.
* 212cd08 removes `<any>` types from `jest.Mock` in the tests.
