### PR TITLE
fix: clear console when creating a new fiddle (#573)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -188,7 +188,10 @@ function getFileMenu(
   const fileMenu: Array<MenuItemConstructorOptions> = [
     {
       label: 'New Fiddle',
-      click: () => ipcMainManager.send(IpcEvents.FS_NEW_FIDDLE),
+      click: () => {
+        ipcMainManager.send(IpcEvents.CLEAR_CONSOLE);
+        return ipcMainManager.send(IpcEvents.FS_NEW_FIDDLE);
+      },
       accelerator: 'CmdOrCtrl+N',
     },
     {


### PR DESCRIPTION
Added small fix to clear the console once the user opens a new Fiddle.

<strong>ScreenShot :</strong>

![fix](https://user-images.githubusercontent.com/53977614/107260335-03ebf000-6a64-11eb-9855-addd6dda76c4.gif)

Closes #573.