### PR TITLE
fix: setupBinary() resolves when download completes

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -9,34 +9,12 @@ import { USER_DATA_PATH } from './constants';
 import { removeTypeDefsForVersion } from './fetch-types';
 import { AppState } from './state';
 
-/**
- * General setup, called with a version. Is called during construction
- * to ensure that we always have or download at least one version.
- *
- * @param {string} iVersion
- * @returns {Promise<void>}
- */
-export async function setupBinary(
+const pendingDownloads: Record<string, Promise<void>> = {};
+
+async function downloadBinary(
   appState: AppState,
-  iVersion: string,
+  version: string,
 ): Promise<void> {
-  const version = normalizeVersion(iVersion);
-  const fs = await fancyImport<typeof fsType>('fs-extra');
-
-  await fs.mkdirp(getDownloadPath(version));
-
-  const { state } = appState.versions[version];
-  if (state === VersionState.downloading || state === VersionState.unzipping) {
-    console.log(`Binary: Electron ${version} already downloading.`);
-    return;
-  }
-
-  if (await getIsDownloaded(version)) {
-    console.log(`Binary: Electron ${version} already downloaded.`);
-    appState.versions[version].state = VersionState.ready;
-    return;
-  }
-
   console.log(`Binary: Electron ${version} not present, downloading`);
   appState.versions[version].state = VersionState.downloading;
 
@@ -49,19 +27,53 @@ export async function setupBinary(
   try {
     appState.versions[version].state = VersionState.unzipping;
 
+    // Ensure the target path exists
+    const fs = await fancyImport<typeof fsType>('fs-extra');
+    await fs.mkdirp(extractPath);
+
     // Ensure the target path is empty
     await fs.emptyDir(extractPath);
 
     const electronFiles = await unzip(zipPath, extractPath);
-    console.log(`Unzipped ${version}`, electronFiles);
+    console.log(`Binary: Unzipped ${version}`, electronFiles);
+    appState.versions[version].state = VersionState.ready;
   } catch (error) {
-    console.warn(`Failure while unzipping ${version}`, error);
+    console.warn(`Binary: Failure while unzipping ${version}`, error);
     appState.versions[version].state = VersionState.unknown;
+  } finally {
+    // This task is done, so remove it from the pending tasks list
+    delete pendingDownloads[version];
+  }
+}
 
+/**
+ * General setup, called with a version. Is called during construction
+ * to ensure that we always have or download at least one version.
+ *
+ * @param {string} iVersion
+ * @returns {Promise<void>}
+ */
+export async function setupBinary(
+  appState: AppState,
+  iVersion: string,
+): Promise<void> {
+  const version = normalizeVersion(iVersion);
+
+  // If we already have it, then we're done
+  if (await getIsDownloaded(version)) {
+    console.log(`Binary: Electron ${version} already downloaded.`);
+    appState.versions[version].state = VersionState.ready;
     return;
   }
 
-  appState.versions[version].state = VersionState.ready;
+  // Return a promise that resolves when the download completes
+  let pending = pendingDownloads[version];
+  if (pending) {
+    console.log(`Binary: Electron ${version} already downloading.`);
+  } else {
+    pending = pendingDownloads[version] = downloadBinary(appState, version);
+  }
+  return pending;
 }
 
 /**

--- a/tests/renderer/binary-spec.ts
+++ b/tests/renderer/binary-spec.ts
@@ -192,7 +192,7 @@ describe('binary', () => {
       expect(mockState.versions['3.0.0'].state).toBe('ready');
     });
 
-    it(`does not download a version while already downloading`, async () => {
+    it(`waits if asked for a version is already downloading`, async () => {
       const fs = require('fs-extra');
       const { download } = require('@electron/get');
 
@@ -202,7 +202,7 @@ describe('binary', () => {
       await setupBinary(mockState, 'v3.0.0');
 
       expect(download).toHaveBeenCalledTimes(0);
-      expect(mockState.versions['3.0.0'].state).toBe('downloading');
+      expect(mockState.versions['3.0.0'].state).toBe('ready');
     });
 
     it('handles an error in the zip file', async () => {


### PR DESCRIPTION
Right now there is an edge case where setupBinary() can resolve before a download is done: if called while a download for that version is already running, setupBinary() returns to avoid parallel downloads. Because of this return, the caller may find their RunnableVersion does not have the state that was expected.
    
This PR keeps track of pending downloads so that when a duplicate call occurs, all callers get a Promise that settles when the download does.
    
This is similar to how renderer/content [safeguards against parallel downloads](https://github.com/electron/fiddle/blob/858e4b1834832e0ea5ccf64825c2bd7d201a8a2b/src/renderer/content.ts#L57) of the same zipfile.