### PR TITLE
fix: accidental switch fall-through in remote-loader

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -78,7 +78,7 @@ export class RemoteLoader {
         );
       }
 
-      const loaders: Array<Promise<any>> = [];
+      const loaders: Array<Promise<void>> = [];
 
       for (const child of folder.data) {
         if (!child.download_url) {

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -7,6 +7,7 @@ import {
   PRELOAD_JS_NAME,
   RENDERER_JS_NAME,
   STYLES_CSS_NAME,
+  FILENAME_KEYS,
 } from '../shared-constants';
 import { getOctokit } from '../utils/octokit';
 import { sortedElectronMap } from '../utils/sorted-electron-map';
@@ -71,12 +72,13 @@ export class RemoteLoader {
 
       const values = await getTemplate(this.appState.version);
 
-      const loaders: Array<Promise<void>> = [];
       if (!Array.isArray(folder.data)) {
         throw new Error(
           'The example Fiddle tried to launch is not a valid Electron example',
         );
       }
+
+      const loaders: Array<Promise<any>> = [];
 
       for (const child of folder.data) {
         if (!child.download_url) {
@@ -84,59 +86,15 @@ export class RemoteLoader {
           continue;
         }
 
-        switch (child.name) {
-          case MAIN_JS_NAME:
-            loaders.push(
-              fetch(child.download_url)
-                .then((r) => r.text())
-                .then((t) => {
-                  values.main = t;
-                }),
-            );
-
-            break;
-          case INDEX_HTML_NAME:
-            loaders.push(
-              fetch(child.download_url)
-                .then((r) => r.text())
-                .then((t) => {
-                  values.html = t;
-                }),
-            );
-
-            break;
-          case RENDERER_JS_NAME:
-            loaders.push(
-              fetch(child.download_url)
-                .then((r) => r.text())
-                .then((t) => {
-                  values.renderer = t;
-                }),
-            );
-
-            break;
-
-          case PRELOAD_JS_NAME:
-            loaders.push(
-              fetch(child.download_url)
-                .then((r) => r.text())
-                .then((t) => {
-                  values.preload = t;
-                }),
-            );
-
-          case STYLES_CSS_NAME:
-            loaders.push(
-              fetch(child.download_url)
-                .then((r) => r.text())
-                .then((t) => {
-                  values.css = t;
-                }),
-            );
-
-            break;
-          default:
-            break;
+        const valueKey = FILENAME_KEYS[child.name];
+        if (valueKey) {
+          loaders.push(
+            fetch(child.download_url)
+              .then((r) => r.text())
+              .then((t) => {
+                values[valueKey] = t;
+              }),
+          );
         }
       }
 

--- a/src/shared-constants.ts
+++ b/src/shared-constants.ts
@@ -4,3 +4,11 @@ export const RENDERER_JS_NAME = 'renderer.js';
 export const PRELOAD_JS_NAME = 'preload.js';
 export const STYLES_CSS_NAME = 'styles.css';
 export const PACKAGE_NAME = 'package.json';
+
+export const FILENAME_KEYS = Object.freeze({
+  [INDEX_HTML_NAME]: 'html',
+  [MAIN_JS_NAME]: 'main',
+  [PRELOAD_JS_NAME]: 'preload',
+  [RENDERER_JS_NAME]: 'renderer',
+  [STYLES_CSS_NAME]: 'css',
+});

--- a/src/utils/read-fiddle.ts
+++ b/src/utils/read-fiddle.ts
@@ -1,23 +1,9 @@
 import { EditorValues } from '../interfaces';
-import {
-  INDEX_HTML_NAME,
-  MAIN_JS_NAME,
-  PRELOAD_JS_NAME,
-  RENDERER_JS_NAME,
-  STYLES_CSS_NAME,
-} from '../shared-constants';
+import { FILENAME_KEYS } from '../shared-constants';
 import { fancyImport } from './import';
 
 import * as fsType from 'fs-extra';
 import * as path from 'path';
-
-const FILENAME_KEYS = Object.freeze({
-  [INDEX_HTML_NAME]: 'html',
-  [MAIN_JS_NAME]: 'main',
-  [PRELOAD_JS_NAME]: 'preload',
-  [RENDERER_JS_NAME]: 'renderer',
-  [STYLES_CSS_NAME]: 'css',
-});
 
 /**
  * Reads a Fiddle from a directory.

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -60,6 +60,10 @@ const mockRepos = [
     download_url: 'https://css',
   },
   {
+    name: PRELOAD_JS_NAME,
+    download_url: 'https://preload',
+  },
+  {
     name: 'other_stuff',
     download_url: 'https://google.com',
   },
@@ -145,6 +149,7 @@ describe('RemoteLoader', () => {
       mockFetchOnce('renderer');
       mockFetchOnce('index');
       mockFetchOnce('css');
+      mockFetchOnce('preload');
     });
 
     it('loads an Electron example', async () => {
@@ -163,6 +168,7 @@ describe('RemoteLoader', () => {
             main: 'main',
             renderer: 'renderer',
             css: 'css',
+            preload: 'preload',
           }),
         ]),
       );


### PR DESCRIPTION
remote-loader currently has an accidental switch fallthrough due to a missing `break;` statement [here](https://github.com/electron/fiddle/blob/255a81d7a7b827d9f290ef72f2924efc9d89ae86/src/renderer/remote-loader.ts#L126).

This PR removes the switch statement by promoting `FILENAME_KEYS` up from [read-fiddle.js](https://github.com/electron/fiddle/blob/255a81d7a7b827d9f290ef72f2924efc9d89ae86/src/utils/read-fiddle.ts#L14) into shared-constants.ts so that it can be used by remote-loader as well. By using this the switch statement can be avoided altogether.

Discovered while fixing up coverage leaks in the autobisect branch :smiley: 