### PR TITLE
feat: add About to Help menu

### DIFF
--- a/src/main/about-panel.ts
+++ b/src/main/about-panel.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { AboutPanelOptionsOptions, app } from 'electron';
+import { app } from 'electron';
 
 /**
  * Sets Fiddle's About panel options on Linux and macOS

--- a/src/main/about-panel.ts
+++ b/src/main/about-panel.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { AboutPanelOptionsOptions, app } from 'electron';
 
 /**
@@ -6,24 +8,17 @@ import { AboutPanelOptionsOptions, app } from 'electron';
  * @returns
  */
 export function setupAboutPanel(): void {
-  if (process.platform === 'win32') return;
+  const contribFile = path.join(__dirname, '../../../static/contributors.json');
+  const iconPath = path.resolve(__dirname, '../../../assets/icons/fiddle.png');
 
-  const options: AboutPanelOptionsOptions = {
+  app.setAboutPanelOptions({
     applicationName: 'Electron Fiddle',
     applicationVersion: app.getVersion(),
-    version: process.versions.electron,
+    authors: fs.readJSONSync(contribFile).map(({ name }) => name),
     copyright: '© Electron Authors',
-  };
-
-  switch (process.platform) {
-    case 'linux':
-      options.website = 'https://electronjs.org/fiddle';
-    case 'darwin':
-      options.credits =
-        'https://github.com/electron/fiddle/graphs/contributors';
-    default:
-    // fallthrough
-  }
-
-  app.setAboutPanelOptions(options);
+    credits: 'https://github.com/electron/fiddle/graphs/contributors',
+    iconPath,
+    version: process.versions.electron,
+    website: 'https://electronjs.org/fiddle',
+  });
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -76,6 +76,15 @@ function getHelpItems(): Array<MenuItemConstructorOptions> {
         shell.openExternal('https://github.com/electron/electron/issues');
       },
     },
+    {
+      type: 'separator',
+    },
+    {
+      label: 'About Electron Fiddle',
+      click() {
+        app.showAboutPanel();
+      },
+    },
   ];
 }
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -31,7 +31,9 @@ function isSubmenu(
  * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getHelpItems(): Array<MenuItemConstructorOptions> {
-  const items = [
+  const items: MenuItemConstructorOptions[] = [];
+
+  items.push(
     {
       type: 'separator',
     },
@@ -76,7 +78,7 @@ function getHelpItems(): Array<MenuItemConstructorOptions> {
         shell.openExternal('https://github.com/electron/electron/issues');
       },
     },
-  ];
+  );
 
   // on macOS, there's already the About Electron Fiddle menu item
   // under the first submenu set by the electron-default-menu package

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -31,7 +31,7 @@ function isSubmenu(
  * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getHelpItems(): Array<MenuItemConstructorOptions> {
-  return [
+  const items = [
     {
       type: 'separator',
     },
@@ -76,16 +76,25 @@ function getHelpItems(): Array<MenuItemConstructorOptions> {
         shell.openExternal('https://github.com/electron/electron/issues');
       },
     },
-    {
-      type: 'separator',
-    },
-    {
-      label: 'About Electron Fiddle',
-      click() {
-        app.showAboutPanel();
-      },
-    },
   ];
+
+  // on macOS, there's already the About Electron Fiddle menu item
+  // under the first submenu set by the electron-default-menu package
+  if (process.platform !== 'darwin') {
+    items.push(
+      {
+        type: 'separator',
+      },
+      {
+        label: 'About Electron Fiddle',
+        click() {
+          app.showAboutPanel();
+        },
+      },
+    );
+  }
+
+  return items;
 }
 
 /**


### PR DESCRIPTION
As @malept reported in #631, we have code to set up the About panel but never use it. This PR adds a Help menuitem to do so.

The previous code  had separate handling for different platforms -- setupAboutPanel() was a no-op on Windows, and then filled in vairous AboutPanelOptions based on platform. Since this setup is cheap, this PR just sets everything unconditionally and leaves it to Electron to decide what to use.

Doing it this way seems more straightforward, but I'm wondering what that `if (process.platform === 'win32') return` was for. It was introduced in https://github.com/electron/fiddle/commit/14279283d648ea73a1853fc972c453a9b40ee725.

Fixes #631.