### PR TITLE
feat: add Runner.autobisect()

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "semver": "^7.3.4",
     "tmp": "0.2.1",
     "tslib": "^2.1.0",
-    "update-electron-app": "^2.0.1"
+    "update-electron-app": "^2.0.1",
+    "valid-url": "^1.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",
@@ -85,6 +86,7 @@
     "@types/react-dom": "^16.9.11",
     "@types/semver": "^7.3.4",
     "@types/tmp": "0.2.0",
+    "@types/valid-url": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "cross-fetch": "^3.1.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,6 +44,12 @@ export interface EditorValues {
   package?: string;
 }
 
+export enum RunResult {
+  SUCCESS = 'success', // exit code === 0
+  FAILURE = 'failure', // ran, but exit code !== 0
+  INVALID = 'invalid', // could not run
+}
+
 export interface RunnableVersion extends Version {
   state: VersionState;
   source: VersionSource;

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -2,6 +2,7 @@ import { autorun } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { MosaicContext } from 'react-mosaic-component';
+import { isWebUri } from 'valid-url';
 
 import { OutputEntry } from '../../interfaces';
 import { AppState } from '../state';
@@ -87,14 +88,24 @@ export class Output extends React.Component<CommandsProps> {
       ? { whiteSpace: 'initial' }
       : {};
 
-    return lines.map((text, lineIndex) => (
-      <div key={`${entry.timestamp}--${index}--${lineIndex}`}>
-        <span style={style} className="output-message">
-          {timestamp}
-          {text}
-        </span>
-      </div>
-    ));
+    const renderLine = (text: string, lineIndex: number): JSX.Element =>
+      isWebUri(text) ? (
+        <div key={`${entry.timestamp}--${index}--${lineIndex}`}>
+          <span style={style} className="output-message">
+            {timestamp}
+            <a href={text}>{text}</a>
+          </span>
+        </div>
+      ) : (
+        <div key={`${entry.timestamp}--${index}--${lineIndex}`}>
+          <span style={style} className="output-message">
+            {timestamp}
+            {text}
+          </span>
+        </div>
+      );
+
+    return lines.map(renderLine);
   }
 
   public render(): JSX.Element | null {

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -27,7 +27,7 @@ export enum ForgeCommands {
   MAKE = 'make',
 }
 
-const resultString: Record<RunResult, string> = Object.seal({
+const resultString: Record<RunResult, string> = Object.freeze({
   [RunResult.FAILURE]: '❌ failed',
   [RunResult.INVALID]: '❓ invalid',
   [RunResult.SUCCESS]: '✅ passed',

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -8,12 +8,22 @@ import { arrayToStringMap } from '../../src/utils/array-to-stringmap';
 export const mockVersionsArray = [
   {
     state: VersionState.ready,
+    version: '2.0.3',
+    source: VersionSource.remote,
+  },
+  {
+    state: VersionState.ready,
     version: '2.0.2',
     source: VersionSource.remote,
   },
   {
     state: VersionState.ready,
     version: '2.0.1',
+    source: VersionSource.remote,
+  },
+  {
+    state: VersionState.ready,
+    version: '2.0.0',
     source: VersionSource.remote,
   },
   {

--- a/tests/mocks/runner.ts
+++ b/tests/mocks/runner.ts
@@ -1,4 +1,5 @@
 export class RunnerMock {
+  public autobisect = jest.fn();
   public run = jest.fn();
   public stop = jest.fn();
 }

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -31,6 +31,11 @@ exports[`VersionSelect component renders 1`] = `
             "state": "ready",
             "version": "1.8.7",
           },
+          "2.0.0": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.0",
+          },
           "2.0.1": Object {
             "source": "remote",
             "state": "ready",
@@ -40,6 +45,11 @@ exports[`VersionSelect component renders 1`] = `
             "source": "remote",
             "state": "ready",
             "version": "2.0.2",
+          },
+          "2.0.3": Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.3",
           },
           "3.0.0-unsupported": Object {
             "source": "remote",
@@ -52,12 +62,22 @@ exports[`VersionSelect component renders 1`] = `
           Object {
             "source": "remote",
             "state": "ready",
+            "version": "2.0.3",
+          },
+          Object {
+            "source": "remote",
+            "state": "ready",
             "version": "2.0.2",
           },
           Object {
             "source": "remote",
             "state": "ready",
             "version": "2.0.1",
+          },
+          Object {
+            "source": "remote",
+            "state": "ready",
+            "version": "2.0.0",
           },
           Object {
             "source": "remote",

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -205,6 +205,33 @@ exports[`ElectronSettings component renders 1`] = `
           </td>
         </tr>
         <tr
+          key="2.0.3"
+        >
+          <td>
+            2.0.3
+          </td>
+          <td>
+            <span>
+              <Blueprint3.Icon
+                icon="box"
+              />
+               
+              Downloaded
+            </span>
+          </td>
+          <td
+            className="action"
+          >
+            <Blueprint3.Button
+              fill={true}
+              icon="trash"
+              onClick={[Function]}
+              small={true}
+              text="Delete"
+            />
+          </td>
+        </tr>
+        <tr
           key="2.0.2"
         >
           <td>
@@ -237,6 +264,33 @@ exports[`ElectronSettings component renders 1`] = `
         >
           <td>
             2.0.1
+          </td>
+          <td>
+            <span>
+              <Blueprint3.Icon
+                icon="box"
+              />
+               
+              Downloaded
+            </span>
+          </td>
+          <td
+            className="action"
+          >
+            <Blueprint3.Button
+              fill={true}
+              icon="trash"
+              onClick={[Function]}
+              small={true}
+              text="Delete"
+            />
+          </td>
+        </tr>
+        <tr
+          key="2.0.0"
+        >
+          <td>
+            2.0.0
           </td>
           <td>
             <span>

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { IpcEvents } from '../../src/ipc-events';
 import { getIsDownloaded } from '../../src/renderer/binary';
 import { ipcRendererManager } from '../../src/renderer/ipc';
+import { RunResult } from '../../src/interfaces';
 import {
   findModulesInEditors,
   getIsPackageManagerInstalled,
@@ -11,6 +12,7 @@ import {
   packageRun,
 } from '../../src/renderer/npm';
 import { ForgeCommands, Runner } from '../../src/renderer/runner';
+import { waitFor } from '../../src/utils/wait-for';
 import { AppState } from '../../src/renderer/state';
 import { MockChildProcess } from '../mocks/child-process';
 import { ElectronFiddleMock } from '../mocks/electron-fiddle';
@@ -62,11 +64,20 @@ describe('Runner component', () => {
     (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
     (spawn as any).mockReturnValueOnce(mockChild);
 
-    expect(await instance.run()).toBe(true);
+    // start a session
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
+    expect(store.isRunning).toBe(true);
+
+    // have the session's electron process exit with success
+    mockChild.emit('close', 0);
+    expect(await runPromise).toBe(RunResult.SUCCESS);
+    expect(store.isRunning).toBe(false);
+
+    // inspect what happened
     expect(getIsDownloaded).toHaveBeenCalled();
     expect(window.ElectronFiddle.app.fileManager.saveToTemp).toHaveBeenCalled();
     expect(installModules).toHaveBeenCalled();
-    expect(store.isRunning).toBe(true);
   });
 
   it('runs with logging when enabled', async () => {
@@ -78,44 +89,88 @@ describe('Runner component', () => {
       return mockChild;
     });
 
-    expect(await instance.run()).toBe(true);
+    // run a mock session that exits with sucess
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
+    mockChild.emit('close', 0);
+    expect(await runPromise).toBe(RunResult.SUCCESS);
+    expect(store.isRunning).toBe(false);
+
+    // inspect what happened
     expect(getIsDownloaded).toHaveBeenCalled();
     expect(window.ElectronFiddle.app.fileManager.saveToTemp).toHaveBeenCalled();
     expect(installModules).toHaveBeenCalled();
-    expect(store.isRunning).toBe(true);
   });
 
-  it('emits output', async () => {
+  it('emits output with exitCode', async () => {
     (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
     (spawn as any).mockReturnValueOnce(mockChild);
 
-    // Output
-    expect(await instance.run()).toBe(true);
+    // run a mock session that says 'hi' twice, then exit(0)
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
     mockChild.stdout.emit('data', 'hi');
     mockChild.stderr.emit('data', 'hi');
-    expect(store.pushOutput).toHaveBeenCalledTimes(7);
-
-    // Stop (with code)
     mockChild.emit('close', 0);
+    expect(await runPromise).toBe(RunResult.SUCCESS);
+    expect(store.isRunning).toBe(false);
+
+    // check the output
+    expect(store.pushOutput).toHaveBeenCalledTimes(8);
     expect(store.pushOutput).toHaveBeenLastCalledWith(
       'Electron exited with code 0.',
     );
+  });
 
-    // Stop (without code)
-    mockChild.emit('close');
-    expect(store.pushOutput).toHaveBeenLastCalledWith('Electron exited.');
+  it('returns failure when app exits nonzero', async () => {
+    (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
+    (spawn as any).mockReturnValueOnce(mockChild);
+    const ARBITRARY_FAIL_CODE = 50;
 
+    // run a mock session that says 'hi' twice, then exits w/o code
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
+    mockChild.emit('close', ARBITRARY_FAIL_CODE);
+    expect(await runPromise).toBe(RunResult.FAILURE);
     expect(store.isRunning).toBe(false);
+
+    // check the output
+    expect(store.pushOutput).toHaveBeenLastCalledWith(
+      `Electron exited with code ${ARBITRARY_FAIL_CODE}.`,
+    );
+  });
+
+  it('emits output without exitCode', async () => {
+    (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
+    (spawn as any).mockReturnValueOnce(mockChild);
+
+    // run a mock session that says 'hi' twice, then exits w/o code
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
+    mockChild.stdout.emit('data', 'hi');
+    mockChild.stderr.emit('data', 'hi');
+    mockChild.emit('close');
+    expect(await runPromise).toBe(RunResult.INVALID);
+    expect(store.isRunning).toBe(false);
+
+    // check the output
+    expect(store.pushOutput).toHaveBeenCalledTimes(8);
+    expect(store.pushOutput).toHaveBeenLastCalledWith('Electron exited.');
   });
 
   it('stops on close', async () => {
     (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
     (spawn as any).mockReturnValueOnce(mockChild);
+    mockChild.kill.mockImplementationOnce(() => mockChild.emit('close'));
 
-    // Stop
-    expect(await instance.run()).toBe(true);
+    // start
+    const runPromise = instance.run();
+    await waitFor(() => store.isRunning);
     expect(store.isRunning).toBe(true);
+
+    // stop while running
     instance.stop();
+    expect(await runPromise).toBe(RunResult.INVALID);
     expect(store.isRunning).toBe(false);
   });
 
@@ -124,16 +179,17 @@ describe('Runner component', () => {
     (spawn as any).mockReturnValueOnce(mockChild);
 
     // Stop
-    expect(await instance.run()).toBe(true);
-    mockChild.emit('close', 0);
+    setTimeout(() => mockChild.emit('close', 0));
+    expect(await instance.run()).toBe(RunResult.SUCCESS);
+
     expect(store.isRunning).toBe(false);
   });
 
   describe('run()', () => {
     it('cleans the app data dir after a run', async (done) => {
       (spawn as any).mockReturnValueOnce(mockChild);
-      expect(await instance.run()).toBe(true);
-      mockChild.emit('close', 0);
+      setTimeout(() => mockChild.emit('close', 0));
+      expect(await instance.run()).toBe(RunResult.SUCCESS);
 
       process.nextTick(() => {
         expect(
@@ -148,9 +204,10 @@ describe('Runner component', () => {
 
     it('does not clean the app data dir after a run if configured', async (done) => {
       (instance as any).appState.isKeepingUserDataDirs = true;
+
+      setTimeout(() => mockChild.emit('close', 0));
       (spawn as any).mockReturnValueOnce(mockChild);
-      expect(await instance.run()).toBe(true);
-      mockChild.emit('close', 0);
+      expect(await instance.run()).toBe(RunResult.SUCCESS);
 
       process.nextTick(() => {
         expect(
@@ -163,16 +220,18 @@ describe('Runner component', () => {
     it('automatically cleans the console when enabled', async () => {
       store.isClearingConsoleOnRun = true;
       (findModulesInEditors as any).mockReturnValueOnce(['fake-module']);
+
+      setTimeout(() => mockChild.emit('close', 0));
       (spawn as any).mockReturnValueOnce(mockChild);
-      expect(await instance.run()).toBe(true);
+      expect(await instance.run()).toBe(RunResult.SUCCESS);
+
       expect(store.clearConsole).toHaveBeenCalled();
-      mockChild.emit('close', 0);
     });
 
     it('does not run version not yet downloaded', async () => {
       (getIsDownloaded as jest.Mock).mockReturnValueOnce(false);
 
-      expect(await instance.run()).toBe(false);
+      expect(await instance.run()).toBe(RunResult.INVALID);
     });
 
     it('does not run if writing files fails', async () => {
@@ -181,7 +240,7 @@ describe('Runner component', () => {
         throw new Error('bwap bwap');
       });
 
-      expect(await instance.run()).toBe(false);
+      expect(await instance.run()).toBe(RunResult.INVALID);
     });
 
     it('does not run if installing modules fails', async () => {
@@ -194,7 +253,7 @@ describe('Runner component', () => {
           throw new Error('Bwap-bwap');
         });
 
-      expect(await instance.run()).toBe(false);
+      expect(await instance.run()).toBe(RunResult.INVALID);
 
       console.error = oldError;
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,6 +2349,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/valid-url@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.3.tgz#a124389fb953559c7f889795a98620e91adb3687"
+  integrity sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -12720,6 +12725,11 @@ v8-to-istanbul@^7.0.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Add `Runner.autobisect()` + full coverage testing.

Found a couple of edge cases, e.g. we want to make sure that the 'good' version is actually good and 'bad' version is actually bad -- the user might be wrong / the test doesn't work everywhere / etc. So we do now check that the 'good' version and 'bad' version didn't return the same RunResult.

Getting into the home stretch now; GUI + CLI are up next.