### PR TITLE
fix: remove unexported member in task-runner-spec

### DIFF
--- a/tests/renderer/task-runner-spec.tsx
+++ b/tests/renderer/task-runner-spec.tsx
@@ -11,7 +11,7 @@ import { IpcEvents } from '../../src/ipc-events';
 
 import { App } from '../../src/renderer/app';
 import { TaskRunner } from '../../src/renderer/task-runner';
-import { ipcRendererManager, IpcRendererManager } from '../../src/renderer/ipc';
+import { ipcRendererManager } from '../../src/renderer/ipc';
 import { AppMock } from '../mocks/app';
 import { MockState } from '../mocks/state';
 
@@ -19,7 +19,7 @@ describe('Task Runner component', () => {
   let app: AppMock;
   let appState: MockState;
   let runner: any;
-  let ipc: IpcRendererManager;
+  let ipc: any;
 
   function makeRunnables(versions: string[]): RunnableVersion[] {
     return versions.map((version) => ({


### PR DESCRIPTION
It seems like #623 makes the tests fail because `IpcRendererManager` is no longer exported. This PR fixes that.