### PR TITLE
refactor: limit tmpdir scope to tests that need them

### DIFF
--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -103,21 +103,6 @@ function CreateWindowStub() {
   };
 }
 
-let fakeUserDataPath: string;
-
-function getFakeUserDataPath() {
-  if (!fakeUserDataPath) {
-    const tmp = require('tmp');
-    tmp.setGracefulCleanup();
-    const tmpdir = tmp.dirSync({
-      template: 'electron-fiddle-tests--user-data-XXXXXX',
-      unsafeCleanup: true, // remove everything
-    });
-    fakeUserDataPath = tmpdir.name;
-  }
-  return fakeUserDataPath;
-}
-
 const app = {
   getName: jest.fn().mockReturnValue('Electron Fiddle'),
   exit: jest.fn(),
@@ -135,7 +120,7 @@ const app = {
   })),
   getLoginItemSettings: jest.fn(),
   getPath: jest.fn((name: string) => {
-    if (name === 'userData') return getFakeUserDataPath();
+    if (name === 'userData') return '/Users/fake-user';
     if (name === 'home') return `~`;
     return '/test-path';
   }),


### PR DESCRIPTION
A small refactor to the content-spec. I recently added a tmpdir for the content-spec to test live unzipping, but think I scoped the code wrong. The feature is only needed in content-spec, so that's where it should live instead of in the `tests/mocks/` helpers.

* In terms of sprawl, this is a good thing because the tmpdir scaffolding now has a narrower scope.
* Since our jest config calls resetMocks() between tests, it's preferable to KISS our mocks' default state.