### PR TITLE
feat: add an icon for Electron DLs being unzipped

### DIFF
--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -42,11 +42,16 @@ export function getItemLabel({ source, state, name }: RunnableVersion): string {
  * @returns
  */
 export function getItemIcon({ state }: RunnableVersion) {
-  return state === 'ready'
-    ? 'saved'
-    : state === 'downloading'
-    ? 'cloud-download'
-    : 'cloud';
+  switch (state) {
+    case VersionState.unknown:
+      return 'cloud';
+    case VersionState.ready:
+      return 'saved';
+    case VersionState.downloading:
+      return 'cloud-download';
+    case VersionState.unzipping:
+      return 'compressed';
+  }
 }
 
 /**

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -16,7 +16,7 @@ import {
 import { ElectronReleaseChannel } from '../../../src/renderer/versions';
 import { mockVersions } from '../../mocks/electron-versions';
 
-const { ready, unknown, downloading } = VersionState;
+const { downloading, ready, unknown, unzipping } = VersionState;
 const { remote, local } = VersionSource;
 
 describe('VersionSelect component', () => {
@@ -133,14 +133,15 @@ describe('VersionSelect component', () => {
 
   describe('getItemIcon()', () => {
     it('returns the correct icon', () => {
-      const vDownloaded = { ...mockVersion1, state: ready };
-      expect(getItemIcon(vDownloaded)).toBe('saved');
-
-      const vDownloading = { ...mockVersion1, state: downloading };
-      expect(getItemIcon(vDownloading)).toBe('cloud-download');
-
-      const vUnknown = { ...mockVersion1, state: unknown };
-      expect(getItemIcon(vUnknown)).toBe('cloud');
+      const icons: Array<{ state: VersionState; expected: string }> = [
+        { state: downloading, expected: 'cloud-download' },
+        { state: ready, expected: 'saved' },
+        { state: unknown, expected: 'cloud' },
+        { state: unzipping, expected: 'compressed' },
+      ];
+      icons.forEach(({ state, expected }) => {
+        expect(getItemIcon({ ...mockVersion1, state })).toBe(expected);
+      });
     });
   });
 


### PR DESCRIPTION
Right now there's a visual wart that during a download the icon goes from 'cloud' (unknown) -> 'cloud-download' (downloading) -> 'cloud' (unzipping) -> 'saved' (saved) and that second shortlived 'cloud' during unzip is a little confusing because for a moment it looks like the download has disappeared. 

This PR uses 'compressed' as the icon during unzip to avoid giving the user that mixed signal.