### PR TITLE
refactor: remove extract-zip from direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "electron-default-menu": "^1.0.2",
     "electron-devtools-installer": "^3.1.1",
     "electron-squirrel-startup": "^1.0.0",
-    "extract-zip": "^2.0.1",
     "fix-path": "^3.0.0",
     "fs-extra": "^9.1.0",
     "mobx": "^5.15.7",

--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import extract from 'extract-zip';
+import decompress from 'decompress';
 
 import { VersionState } from '../interfaces';
 import { normalizeVersion } from '../utils/normalize-version';
@@ -244,7 +244,7 @@ async function unzip(zipPath: string, dir: string): Promise<void> {
   process.noAsar = true;
 
   try {
-    await extract(zipPath, { dir });
+    await decompress(zipPath, dir);
     console.log(`Binary: Unpacked!`);
   } finally {
     process.noAsar = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5525,7 +5525,7 @@ extract-zip@^1.0.3:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
-extract-zip@^2.0.0, extract-zip@^2.0.1:
+extract-zip@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==


### PR DESCRIPTION
Another minor cleanup PR after the recent whirlwind of commits.

`decompress` was recently added as a direct dependency in package.json. `extract-zip` was already a direct dependency. The two modules are very similar. The reason for choosing one over the other is renderer/content.ts needs to be able to operate on an input stream instead of an input file. `decompress` can do that, so it wins.

In practice this doesn't shrink our footprint since both are still required in our dependency tree [electron-rebuild -> got -> decompress] and [electron-repackager -> extract-zip], but at least this way it's not blocked by anything in Electron Fiddle.