### PR TITLE
refactor: remove unnecessary 'async' from getIsDownloaded()

### DIFF
--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -70,9 +70,8 @@ export class AddVersionDialog extends React.Component<
    *
    * @param {React.ChangeEvent<HTMLInputElement>} event
    */
-  public async setFolderPath(folderPath: string) {
-    const isValidElectron = !!(await getIsDownloaded('custom', folderPath));
-
+  public setFolderPath(folderPath: string) {
+    const isValidElectron = getIsDownloaded('custom', folderPath);
     this.setState({ folderPath, isValidElectron });
   }
 

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -71,7 +71,7 @@ export class Runner {
       return false;
     }
 
-    const isReady = await getIsDownloaded(version, localPath);
+    const isReady = getIsDownloaded(version, localPath);
 
     if (!isReady) {
       console.warn(`Runner: Binary ${version} not ready`);

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -29,9 +29,6 @@ describe('AddVersionDialog component', () => {
     store = {
       isAddVersionDialogShowing: true,
       addLocalVersion: jest.fn(),
-      binaryManager: {
-        getIsDownloaded: jest.fn(),
-      },
     };
   });
 
@@ -70,7 +67,7 @@ describe('AddVersionDialog component', () => {
 
   describe('setFolderPath()', () => {
     it('does something', async () => {
-      (getIsDownloaded as jest.Mock).mockResolvedValue(true);
+      (getIsDownloaded as jest.Mock).mockReturnValue(true);
       const wrapper = shallow(<AddVersionDialog appState={store} />);
       await (wrapper.instance() as any).setFolderPath('/test/');
 


### PR DESCRIPTION
A minor refactor to `src/renderer/binary getIsDownloaded()`, which is async only because it uses fancy-import. However this isn't necessary in order for testing, so the code can be simplified a little by removing `async`.