### PR TITLE
refactor: remove remote from `chrome-mac.tsx`

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -29,6 +29,7 @@ export enum IpcEvents {
   SET_APPDATA_DIR = 'SET_APPDATA_DIR',
   SELECT_ALL_IN_EDITOR = 'SELECT_ALL_IN_EDITOR',
   BLOCK_ACCELERATORS = 'BLOCK_ACCELERATORS',
+  CLICK_TITLEBAR_MAC = 'CLICK_TITLEBAR_MAC',
 }
 
 export const ipcMainEvents = [
@@ -40,6 +41,7 @@ export const ipcMainEvents = [
   IpcEvents.SHOW_INACTIVE,
   IpcEvents.CONFIRM_QUIT,
   IpcEvents.BLOCK_ACCELERATORS,
+  IpcEvents.CLICK_TITLEBAR_MAC,
 ];
 
 export const ipcRendererEvents = [

--- a/src/renderer/components/chrome-mac.tsx
+++ b/src/renderer/components/chrome-mac.tsx
@@ -1,8 +1,9 @@
-import { remote } from 'electron';
 import { observer } from 'mobx-react';
 import * as React from 'react';
+import { IpcEvents } from '../../ipc-events';
 
 import { getTitle } from '../../utils/get-title';
+import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
 
 export interface ChromeMacProps {
@@ -12,20 +13,7 @@ export interface ChromeMacProps {
 @observer
 export class ChromeMac extends React.Component<ChromeMacProps> {
   public handleDoubleClick = () => {
-    const doubleClickAction = remote.systemPreferences.getUserDefault(
-      'AppleActionOnDoubleClick',
-      'string',
-    );
-    const win = remote.getCurrentWindow();
-    if (doubleClickAction === 'Minimize') {
-      win.minimize();
-    } else if (doubleClickAction === 'Maximize') {
-      if (!win.isMaximized()) {
-        win.maximize();
-      } else {
-        win.unmaximize();
-      }
-    }
+    ipcRendererManager.send(IpcEvents.CLICK_TITLEBAR_MAC);
   };
 
   public render() {

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -221,6 +221,7 @@ const electronMock = {
 
 electronMock.BrowserWindow.getAllWindows.mockReturnValue([]);
 electronMock.BrowserWindow.fromId.mockReturnValue(mainWindowStub);
+electronMock.BrowserWindow.fromWebContents.mockReturnValue(mainWindowStub);
 electronMock.BrowserWindow.getFocusedWindow.mockReturnValue(focusedWindowStub);
 electronMock.remote.getCurrentWindow.mockReturnValue(mainWindowStub);
 

--- a/tests/renderer/binary-spec.ts
+++ b/tests/renderer/binary-spec.ts
@@ -162,7 +162,7 @@ describe('binary', () => {
     });
 
     it('throws on other platforms', () => {
-      overridePlatform('bleepbloop');
+      overridePlatform('android');
 
       expect(() => getElectronBinaryPath('v3.0.0')).toThrow();
     });

--- a/tests/renderer/components/chrome-mac-spec.tsx
+++ b/tests/renderer/components/chrome-mac-spec.tsx
@@ -1,9 +1,9 @@
-import * as electron from 'electron';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
+import { IpcEvents } from '../../../src/ipc-events';
 
 import { ChromeMac } from '../../../src/renderer/components/chrome-mac';
-import { MockBrowserWindow } from '../../mocks/browser-window';
+import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { overridePlatform, resetPlatform } from '../../utils';
 
 describe('Chrome-Mac component', () => {
@@ -26,86 +26,15 @@ describe('Chrome-Mac component', () => {
   });
 
   describe('handleDoubleClick', () => {
-    it('should minimize the window if AppleActionOnDoubleClick is minimize', () => {
+    it('should send a message to the main process', () => {
       const wrapper = mount(<ChromeMac appState={store} />);
       const chrome = wrapper.instance() as ChromeMac;
-      const fakeWindow = new MockBrowserWindow();
-      (electron.remote.systemPreferences
-        .getUserDefault as jest.Mock).mockReturnValue('Minimize');
-      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(
-        fakeWindow,
-      );
+      ipcRendererManager.send = jest.fn();
 
       chrome.handleDoubleClick();
-
-      expect(
-        electron.remote.systemPreferences.getUserDefault,
-      ).toHaveBeenCalled();
-      expect(fakeWindow.minimize).toHaveBeenCalled();
-      expect(fakeWindow.maximize).not.toHaveBeenCalled();
-      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
-    });
-
-    it('should maximize the window if AppleActionOnDoubleClick is maximize and the window is not maximized', () => {
-      const wrapper = mount(<ChromeMac appState={store} />);
-      const chrome = wrapper.instance() as ChromeMac;
-      const fakeWindow = new MockBrowserWindow();
-      (electron.remote.systemPreferences
-        .getUserDefault as jest.Mock).mockReturnValue('Maximize');
-      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(
-        fakeWindow,
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.CLICK_TITLEBAR_MAC,
       );
-      fakeWindow.isMaximized.mockReturnValue(false);
-
-      chrome.handleDoubleClick();
-
-      expect(
-        electron.remote.systemPreferences.getUserDefault,
-      ).toHaveBeenCalled();
-      expect(fakeWindow.minimize).not.toHaveBeenCalled();
-      expect(fakeWindow.maximize).toHaveBeenCalled();
-      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
-    });
-
-    it('should unmaximize the window if AppleActionOnDoubleClick is maximize and the window is maximized', () => {
-      const wrapper = mount(<ChromeMac appState={store} />);
-      const chrome = wrapper.instance() as ChromeMac;
-      const fakeWindow = new MockBrowserWindow();
-      (electron.remote.systemPreferences
-        .getUserDefault as jest.Mock).mockReturnValue('Maximize');
-      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(
-        fakeWindow,
-      );
-      fakeWindow.isMaximized.mockReturnValue(true);
-
-      chrome.handleDoubleClick();
-
-      expect(
-        electron.remote.systemPreferences.getUserDefault,
-      ).toHaveBeenCalled();
-      expect(fakeWindow.minimize).not.toHaveBeenCalled();
-      expect(fakeWindow.maximize).not.toHaveBeenCalled();
-      expect(fakeWindow.unmaximize).toHaveBeenCalled();
-    });
-
-    it('should do nothingif AppleActionOnDoubleClick is an unknown value', () => {
-      const wrapper = mount(<ChromeMac appState={store} />);
-      const chrome = wrapper.instance() as ChromeMac;
-      const fakeWindow = new MockBrowserWindow();
-      (electron.remote.systemPreferences
-        .getUserDefault as jest.Mock).mockReturnValue('Nonsense');
-      (electron.remote.getCurrentWindow as jest.Mock).mockReturnValue(
-        fakeWindow,
-      );
-
-      chrome.handleDoubleClick();
-
-      expect(
-        electron.remote.systemPreferences.getUserDefault,
-      ).toHaveBeenCalled();
-      expect(fakeWindow.minimize).not.toHaveBeenCalled();
-      expect(fakeWindow.maximize).not.toHaveBeenCalled();
-      expect(fakeWindow.unmaximize).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,6 @@
 const platform = process.platform;
 
-export function overridePlatform(value: string) {
+export function overridePlatform(value: NodeJS.Platform) {
   Object.defineProperty(process, 'platform', {
     value,
     writable: true,

--- a/tests/utils/electron-name-spec.ts
+++ b/tests/utils/electron-name-spec.ts
@@ -7,11 +7,13 @@ describe('electron-name', () => {
   });
 
   it('returns the right name for each platform', () => {
-    [
+    const platforms: Array<{ platform: NodeJS.Platform; expected: string }> = [
       { platform: 'win32', expected: 'electron.exe' },
       { platform: 'darwin', expected: 'Electron.app' },
       { platform: 'linux', expected: 'electron' },
-    ].forEach(({ platform, expected }) => {
+    ];
+
+    platforms.forEach(({ platform, expected }) => {
       overridePlatform(platform);
       expect(getElectronNameForPlatform()).toBe(expected);
     });


### PR DESCRIPTION
Ref #418

Moves the click handler for the macOS titlebar into the main process.