### PR TITLE
refactor: resize console with `replaceWith` API

### DIFF
--- a/src/renderer/components/output-editors-wrapper.tsx
+++ b/src/renderer/components/output-editors-wrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Mosaic, MosaicNode } from 'react-mosaic-component';
+import { Mosaic, MosaicNode, MosaicParent } from 'react-mosaic-component';
 
 import { AppState } from '../state';
 import { Editors } from './editors';
@@ -49,13 +49,12 @@ export class OutputEditorsWrapper extends React.Component<
     );
   }
 
-  private onChange = (currentNode: any) => {
-    const isConsoleShowing = currentNode.splitPercentage !== 0;
+  private onChange = (rootNode: MosaicParent<WrapperMosaicId>) => {
+    const isConsoleShowing = rootNode.splitPercentage !== 0;
 
     if (isConsoleShowing !== this.props.appState.isConsoleShowing) {
       this.props.appState.isConsoleShowing = isConsoleShowing;
     }
-
-    this.setState({ mosaicArrangement: currentNode });
+    this.setState({ mosaicArrangement: rootNode });
   };
 }

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -4,32 +4,17 @@ import * as React from 'react';
 import { Output } from '../../../src/renderer/components/output';
 import { MockState } from '../../mocks/state';
 
-let mockContext: any = {};
-
-jest.mock('react-mosaic-component', () => {
-  const { MosaicContext, MosaicRootActions } = jest.requireActual(
-    'react-mosaic-component',
-  );
-
-  return {
-    MosaicContext,
-    MosaicRootActions,
-  };
-});
-
-beforeAll(() => {
-  mockContext = {
-    mosaicActions: {
-      expand: jest.fn(),
-      remove: jest.fn(),
-      hide: jest.fn(),
-      replaceWith: jest.fn(),
-      updateTree: jest.fn(),
-      getRoot: jest.fn(),
-    },
-    mosaicId: 'output',
-  };
-});
+const mockContext = {
+  mosaicActions: {
+    expand: jest.fn(),
+    remove: jest.fn(),
+    hide: jest.fn(),
+    replaceWith: jest.fn(),
+    updateTree: jest.fn(),
+    getRoot: jest.fn(),
+  },
+  mosaicId: 'output',
+};
 
 describe('Output component', () => {
   let store: any;
@@ -87,13 +72,20 @@ describe('Output component', () => {
       disableLifecycleMethods: true,
     });
 
+    mockContext.mosaicActions.getRoot.mockReturnValue({
+      direction: 'row',
+      first: 'output',
+      second: 'editors',
+    });
+
     wrapper.instance().context = mockContext;
     wrapper.instance().componentDidMount!();
 
-    expect(mockContext.mosaicActions.expand).toHaveBeenCalledWith(
-      ['first'],
-      25,
+    expect(mockContext.mosaicActions.replaceWith).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ splitPercentage: 25 }),
     );
+    expect(wrapper.html()).not.toBe(null);
 
     store.isConsoleShowing = false;
 


### PR DESCRIPTION
This refactor PR replaces the `this.context.mosaicActions` function that we use to expand and hide the console.

### Background

In `react-mosaic`, information about the current layout is stored in a binary tree of `MosaicNode<T>` objects. An object might looks like this, where `first` and `second` are child nodes:

```js
{
  direction: 'row', // or 'column'
  first: 'panel1',
  second: 'panel2',
  splitPercentage: 50 // between 0 and 100
}
```

The most important value for this PR is `splitPercentage`, which defines the percentage of area that the first item occupies (in the case above, both panels occupy half of the available space).

The module's advanced API allows you to programmatically modify this tree through React Context (available in `this.context.mosaicActions`. We currently use [`this.context.mosaicActions.expand()`](https://github.com/nomcopter/react-mosaic/blob/a80ebd407516e5b9040f8a943b9a41bd9da23835/src/contextTypes.ts#L34)  to set the console's screen real estate to either 25% or 0%. 

### Motivation

The `expand()` function changes the `splitPercentage` property of a Node, but also **bubbles this value up** to the root of the node.

This works for us right now because we only have one level of nodes in our tree. If we ever want to add more complexity to the UI with nested nodes, this function would affect all parent nodes of the console panel.

### Change

Instead of calling `expand()`, we call [`replaceWith()`](https://github.com/nomcopter/react-mosaic/blob/a80ebd407516e5b9040f8a943b9a41bd9da23835/src/contextTypes.ts#L50) to replace the value of the entire tree. This gives us full control of what we want to change.

