### PR TITLE
chore: display better error when packaging

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -279,7 +279,7 @@ export class Runner {
       pushOutput(`Saved files to ${dir}`);
       return dir;
     } catch (error) {
-      pushError('Failed to save files.', error);
+      pushError('Failed to save files.', error.message);
     }
 
     return null;


### PR DESCRIPTION
Refs https://github.com/electron/fiddle/issues/568.

The error was showing as `[object ErrorEvent]` and we want the user to see a more descriptive message. We should be pushing the message property of the [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent) and not the object itself.

cc @felixrieseberg @erickzhao 