### PR TITLE
refactor: avoid global calls in renderer/state

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -21,8 +21,9 @@ import { EMPTY_EDITOR_CONTENT, SORTED_EDITORS } from './constants';
 import { FileManager } from './file-manager';
 import { RemoteLoader } from './remote-loader';
 import { Runner } from './runner';
+import { AppState } from './state';
+import { getElectronVersions } from './versions';
 import { TaskRunner } from './task-runner';
-import { appState } from './state';
 import { getTheme } from './themes';
 import { defaultDark, defaultLight } from './themes-defaults';
 
@@ -35,10 +36,10 @@ import { defaultDark, defaultLight } from './themes-defaults';
 export class App {
   public typeDefDisposable: MonacoType.IDisposable | null = null;
   public monaco: typeof MonacoType | null = null;
-  public state = appState;
-  public fileManager = new FileManager(appState);
-  public remoteLoader = new RemoteLoader(appState);
-  public runner = new Runner(appState);
+  public state = new AppState(getElectronVersions());
+  public fileManager = new FileManager(this.state);
+  public remoteLoader = new RemoteLoader(this.state);
+  public runner = new Runner(this.state);
   public readonly taskRunner: TaskRunner;
 
   constructor() {

--- a/src/renderer/fetch-types.ts
+++ b/src/renderer/fetch-types.ts
@@ -137,8 +137,7 @@ export async function updateEditorTypeDefinitions(
   };
 
   // If this method is called before we're ready, we'll delay this work a bit
-  if (!window.ElectronFiddle.app || !window.ElectronFiddle.app.monaco)
-    return defer();
+  if (!window.ElectronFiddle?.app?.monaco) return defer();
 
   const { app } = window.ElectronFiddle;
   const monaco: typeof MonacoType = app.monaco!;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -53,9 +53,6 @@ import {
   saveLocalVersions,
 } from './versions';
 
-const knownVersions = getElectronVersions();
-const defaultVersion = getDefaultVersion(knownVersions);
-
 /**
  * The application's state. Exported as a singleton below.
  *
@@ -64,7 +61,6 @@ const defaultVersion = getDefaultVersion(knownVersions);
  */
 export class AppState {
   // -- Persisted settings ------------------
-  @observable public version: string = defaultVersion;
   @observable public theme: string | null = localStorage.getItem('theme');
   @observable public gitHubAvatarUrl: string | null = localStorage.getItem(
     'gitHubAvatarUrl',
@@ -116,10 +112,8 @@ export class AppState {
     (this.retrieve('acceleratorsToBlock') as Array<BlockableAccelerator>) || [];
   // -- Various session-only state ------------------
   @observable public gistId: string | undefined;
-  @observable public versions: Record<
-    string,
-    RunnableVersion
-  > = Object.fromEntries(knownVersions.map((ver) => [ver.version, ver]));
+  @observable public versions: Record<string, RunnableVersion>;
+  @observable public version: string;
   @observable public output: Array<OutputEntry> = [];
   @observable public localPath: string | undefined;
   @observable public genericDialogOptions: GenericDialogOptions = {
@@ -165,9 +159,10 @@ export class AppState {
 
   private outputBuffer = '';
   private name: string;
+  private readonly defaultVersion: string;
   public appData: string;
 
-  constructor() {
+  constructor(versions: RunnableVersion[]) {
     // Bind all actions
     this.downloadVersion = this.downloadVersion.bind(this);
     this.pushError = this.pushError.bind(this);
@@ -192,10 +187,16 @@ export class AppState {
     this.hideChannels = this.hideChannels.bind(this);
     this.showChannels = this.showChannels.bind(this);
 
+    // init fields
+    this.versions = Object.fromEntries(versions.map((v) => [v.version, v]));
+    this.defaultVersion = getDefaultVersion(versions);
+    this.version = this.defaultVersion;
+
+    ipcRendererManager.removeAllListeners(IpcEvents.BEFORE_QUIT);
+    ipcRendererManager.removeAllListeners(IpcEvents.BISECT_COMMANDS_TOGGLE);
+    ipcRendererManager.removeAllListeners(IpcEvents.CLEAR_CONSOLE);
     ipcRendererManager.removeAllListeners(IpcEvents.OPEN_SETTINGS);
     ipcRendererManager.removeAllListeners(IpcEvents.SHOW_WELCOME_TOUR);
-    ipcRendererManager.removeAllListeners(IpcEvents.CLEAR_CONSOLE);
-    ipcRendererManager.removeAllListeners(IpcEvents.BISECT_COMMANDS_TOGGLE);
 
     ipcRendererManager.on(IpcEvents.OPEN_SETTINGS, this.toggleSettings);
     ipcRendererManager.on(IpcEvents.SHOW_WELCOME_TOUR, this.showTour);
@@ -325,11 +326,7 @@ export class AppState {
    * one that can be found.
    */
   @computed get currentElectronVersion(): RunnableVersion {
-    if (this.versions[this.version]) {
-      return this.versions[this.version];
-    } else {
-      return this.versions[defaultVersion];
-    }
+    return this.versions[this.version] || this.versions[this.defaultVersion];
   }
 
   /**
@@ -561,10 +558,8 @@ export class AppState {
     const version = normalizeVersion(input);
 
     if (!this.hasVersion(input)) {
-      console.warn(
-        `State: Called setVersion() with ${version}, which does not exist.`,
-      );
-      await this.setVersion(knownVersions[0].version);
+      console.warn(`State: setVersion() got an unknown version ${version}`);
+      await this.setVersion(this.versionsToShow[0].version);
       return;
     }
 
@@ -874,6 +869,3 @@ export class AppState {
     return JSON.parse(value || 'null') as T;
   }
 }
-
-export const appState = new AppState();
-appState.setVersion(appState.version);

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -292,6 +292,8 @@ export class AppState {
     ipcRendererManager.send(IpcEvents.BLOCK_ACCELERATORS, [
       ...this.acceleratorsToBlock,
     ]);
+
+    this.setVersion(this.version);
   }
 
   /**

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -10,17 +10,6 @@ import { defaultDark, defaultLight } from '../../src/renderer/themes-defaults';
 jest.mock('../../src/renderer/file-manager', () =>
   require('../mocks/file-manager'),
 );
-jest.mock('../../src/renderer/state', () => ({
-  appState: {
-    closedPanels: {},
-    getName: () => 'Test',
-    hideChannels: jest.fn(),
-    pushOutput: jest.fn(),
-    setVersion: jest.fn(),
-    showChannels: jest.fn(),
-    theme: 'defaultDark',
-  },
-}));
 jest.mock('../../src/renderer/components/header', () => ({
   Header: () => 'Header;',
 }));


### PR DESCRIPTION
No functional changes. This is another PR like https://github.com/electron/fiddle/pull/642 aimed at simplifying our tests by reducing side-effects / shared state / unintended code execution.

This time around, it's about avoiding the global calls that are made as a side-effect of importing `state.ts`:
* getElectronVersions()
* getDefaultVersion()
* the biggie, everything in AppState.constructor() due to the AppState that is unconditionally created
* appState.setVersion()

This PR removes these so that importing state.ts has no side-effects. In production, state is instantiated by the App in the same way it does runner, fileManager, loader, etc.

*edit:* PR contains no new uncovered code. Coveralls is upset about code removal. :1st_place_medal: 