### PR TITLE
fix: installers for nightlies

### DIFF
--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -16,7 +16,10 @@ const definitionPath = path.join(USER_DATA_PATH, 'electron-typedef');
  * @returns {Promise<string>}
  */
 export async function fetchTypeDefinitions(version: string): Promise<string> {
-  const url = `https://unpkg.com/electron@${version}/electron.d.ts`;
+  const packageName = version.includes('nightly')
+    ? 'electron-nightly'
+    : 'electron';
+  const url = `https://unpkg.com/${packageName}@${version}/electron.d.ts`;
 
   let text: string;
   try {

--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -138,7 +138,7 @@ export async function installModules(
   let nameArgs: Array<string> = [];
 
   if (packageManager === 'npm') {
-    nameArgs = names.length > 0 ? ['-S', ...names] : ['--dev --prod'];
+    nameArgs = names.length > 0 ? ['-S', ...names] : ['--also=dev --prod'];
   } else {
     nameArgs = [...names];
   }

--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -1,5 +1,7 @@
+import { execSync } from 'child_process';
 import { Files } from '../../interfaces';
 import { PACKAGE_NAME } from '../../shared-constants';
+import { getElectronBinaryPath } from '../binary';
 
 /**
  * This transform turns the files into an electron-forge
@@ -34,6 +36,19 @@ export async function forgeTransform(files: Files): Promise<Files> {
       parsed.config = parsed.config || {};
       parsed.config.forge = {};
       parsed.config.forge.packagerConfig = {};
+
+      const nightlyVersion = parsed.devDependencies['electron-nightly'];
+      if (nightlyVersion) {
+        // Fetch forced ABI for nightly.
+        const binaryPath = getElectronBinaryPath(nightlyVersion);
+        const abi = execSync(
+          `ELECTRON_RUN_AS_NODE=1 "${binaryPath}" -p process.versions.modules`,
+        );
+
+        parsed.config.forge.electronRebuildConfig = {
+          forceABI: abi.toString().trim(),
+        };
+      }
 
       // electron-forge makers
       parsed.config.forge.makers = [

--- a/src/utils/get-package.ts
+++ b/src/utils/get-package.ts
@@ -35,7 +35,10 @@ export async function getPackageJson(
   const dependencies: Record<string, string> = {};
 
   if (includeElectron) {
-    devDependencies.electron = appState.version;
+    const packageName = appState.version?.includes('nightly')
+      ? 'electron-nightly'
+      : 'electron';
+    devDependencies[packageName] = appState.version;
   }
 
   if (includeDependencies && values) {

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -220,7 +220,7 @@ describe('npm', () => {
 
         expect(exec).toHaveBeenCalledWith<any>(
           '/my/directory',
-          'npm install --dev --prod',
+          'npm install --also=dev --prod',
         );
       });
     });

--- a/tests/utils/get-package-spec.ts
+++ b/tests/utils/get-package-spec.ts
@@ -47,6 +47,51 @@ describe('get-package', () => {
     );
   });
 
+  it('getPackageJson() includes electron-nightly if needed', async () => {
+    const result = await getPackageJson(
+      {
+        getName: () => 'test-app',
+        version: '1.0.0-nightly.123456789',
+      } as any,
+      {
+        main: 'app.goDoTheThing()',
+        renderer: `const say = require('say')`,
+        html: '<html />',
+        preload: 'preload',
+        css: 'body { color: black }',
+      },
+      {
+        includeElectron: true,
+        includeDependencies: true,
+      },
+    );
+
+    expect(result).toEqual(
+      JSON.stringify(
+        {
+          name: 'test-app',
+          productName: 'test-app',
+          description: 'My Electron application description',
+          keywords: [],
+          main: './main.js',
+          version: '1.0.0',
+          author: 'test-user',
+          scripts: {
+            start: 'electron .',
+          },
+          dependencies: {
+            say: '*',
+          },
+          devDependencies: {
+            'electron-nightly': '1.0.0-nightly.123456789',
+          },
+        },
+        undefined,
+        2,
+      ),
+    );
+  });
+
   it('getPackageJson() includes electron if needed', async () => {
     const result = await getPackageJson(
       {


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/392.

Fixes packaging nightly builds. Also fixes fetching types for nightly builds.

Nightlies come from electron-nightly and not electron, so we need to change the name in package.json. We also need to force a new ABI number as none has been assigned for nightlies.

Tested on macOS.