### PR TITLE
test: improve binary spec coverage

### DIFF
--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -26,6 +26,3 @@ export class MockVersions {
     this.mockVersionsArray = arr;
   }
 }
-
-// export static instances for the tests that still use them
-export const { mockVersions, mockVersionsArray } = new MockVersions();

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -26,3 +26,6 @@ export class MockVersions {
     this.mockVersionsArray = arr;
   }
 }
+
+// export static instances for the tests that still use them
+export const { mockVersions, mockVersionsArray } = new MockVersions();


### PR DESCRIPTION
No functional changes, not even a refactor.

Just adds coverage for a couple of pieces in `renderer/binary`!