### PR TITLE
perf: faster sorting in sortedElectronMap()

### DIFF
--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -17,12 +17,14 @@ interface SemRunnable {
   runnable: RunnableVersion;
 }
 
-function compareSemRunnable(a: SemRunnable, b: SemRunnable) {
+// non-semver goes first, sorted lexicographically
+// semvers follow, sorted newest-to-oldest
+function compareByNew(a: SemRunnable, b: SemRunnable) {
   if (!a.sem && !b.sem)
     return a.runnable.version.localeCompare(b.runnable.version);
-  if (!a.sem) return 1;
-  if (!b.sem) return -1;
-  return electronSemVerCompare(a.sem!, b.sem!);
+  if (!a.sem) return -1;
+  if (!b.sem) return 1;
+  return -electronSemVerCompare(a.sem!, b.sem!);
 }
 
 /**
@@ -37,8 +39,7 @@ function sortByNew(versions: RunnableVersion[]): RunnableVersion[] {
       runnable,
       sem: semver.parse(runnable?.version),
     }))
-    .sort(compareSemRunnable)
-    .reverse() // newest to oldest
+    .sort(compareByNew)
     .map(({ runnable }) => runnable);
 }
 

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -41,7 +41,7 @@ export function sortedElectronMap<T>(
     run: RunnableVersion,
   ];
   return Object.entries(versions)
-    .map(([ver, val]): VerSemRun => [ver, semver.parse(ver), val])
+    .map(([ver, run]): VerSemRun => [ver, semver.parse(ver), run])
     .sort(([vera, sema], [verb, semb]) => compare(sema || vera, semb || verb))
     .map(([ver, _, run]) => mapFn(ver, run));
 }

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -2,45 +2,26 @@ import * as semver from 'semver';
 
 import { RunnableVersion } from '../interfaces';
 
-// Electron's approach is nightly -> beta -> stable,
-// so account for 'beta' coming before 'nightly' lexicographically
 function electronSemVerCompare(a: semver.SemVer, b: semver.SemVer) {
   const l = a.compareMain(b);
   if (l) return l;
+  // Electron's approach is nightly -> beta -> stable.
+  // Account for 'beta' coming before 'nightly' lexicographically
   if (a.prerelease[0] === 'nightly' && b.prerelease[0] === 'beta') return -1;
   if (a.prerelease[0] === 'beta' && b.prerelease[0] === 'nightly') return 1;
   return a.comparePre(b);
 }
 
-interface SemRun {
-  sem: semver.SemVer | null;
-  runnable: RunnableVersion;
-}
+function sortByNew(a: semver.SemVer | string, b: semver.SemVer | string) {
+  // non-semver goes first, sorted lexicographically
+  const astr = typeof a === 'string';
+  const bstr = typeof b === 'string';
+  if (astr && bstr) return (a as string).localeCompare(b as string);
+  if (astr) return -1;
+  if (bstr) return 1;
 
-// non-semver goes first, sorted lexicographically
-// then semver, sorted newest-to-oldest
-function compareSemRunByNew(a: SemRun, b: SemRun) {
-  if (!a.sem && !b.sem)
-    return a.runnable.version.localeCompare(b.runnable.version);
-  if (!a.sem) return -1;
-  if (!b.sem) return 1;
-  return -electronSemVerCompare(a.sem!, b.sem!);
-}
-
-/**
- * Returns a new sorted array of RunnableVersions
- *
- * @param {Array<RunnableVersion>} versions - unsorted
- * @returns {Array<RunnableVersion>}
- */
-function sortByNew(versions: RunnableVersion[]): RunnableVersion[] {
-  return versions
-    .map((runnable) => ({
-      runnable,
-      sem: semver.parse(runnable?.version),
-    }))
-    .sort(compareSemRunByNew)
-    .map(({ runnable }) => runnable);
+  // then semver, sorted newest-to-oldest
+  return -electronSemVerCompare(a as semver.SemVer, b as semver.SemVer);
 }
 
 /**
@@ -54,7 +35,16 @@ export function sortedElectronMap<T>(
   versions: Record<string, RunnableVersion>,
   mapFn: (key: string, version: RunnableVersion) => T,
 ) {
-  const runnables = Object.values(versions).filter((r) => r);
-  const sorted = sortByNew(runnables);
-  return sorted.map((runnable) => mapFn(runnable.version, runnable));
+  const map: Map<string | semver.SemVer, RunnableVersion> = new Map(
+    Object.entries(versions).map(([key, val]) => [
+      semver.parse(key) || key,
+      val,
+    ]),
+  );
+  const keys = [...map.keys()].sort(sortByNew);
+  return keys.map((key) => {
+    const ver = typeof key === 'string' ? key : key.version;
+    const run = map.get(key);
+    return mapFn(ver, run!);
+  });
 }

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -12,7 +12,7 @@ function electronSemVerCompare(a: semver.SemVer, b: semver.SemVer) {
   return a.comparePre(b);
 }
 
-function sortByNew(a: semver.SemVer | string, b: semver.SemVer | string) {
+function compare(a: semver.SemVer | string, b: semver.SemVer | string) {
   // non-semver goes first, sorted lexicographically
   const astr = typeof a === 'string';
   const bstr = typeof b === 'string';
@@ -28,20 +28,20 @@ function sortByNew(a: semver.SemVer | string, b: semver.SemVer | string) {
  * Sorts Electron versions and returns the result of a map function.
  *
  * @param {Record<string, RunnableVersion?>} versions
- * @param {(key: string, version: RunnableVersion) => void} mapFn
+ * @param {(key: string, version: RunnableVersion?) => T} mapFn
  * @returns {Array<T>}
  */
 export function sortedElectronMap<T>(
   versions: Record<string, RunnableVersion>,
   mapFn: (key: string, version: RunnableVersion) => T,
 ) {
-  const map: Map<string | semver.SemVer, RunnableVersion> = new Map(
+  const map: Map<semver.SemVer | string, RunnableVersion> = new Map(
     Object.entries(versions).map(([key, val]) => [
       semver.parse(key) || key,
       val,
     ]),
   );
-  const keys = [...map.keys()].sort(sortByNew);
+  const keys = [...map.keys()].sort(compare);
   return keys.map((key) => {
     const ver = typeof key === 'string' ? key : key.version;
     const run = map.get(key);

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -32,13 +32,13 @@ function compare(a: semver.SemVer | string, b: semver.SemVer | string) {
  * @returns {Array<T>}
  */
 export function sortedElectronMap<T>(
-  versions: Record<string, RunnableVersion | null>,
-  mapFn: (key: string, version: RunnableVersion | null) => T,
+  versions: Record<string, RunnableVersion>,
+  mapFn: (key: string, version: RunnableVersion) => T,
 ) {
   type VerSemRun = [
     ver: string,
     sem: semver.SemVer | null,
-    run: RunnableVersion | null,
+    run: RunnableVersion,
   ];
   return Object.entries(versions)
     .map(([ver, val]): VerSemRun => [ver, semver.parse(ver), val])

--- a/src/utils/sorted-electron-map.ts
+++ b/src/utils/sorted-electron-map.ts
@@ -32,19 +32,16 @@ function compare(a: semver.SemVer | string, b: semver.SemVer | string) {
  * @returns {Array<T>}
  */
 export function sortedElectronMap<T>(
-  versions: Record<string, RunnableVersion>,
-  mapFn: (key: string, version: RunnableVersion) => T,
+  versions: Record<string, RunnableVersion | null>,
+  mapFn: (key: string, version: RunnableVersion | null) => T,
 ) {
-  const map: Map<semver.SemVer | string, RunnableVersion> = new Map(
-    Object.entries(versions).map(([key, val]) => [
-      semver.parse(key) || key,
-      val,
-    ]),
-  );
-  const keys = [...map.keys()].sort(compare);
-  return keys.map((key) => {
-    const ver = typeof key === 'string' ? key : key.version;
-    const run = map.get(key);
-    return mapFn(ver, run!);
-  });
+  type VerSemRun = [
+    ver: string,
+    sem: semver.SemVer | null,
+    run: RunnableVersion | null,
+  ];
+  return Object.entries(versions)
+    .map(([ver, val]): VerSemRun => [ver, semver.parse(ver), val])
+    .sort(([vera, sema], [verb, semb]) => compare(sema || vera, semb || verb))
+    .map(([ver, _, run]) => mapFn(ver, run));
 }

--- a/tests/utils/sorted-electron-map-spec.ts
+++ b/tests/utils/sorted-electron-map-spec.ts
@@ -85,8 +85,8 @@ describe('sorted-electron-map', () => {
 
     const result = sortedElectronMap(map, (_k, e) => e);
     expect(result).toStrictEqual<any>([
-      { version: 'moreGarbage' },
       { version: 'garbage' },
+      { version: 'moreGarbage' },
       { version: 'v3.0.0' },
       { version: 'v1.0.0' },
     ]);

--- a/tests/utils/sorted-electron-map-spec.ts
+++ b/tests/utils/sorted-electron-map-spec.ts
@@ -27,29 +27,29 @@ describe('sorted-electron-map', () => {
       '2.0.0-nightly.20200101': {
         version: 'v2.0.0-nightly.20200101',
       },
+      '2.0.0-beta.1': {
+        version: 'v2.0.0-beta.1',
+      },
       '2.0.0-nightly.20200102': {
         version: 'v2.0.0-nightly.20200102',
-      },
-      '2.0.0': {
-        version: 'v2.0.0',
-      },
-      '3.0.0-nightly.20200105': {
-        version: 'v3.0.0-nightly.20200105',
-      },
-      '3.0.0': {
-        version: 'v3.0.0',
       },
       '3.0.0-beta.1': {
         version: 'v3.0.0-beta.1',
       },
-      '2.0.0-beta.1': {
-        version: 'v2.0.0-beta.1',
+      '3.0.0-nightly.20200105': {
+        version: 'v3.0.0-nightly.20200105',
       },
       '2.0.0-beta.2': {
         version: 'v2.0.0-beta.2',
       },
       '2.0.0-beta.3': {
         version: 'v2.0.0-beta.3',
+      },
+      '2.0.0': {
+        version: 'v2.0.0',
+      },
+      '3.0.0': {
+        version: 'v3.0.0',
       },
     };
 

--- a/tests/utils/sorted-electron-map-spec.ts
+++ b/tests/utils/sorted-electron-map-spec.ts
@@ -85,8 +85,8 @@ describe('sorted-electron-map', () => {
 
     const result = sortedElectronMap(map, (_k, e) => e);
     expect(result).toStrictEqual<any>([
-      { version: 'garbage' },
       { version: 'moreGarbage' },
+      { version: 'garbage' },
       { version: 'v3.0.0' },
       { version: 'v1.0.0' },
     ]);


### PR DESCRIPTION
Refactor sortedElectronMap() to parse the versions strings less often.

Calls to `semver.valid()`, `semver.prerelease()`, `semver.coerce()`, and `semver.gt()` keep causing the version string to be  reparsed. This refactor calls `semver.parse()` once per RunnableVersion and uses that object for the compare function. For our current startup, this drops the number of times `semver.parse()` is called on startup from 50k times to 4k times.
