### PR TITLE
fix: replacing an existing gist link

### DIFF
--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -111,11 +111,13 @@ export class AddressBar extends React.Component<
     this.setState({ value: event.target.value });
   }
 
-  public handleBlur(_event: React.FocusEvent<HTMLInputElement>) {
+  public handleBlur(event: React.FocusEvent<HTMLInputElement>) {
     const { gistId } = this.props.appState;
     const url = urlFromId(gistId);
 
-    if (url) {
+    const shouldResetURL =
+      url === event.target.value || event.target.value === '';
+    if (url && shouldResetURL) {
       this.setState({ value: url });
     }
   }


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/571.

Refs https://github.com/electron/fiddle/pull/531.

Fixes an issue where it was impossible to load a new gist via command bar when one was previously loaded. This was happening because the `onBlur` handler always pulled what it thought was the current gist from `appState`, which meant that if the gist a user was trying to load was not the same as the one in `appState`, it would be overwritten. This PR tries to fix that by asserting that the command bar is either empty or contains the last gist stored into `appState` before reloading the last stored Fiddle Gist.

Tested with the outlined steps in https://github.com/electron/fiddle/issues/571.