### PR TITLE
perf: faster isReleasedMajor()

### DIFF
--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -100,8 +100,7 @@ function isReleasedMajor(version: semver.SemVer) {
     .filter((version) => version.source === VersionSource.remote)
     .map((version) => semver.parse(version.version))
     .filter((version) => !!version)
-    .sort((a: semver.SemVer, b: semver.SemVer) => semver.compare(a, b))
-    .pop();
+    .reduce((acc, cur) => (acc && acc.compare(cur!) > 0 ? acc : cur));
   return newestRelease && version.major <= newestRelease.major;
 }
 


### PR DESCRIPTION
A small change to some code I wrote last week that keeps showing up with a larger-than-necessary footprint in the coverage tests. To get the max item from a `semver.SemVer[]` we don't need to sort the array; we can walk the array with reduce().

Brings this line from O(n log n) to O(n).