### PR TITLE
fix: nullptr dereference in runner's cleanup function

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -317,7 +317,7 @@ export class Runner {
     }
 
     const name = await this.appState.getName();
-    const appData = path.join(this.appState.appData, name);
+    const appData = path.join(window.ElectronFiddle.appPaths.appData, name);
 
     console.log(`Cleanup: Deleting data dir ${appData}`);
     await window.ElectronFiddle.app.fileManager.cleanup(appData);

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -206,9 +206,6 @@ export class AppState {
       this.toggleBisectCommands,
     );
     ipcRendererManager.on(IpcEvents.BEFORE_QUIT, this.setIsQuitting);
-    ipcRendererManager.once(IpcEvents.GET_APP_PATHS, (_event, dir) => {
-      this.appData = dir;
-    });
 
     // Setup auto-runs
     autorun(() => this.save('theme', this.theme));


### PR DESCRIPTION
Was previously erroring out upon passing undefined into `path.join()`.

Related to the appData -> appPaths improvements in https://github.com/electron/fiddle/pull/602