### PR TITLE
refactor: minor test cleanups

### DIFF
--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -105,12 +105,12 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     );
 
     ipcRendererManager.on(IpcEvents.SELECT_ALL_IN_EDITOR, (_event) => {
-      // programmatically fetch all editor contents and set as selection
       const editor = getFocusedEditor();
-      const range = editor?.getModel()?.getFullModelRange();
-
-      if (!!range) {
-        editor?.setSelection(range);
+      if (editor) {
+        const model = editor.getModel();
+        if (model) {
+          editor.setSelection(model.getFullModelRange());
+        }
       }
     });
 

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -82,6 +82,8 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
    * @memberof Editors
    */
   public async componentDidMount() {
+    this.stopListening();
+
     ipcRendererManager.on(
       IpcEvents.MONACO_EXECUTE_COMMAND,
       (_event, cmd: string) => {
@@ -119,7 +121,10 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
 
   public componentWillUnmount() {
     this.disposeLayoutAutorun();
+    this.stopListening();
+  }
 
+  private stopListening() {
     ipcRendererManager.removeAllListeners(IpcEvents.MONACO_EXECUTE_COMMAND);
     ipcRendererManager.removeAllListeners(IpcEvents.FS_NEW_FIDDLE);
     ipcRendererManager.removeAllListeners(IpcEvents.MONACO_TOGGLE_OPTION);

--- a/src/utils/editor-mounted.ts
+++ b/src/utils/editor-mounted.ts
@@ -1,28 +1,16 @@
 import { MosaicId } from '../interfaces';
 
+import { waitFor } from './wait-for';
+
 /**
  * Waits for editors to mount on a list of Mosaic IDs
  * @param editors
  */
 export function waitForEditorsToMount(editors: Array<MosaicId>) {
-  let time = 0;
-  const maxTime = 3000;
-  const interval = 100;
-  return new Promise<void>((resolve, reject) => {
-    (function checkMountedEditors() {
-      const allMounted = editors.every(
-        (id) => !!window.ElectronFiddle.editors[id],
-      );
-      if (allMounted) {
-        return resolve();
-      }
-      time += interval;
-      if (time > maxTime) {
-        return reject(
-          `Timed out after ${maxTime}ms: can't mount editors onto mosaics.`,
-        );
-      }
-      setTimeout(checkMountedEditors, 100);
-    })();
+  const allMounted = () =>
+    editors.every((id) => !!window.ElectronFiddle.editors[id]);
+  const opts = { timeout: 3000, interval: 100 };
+  return waitFor(allMounted, opts).catch((error) => {
+    throw `Can't mount editors onto mosaics. ${error.toString()}`;
   });
 }

--- a/src/utils/wait-for.ts
+++ b/src/utils/wait-for.ts
@@ -1,0 +1,32 @@
+/**
+ * Waits up to `timeout` msec for a test to pass.
+ *
+ * @return a promise that returns the test result on success, or rejects on timeout
+ * @param {() => any} test - function to test
+ * @param {Object} options
+ * @param {Number} [options.interval=100] - polling frequency, in msec
+ * @param {Number} [options.timeout=2000] - timeout interval, in msec
+ */
+export async function waitFor(
+  test: () => any,
+  options = {
+    interval: 100,
+    timeout: 2000,
+  },
+): Promise<any> {
+  const { interval, timeout } = options;
+  let elapsed = 0;
+  return new Promise<void>((resolve, reject) => {
+    (function check() {
+      const result = test();
+      if (result) {
+        return resolve(result);
+      }
+      elapsed += interval;
+      if (elapsed >= timeout) {
+        return reject(`Timed out: ${timeout}ms`);
+      }
+      setTimeout(check, interval);
+    })();
+  });
+}

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -272,6 +272,15 @@ describe('menu', () => {
 
     describe('getFileMenu()', () => {
       let file: any;
+      enum Idx {
+        NEW_FIDDLE = 0,
+        NEW_WINDOW = 1,
+        OPEN = 3,
+        SAVE = 5,
+        SAVE_AS = 6,
+        PUBLISH = 8,
+        FORGE = 9,
+      }
 
       beforeEach(() => {
         const mock = (electron.Menu.buildFromTemplate as any).mock;
@@ -280,50 +289,50 @@ describe('menu', () => {
       });
 
       it('creates a new fiddle', () => {
-        file.submenu[0].click();
+        file.submenu[Idx.NEW_FIDDLE].click();
         expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
           IpcEvents.FS_NEW_FIDDLE,
         );
       });
 
       it('creates a new window', () => {
-        file.submenu[1].click();
-        file.submenu[1].click();
+        file.submenu[Idx.NEW_WINDOW].click();
+        file.submenu[Idx.NEW_WINDOW].click();
         expect(createMainWindow).toHaveBeenCalledTimes(2);
       });
 
       it('opens a Fiddle', () => {
-        file.submenu[3].click();
+        file.submenu[Idx.OPEN].click();
         expect(electron.dialog.showOpenDialog).toHaveBeenCalled();
       });
 
       it('saves a Fiddle', () => {
-        file.submenu[5].click();
+        file.submenu[Idx.SAVE].click();
         expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
           IpcEvents.FS_SAVE_FIDDLE,
         );
       });
 
       it('saves a Fiddle as', () => {
-        file.submenu[6].click();
+        file.submenu[Idx.SAVE_AS].click();
         expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
 
       it('saves a Fiddle as a gist', () => {
-        file.submenu[8].click();
+        file.submenu[Idx.PUBLISH].click();
         expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
           IpcEvents.FS_SAVE_FIDDLE_GIST,
         );
       });
 
       it('saves a Fiddle as a forge project', () => {
-        file.submenu[9].click();
+        file.submenu[Idx.FORGE].click();
         expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
 
       it('saves a Fiddle with blocked accelerator', () => {
         setupMenu([BlockableAccelerator.save]);
-        file.submenu[5].click();
+        file.submenu[Idx.SAVE].click();
         expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
           IpcEvents.FS_SAVE_FIDDLE,
         );
@@ -331,7 +340,7 @@ describe('menu', () => {
 
       it('saves as a Fiddle with blocked accelerator', () => {
         setupMenu([BlockableAccelerator.saveAs]);
-        file.submenu[6].click();
+        file.submenu[Idx.SAVE_AS].click();
         expect(electron.dialog.showOpenDialogSync).toHaveBeenCalled();
       });
     });

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { VersionSource, VersionState } from '../../../src/interfaces';
 import { ElectronSettings } from '../../../src/renderer/components/settings-electron';
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
-import { mockVersions } from '../../mocks/electron-versions';
+import { mockVersions, mockVersionsArray } from '../../mocks/electron-versions';
 
 describe('ElectronSettings component', () => {
   let store: any;
@@ -97,7 +97,9 @@ describe('ElectronSettings component', () => {
     const instance = wrapper.instance() as any;
     await instance.handleDeleteAll();
 
-    expect(store.removeVersion).toHaveBeenCalledTimes(2);
+    expect(store.removeVersion).toHaveBeenCalledTimes(
+      mockVersionsArray.length - 1,
+    );
   });
 
   it('handles the downloadAll()', async () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -397,10 +397,9 @@ describe('AppState', () => {
   });
 
   describe('setVersion()', () => {
-    it('falls back if a version does not exist', async () => {
+    it('uses the newest version iff the specified version does not exist', async () => {
       await appState.setVersion('v999.99.99');
-
-      expect(appState.version).toBe('2.0.3');
+      expect(appState.version).toBe(mockVersionsArray[0].version);
     });
 
     it('downloads a version if necessary', async () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,5 +1,4 @@
 import * as MonacoType from 'monaco-editor';
-import { when } from 'mobx';
 
 import {
   ALL_MOSAICS,
@@ -27,6 +26,7 @@ import {
   saveLocalVersions,
 } from '../../src/renderer/versions';
 import { createMosaicArrangement } from '../../src/utils/editors-mosaic-arrangement';
+import { waitFor } from '../../src/utils/wait-for';
 import { getName } from '../../src/utils/get-title';
 import { mockVersions, mockVersionsArray } from '../mocks/electron-versions';
 import { overridePlatform, resetPlatform } from '../utils';
@@ -144,19 +144,21 @@ describe('AppState', () => {
     });
 
     it('sets the onDidChangeModelContent handler if saved', async (done) => {
+      // confirm that setting appState.isUnsaved to false
+      // causes a new change-model-content callback to be installed
       appState.isUnsaved = false;
-      await when(() => appState.isUnsaved === false);
-
-      expect(window.onbeforeunload).toBe(null);
-
       const fn = window.ElectronFiddle.editors!.renderer!
         .onDidChangeModelContent;
-      const call = (fn as jest.Mock<any>).mock.calls[0];
-      const cb = call[0];
+      await waitFor(() => (fn as jest.Mock).mock.calls.length > 0);
+      expect(window.onbeforeunload).toBe(null);
+      expect(fn as jest.Mock).toHaveBeenCalledTimes(1);
 
-      cb();
-
+      // confirm that invoking the new callback sets appState.isUnsaved to true
+      const call = (fn as jest.Mock).mock.calls[0];
+      const callback = call[0];
+      callback();
       expect(appState.isUnsaved).toBe(true);
+
       done();
     });
   });

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -28,7 +28,7 @@ import {
 } from '../../src/renderer/versions';
 import { createMosaicArrangement } from '../../src/utils/editors-mosaic-arrangement';
 import { getName } from '../../src/utils/get-title';
-import { mockVersions } from '../mocks/electron-versions';
+import { mockVersions, mockVersionsArray } from '../mocks/electron-versions';
 import { overridePlatform, resetPlatform } from '../utils';
 
 jest.mock('../../src/renderer/content', () => ({
@@ -327,14 +327,14 @@ describe('AppState', () => {
       appState.channelsToShow = ['Unsupported' as any];
       expect(appState.versionsToShow.length).toEqual(0);
       appState.channelsToShow = ['Stable' as any];
-      expect(appState.versionsToShow.length).toEqual(3);
+      expect(appState.versionsToShow.length).toEqual(mockVersionsArray.length);
     });
 
     it('excludes states', () => {
       appState.statesToShow = [VersionState.downloading];
       expect(appState.versionsToShow.length).toEqual(0);
       appState.statesToShow = [VersionState.ready];
-      expect(appState.versionsToShow.length).toEqual(3);
+      expect(appState.versionsToShow.length).toEqual(mockVersionsArray.length);
     });
   });
 
@@ -400,7 +400,7 @@ describe('AppState', () => {
     it('falls back if a version does not exist', async () => {
       await appState.setVersion('v999.99.99');
 
-      expect(appState.version).toBe('2.0.2');
+      expect(appState.version).toBe('2.0.3');
     });
 
     it('downloads a version if necessary', async () => {
@@ -467,11 +467,9 @@ describe('AppState', () => {
       // We just want to verify that the version state was
       // refreshed - we didn't actually add the local version
       // above, since versions.ts is mocked
-      expect(Object.keys(appState.versions)).toEqual([
-        '2.0.2',
-        '2.0.1',
-        '1.8.7',
-      ]);
+      expect(Object.keys(appState.versions)).toEqual(
+        mockVersionsArray.map((v) => v.version),
+      );
     });
   });
 


### PR DESCRIPTION
Some of the test / coverage changes in the autobisect branch are not directly related to autobisect, so I've extracted them out to their own branch here to reduce sprawl. This is a handful of small test refactors:

* Avoid some magic numbers / magic strings, using symbolic names or computed values instead. This is _not_ comprehensive; the changes are in places where the magic values are changing in the autobisect branch
* Fix a double-subscribe-to-IPC issue in editors.tsx
* Improve coverage in SELECT_ALL, FS_NEW_FIDDLE, and editors.setFocused()
* Add a new util `waitFor()` that is extract-method'ed from `waitForEditorsToMount()`