### PR TITLE
refactor: add getVersionState()

### DIFF
--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -6,6 +6,7 @@ import {
   VersionSource,
   VersionState,
 } from '../interfaces';
+import { getVersionState } from './binary';
 import { normalizeVersion } from '../utils/normalize-version';
 
 /**
@@ -135,6 +136,7 @@ function saveVersions(key: VersionKeys, versions: Array<Version>) {
 
 function sanitizeVersion(ver: RunnableVersion): RunnableVersion {
   ver.version = normalizeVersion(ver.version);
+  ver.state = getVersionState(ver);
   return ver;
 }
 

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -26,6 +26,3 @@ export class MockVersions {
     this.mockVersionsArray = arr;
   }
 }
-
-// export static instances for the tests that still use them
-export const { mockVersions, mockVersionsArray } = new MockVersions();

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -26,3 +26,6 @@ export class MockVersions {
     this.mockVersionsArray = arr;
   }
 }
+
+// export static instances for the tests that still use them
+export const { mockVersions, mockVersionsArray } = new MockVersions();


### PR DESCRIPTION
This refactor replaces `getDownloadingVersions()` and `getDownloadedVersions()` with a new function, `getVersionState()` which is intended to be more flexible in that it can also determine any state a Version is in, rather than just downloading/downloaded. For example, is it being unzipped at the moment.

This is an interim step towards dual goals of (a) adding a new state of "downloaded but zipped" for https://github.com/electron/fiddle/issues/644 and (b) cleanup to `state.versions` s.t. we don't need to keep rebuilding all those mobx proxies all the time.