### PR TITLE
feat: new version filters in File > Preferences > Electron

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,7 +58,6 @@ export const enum ElectronReleaseChannel {
   stable = 'Stable',
   beta = 'Beta',
   nightly = 'Nightly',
-  unsupported = 'Unsupported',
 }
 
 export interface SetFiddleOptions {

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -65,7 +65,7 @@ export class ElectronSettings extends React.Component<
   }
 
   /**
-   * Handles toggline whether to show undownloaded vesions
+   * Toggles visibility of non-downloaded versions
    *
    * @param {React.ChangeEvent<HTMLInputElement>} event
    */
@@ -76,7 +76,7 @@ export class ElectronSettings extends React.Component<
   }
 
   /**
-   * Handles toggline whether to show obsolete vesions
+   * Toggles visibility of obsolete versions
    *
    * @param {React.ChangeEvent<HTMLInputElement>} event
    */

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -597,14 +597,12 @@ export class AppState {
       } catch (err) {
         console.info('TypeDefs: Unable to start watching.');
       }
-    } else {
-      if (!!this.localTypeWatcher) {
-        console.info(
-          `TypeDefs: Switched to downloaded version ${version}. Unwatching local typedefs.`,
-        );
-        this.localTypeWatcher.close();
-        this.localTypeWatcher = undefined;
-      }
+    } else if (!!this.localTypeWatcher) {
+      console.info(
+        `TypeDefs: Switched to downloaded version ${version}. Unwatching local typedefs.`,
+      );
+      this.localTypeWatcher.close();
+      this.localTypeWatcher = undefined;
     }
     await updateEditorTypeDefinitions(ver);
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -83,13 +83,9 @@ export class AppState {
     ElectronReleaseChannel.stable,
     ElectronReleaseChannel.beta,
   ];
-  @observable public statesToShow: Array<VersionState> = (this.retrieve(
-    'statesToShow',
-  ) as Array<VersionState>) || [
-    VersionState.downloading,
-    VersionState.ready,
-    VersionState.unknown,
-  ];
+  @observable public showUndownloadedVersions = !!(
+    this.retrieve('showUndownloadedVersions') ?? true
+  );
   @observable public isKeepingUserDataDirs = !!this.retrieve(
     'isKeepingUserDataDirs',
   );
@@ -229,7 +225,9 @@ export class AppState {
     autorun(() => this.save('executionFlags', this.executionFlags));
     autorun(() => this.save('version', this.version));
     autorun(() => this.save('channelsToShow', this.channelsToShow));
-    autorun(() => this.save('statesToShow', this.statesToShow));
+    autorun(() =>
+      this.save('showUndownloadedVersions', this.showUndownloadedVersions),
+    );
     autorun(() => this.save('packageManager', this.packageManager ?? 'npm'));
     autorun(() => this.save('acceleratorsToBlock', this.acceleratorsToBlock));
 
@@ -336,11 +334,13 @@ export class AppState {
    * current settings for states and channels to display
    */
   @computed get versionsToShow(): Array<RunnableVersion> {
-    const { channelsToShow, statesToShow, versions } = this;
+    const { channelsToShow, showUndownloadedVersions, versions } = this;
 
     const filter = (ver: RunnableVersion) =>
       ver &&
-      statesToShow.includes(ver.state) &&
+      (showUndownloadedVersions ||
+        ver.state === VersionState.unzipping ||
+        ver.state === VersionState.ready) &&
       channelsToShow.includes(getReleaseChannel(ver));
 
     return sortVersions(Object.values(versions).filter(filter));

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -69,10 +69,6 @@ export function getReleaseChannel(
     return ElectronReleaseChannel.nightly;
   }
 
-  if (tag.includes('unsupported')) {
-    return ElectronReleaseChannel.unsupported;
-  }
-
   // Must be a stable version, right?
   return ElectronReleaseChannel.stable;
 }
@@ -315,4 +311,16 @@ function isElectronVersion(
   input: Version | RunnableVersion,
 ): input is RunnableVersion {
   return (input as RunnableVersion).source !== undefined;
+}
+
+export function getOldestSupportedVersion(): string | undefined {
+  const NUM_STABLE_BRANCHES = process.env.NUM_STABLE_BRANCHES || 3;
+
+  const oldestSupported = getElectronVersions()
+    .map(({ version }) => version)
+    .filter((version) => /^\d+\.0\.0$/.test(version))
+    .sort(semver.compare)
+    .slice(-NUM_STABLE_BRANCHES)
+    .shift();
+  return oldestSupported;
 }

--- a/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-version-chooser-spec.tsx.snap
@@ -15,10 +15,6 @@ exports[`VersionSelect component renders 1`] = `
           "version": "2.0.2",
         },
         "setVersion": [MockFunction],
-        "statesToShow": Array [
-          "ready",
-          "downloading",
-        ],
         "version": "2.0.2",
         "versions": Object {
           "1.0.0": Object {

--- a/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-bisect-spec.tsx.snap
@@ -53,9 +53,6 @@ exports[`BisectDialog component renders 1`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -136,9 +133,6 @@ exports[`BisectDialog component renders 1`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -292,9 +286,6 @@ exports[`BisectDialog component renders 2`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -368,9 +359,6 @@ exports[`BisectDialog component renders 2`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -517,9 +505,6 @@ exports[`BisectDialog component renders 3`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -600,9 +585,6 @@ exports[`BisectDialog component renders 3`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -749,9 +731,6 @@ exports[`BisectDialog component renders 4`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -832,9 +811,6 @@ exports[`BisectDialog component renders 4`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -989,9 +965,6 @@ exports[`BisectDialog component renders 5`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",
@@ -1072,9 +1045,6 @@ exports[`BisectDialog component renders 5`] = `
                 "Stable",
               ],
               "setVersion": [MockFunction],
-              "statesToShow": Array [
-                "ready",
-              ],
               "versions": Array [
                 Object {
                   "source": "local",

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -9,8 +9,15 @@ exports[`ElectronSettings component renders 1`] = `
   </h2>
   <Blueprint3.Callout>
     <Blueprint3.FormGroup
-      label="Include Electron versions from these release channels:"
+      label="Show Electron versions:"
     >
+      <Blueprint3.Checkbox
+        checked={false}
+        id="showUndownloadedVersions"
+        inline={true}
+        label="Undownloaded"
+        onChange={[Function]}
+      />
       <Blueprint3.Tooltip
         content="Can't disable channel of selected version (2.0.1)"
         disabled={false}
@@ -91,42 +98,6 @@ exports[`ElectronSettings component renders 1`] = `
           onChange={[Function]}
         />
       </Blueprint3.Tooltip>
-    </Blueprint3.FormGroup>
-    <Blueprint3.FormGroup
-      label="Include Electron versions that are:"
-    >
-      <Blueprint3.Tooltip
-        content="Always enabled"
-        hoverCloseDelay={0}
-        hoverOpenDelay={100}
-        intent="primary"
-        minimal={false}
-        position="bottom"
-        transitionDuration={100}
-      >
-        <Blueprint3.Checkbox
-          checked={true}
-          disabled={true}
-          id="ready"
-          inline={true}
-          label="Ready"
-          onChange={[Function]}
-        />
-      </Blueprint3.Tooltip>
-      <Blueprint3.Checkbox
-        checked={true}
-        id="downloading"
-        inline={true}
-        label="Downloading"
-        onChange={[Function]}
-      />
-      <Blueprint3.Checkbox
-        checked={false}
-        id="unknown"
-        inline={true}
-        label="Not Downloaded"
-        onChange={[Function]}
-      />
     </Blueprint3.FormGroup>
   </Blueprint3.Callout>
   <br />

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -9,15 +9,8 @@ exports[`ElectronSettings component renders 1`] = `
   </h2>
   <Blueprint3.Callout>
     <Blueprint3.FormGroup
-      label="Show Electron versions:"
+      label="Include Electron versions:"
     >
-      <Blueprint3.Checkbox
-        checked={false}
-        id="showUndownloadedVersions"
-        inline={true}
-        label="Undownloaded"
-        onChange={[Function]}
-      />
       <Blueprint3.Tooltip
         content="Can't disable channel of selected version (2.0.1)"
         disabled={false}
@@ -78,23 +71,26 @@ exports[`ElectronSettings component renders 1`] = `
           onChange={[Function]}
         />
       </Blueprint3.Tooltip>
+      <Blueprint3.Checkbox
+        checked={false}
+        id="showUndownloadedVersions"
+        inline={true}
+        label="Not downloaded"
+        onChange={[Function]}
+      />
       <Blueprint3.Tooltip
-        content="Can't disable channel of selected version (2.0.1)"
-        disabled={true}
+        content="Include versions that have reached end-of-life (older than 9.0.0)"
         hoverCloseDelay={0}
         hoverOpenDelay={100}
         intent="primary"
-        key="Unsupported"
         minimal={false}
         position="bottom"
         transitionDuration={100}
       >
         <Blueprint3.Checkbox
-          checked={false}
-          disabled={false}
-          id="Unsupported"
+          id="showObsoleteVersions"
           inline={true}
-          label="Unsupported"
+          label="Obsolete"
           onChange={[Function]}
         />
       </Blueprint3.Tooltip>

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -45,7 +45,6 @@ describe('VersionSelect component', () => {
         ElectronReleaseChannel.stable,
         ElectronReleaseChannel.beta,
       ],
-      statesToShow: [VersionState.ready, VersionState.downloading],
       setVersion: jest.fn(),
       get currentElectronVersion() {
         return mockVersions['2.0.2'];

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -28,7 +28,6 @@ describe('BisectDialog component', () => {
       versions,
       versionsToShow: versions,
       channelsToShow: [ElectronReleaseChannel.stable],
-      statesToShow: [VersionState.ready],
       setVersion: jest.fn(),
     };
   });

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -25,7 +25,7 @@ describe('ElectronSettings component', () => {
         ElectronReleaseChannel.stable,
         ElectronReleaseChannel.beta,
       ],
-      statesToShow: [VersionState.ready, VersionState.downloading],
+      showUndownloadedVersions: false,
       downloadVersion: jest.fn(),
       removeVersion: jest.fn(),
       updateElectronVersions: jest.fn(),
@@ -95,7 +95,6 @@ describe('ElectronSettings component', () => {
       state: VersionState.unknown,
       version,
     };
-    store.statesToShow.push(VersionState.unknown);
     store.versions = { version: ver };
     store.versionsToShow = [ver];
 
@@ -153,22 +152,12 @@ describe('ElectronSettings component', () => {
       const instance = wrapper.instance() as any;
       await instance.handleStateChange({
         currentTarget: {
-          id: VersionState.ready,
-          checked: false,
-        },
-      });
-
-      await instance.handleStateChange({
-        currentTarget: {
-          id: VersionState.unknown,
+          id: 'showUndownloadedVersions',
           checked: true,
         },
       });
 
-      expect(store.statesToShow).toEqual([
-        VersionState.downloading,
-        VersionState.unknown,
-      ]);
+      expect(store.showUndownloadedVersions).toBe(true);
     });
   });
 

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -152,18 +152,31 @@ describe('ElectronSettings component', () => {
     });
   });
 
-  describe('handleVersionChange()', () => {
-    it('handles a new selection', async () => {
-      const wrapper = shallow(<ElectronSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleStateChange({
-        currentTarget: {
-          id: 'showUndownloadedVersions',
-          checked: true,
-        },
-      });
+  describe('handleStateChange()', () => {
+    it('toggles remote versions', async () => {
+      const id = 'showUndownloadedVersions';
+      for (const checked of [true, false]) {
+        const wrapper = shallow(<ElectronSettings appState={store} />);
+        const instance = wrapper.instance() as any;
+        await instance.handleStateChange({
+          currentTarget: { checked, id },
+        });
+        expect(store[id]).toBe(checked);
+      }
+    });
+  });
 
-      expect(store.showUndownloadedVersions).toBe(true);
+  describe('handleShowObsoleteChange()', () => {
+    it('toggles obsolete versions', async () => {
+      const id = 'showObsoleteVersions';
+      for (const checked of [true, false]) {
+        const wrapper = shallow(<ElectronSettings appState={store} />);
+        const instance = wrapper.instance() as any;
+        await instance.handleShowObsoleteChange({
+          currentTarget: { checked, id },
+        });
+        expect(store[id]).toBe(checked);
+      }
     });
   });
 

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -7,6 +7,7 @@ import {
   VersionSource,
   VersionState,
 } from '../../../src/interfaces';
+import * as versions from '../../../src/renderer/versions';
 import { ElectronSettings } from '../../../src/renderer/components/settings-electron';
 import { MockVersions } from '../../mocks/electron-versions';
 
@@ -42,6 +43,10 @@ describe('ElectronSettings component', () => {
   });
 
   it('renders', () => {
+    const spy = jest
+      .spyOn(versions, 'getOldestSupportedVersion')
+      .mockReturnValue('9.0.0');
+
     const moreVersions: RunnableVersion[] = [
       {
         source: VersionSource.local,
@@ -61,8 +66,9 @@ describe('ElectronSettings component', () => {
     }
 
     const wrapper = shallow(<ElectronSettings appState={store} />);
-
     expect(wrapper).toMatchSnapshot();
+
+    spy.mockRestore();
   });
 
   it('handles removing a version', async () => {

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -49,7 +49,6 @@ describe('VersionSelect component', () => {
         ElectronReleaseChannel.stable,
         ElectronReleaseChannel.beta,
       ],
-      statesToShow: [VersionState.ready, VersionState.downloading],
       setVersion: jest.fn(),
       get currentRunnableVersion() {
         return mockVersions['2.0.2'];

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -57,12 +57,13 @@ jest.mock('../../src/renderer/versions', () => {
   const { mockVersionsArray } = new MockVersions();
 
   return {
-    getUpdatedElectronVersions: jest.fn().mockResolvedValue(mockVersionsArray),
-    getElectronVersions: jest.fn(),
-    getDefaultVersion: () => '2.0.2',
     addLocalVersion: jest.fn(),
-    saveLocalVersions: jest.fn(),
+    getDefaultVersion: () => '2.0.2',
+    getElectronVersions: jest.fn(),
+    getOldestSupportedVersion: jest.fn(),
     getReleaseChannel,
+    getUpdatedElectronVersions: jest.fn().mockResolvedValue(mockVersionsArray),
+    saveLocalVersions: jest.fn(),
   };
 });
 jest.mock('../../src/utils/get-name', () => ({
@@ -376,12 +377,8 @@ describe('AppState', () => {
         ElectronReleaseChannel.beta,
         ElectronReleaseChannel.nightly,
         ElectronReleaseChannel.stable,
-        ElectronReleaseChannel.unsupported,
       ];
-      appState.hideChannels([
-        ElectronReleaseChannel.beta,
-        ElectronReleaseChannel.unsupported,
-      ]);
+      appState.hideChannels([ElectronReleaseChannel.beta]);
       expect([...appState.channelsToShow].sort()).toEqual([
         ElectronReleaseChannel.nightly,
         ElectronReleaseChannel.stable,

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -47,6 +47,7 @@ jest.mock('../../src/renderer/binary', () => ({
   getVersionState: jest.fn().mockImplementation((v) => v.state),
 }));
 jest.mock('../../src/renderer/fetch-types', () => ({
+  getLocalTypePathForVersion: jest.fn(),
   updateEditorTypeDefinitions: jest.fn(),
 }));
 jest.mock('../../src/renderer/versions', () => {
@@ -495,6 +496,13 @@ describe('AppState', () => {
       expect(getTemplate).toHaveBeenCalledTimes(1);
       expect(window.ElectronFiddle.app.replaceFiddle).toHaveBeenCalledTimes(1);
     });
+
+    it('updates typescript definitions', async () => {
+      const version = '2.0.2';
+      const ver = appState.versions[version];
+      ver.source = VersionSource.local;
+      appState.setVersion(version);
+    });
   });
 
   describe('setTheme()', () => {
@@ -706,8 +714,12 @@ describe('AppState', () => {
 
   describe('blockAccelerators()', () => {
     it('adds an accelerator to be blocked', () => {
-      appState.addAcceleratorToBlock(BlockableAccelerator.save);
+      appState.acceleratorsToBlock = [];
 
+      appState.addAcceleratorToBlock(BlockableAccelerator.save);
+      expect(appState.acceleratorsToBlock).toEqual([BlockableAccelerator.save]);
+
+      appState.addAcceleratorToBlock(BlockableAccelerator.save);
       expect(appState.acceleratorsToBlock).toEqual([BlockableAccelerator.save]);
     });
 
@@ -715,7 +727,9 @@ describe('AppState', () => {
       appState.acceleratorsToBlock = [BlockableAccelerator.save];
 
       appState.removeAcceleratorToBlock(BlockableAccelerator.save);
+      expect(appState.acceleratorsToBlock).toEqual([]);
 
+      appState.removeAcceleratorToBlock(BlockableAccelerator.save);
       expect(appState.acceleratorsToBlock).toEqual([]);
     });
   });

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -339,10 +339,15 @@ describe('AppState', () => {
       expect(appState.versionsToShow.length).toEqual(mockVersionsArray.length);
     });
 
-    it('excludes states', () => {
-      appState.statesToShow = [VersionState.downloading];
+    it('handles undownloaded versions', () => {
+      Object.values(appState.versions).forEach(
+        (ver) => (ver.state = VersionState.unknown),
+      );
+
+      appState.showUndownloadedVersions = false;
       expect(appState.versionsToShow.length).toEqual(0);
-      appState.statesToShow = [VersionState.ready];
+
+      appState.showUndownloadedVersions = true;
       expect(appState.versionsToShow.length).toEqual(mockVersionsArray.length);
     });
   });

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -86,14 +86,6 @@ describe('versions', () => {
       ).toBe(ElectronReleaseChannel.beta);
     });
 
-    it('identifies an unsupported release', () => {
-      expect(
-        getReleaseChannel({
-          version: 'v2.1.0-unsupported.20180809',
-        } as any),
-      ).toBe(ElectronReleaseChannel.unsupported);
-    });
-
     it('identifies a stable release', () => {
       expect(
         getReleaseChannel({


### PR DESCRIPTION
This PR revamps the version filters in File > Preferences > Electron:

1. The `statesToShow` toggles exist because those toggles fit the implementation, e.g. there's not really a use case for saying, e.g. "I only want to see versions that aren't downloaded." ... and the "Ready" toggle is unclickable with a tooltip that reads "Always enabled." This PR replaces that row with one toggle: "Show non-downloaded versions?"

2. The 'unsupported' filter has been removed. Back in 2019(?) the project made an Electron release tagged 'unsupported' because of reasons. It was a one-off thing that hasn't been done in years and doesn't need to be in the UI.

3. A new 'obsolete' filter has been added. This filter toggles whether or not end-of-lifed versions of Electron should be shown. This is a useful setting because disabling EOL versions by default (a) cuts down `versionsToShow` down from 580 versions to 111, and (b) signals to new users that it's preferable to write code on supported versions. Maintainers or users who need access to EOL versions can toggle the setting to get the same long list we know and love :heart: 

Removing `statesToShow` will make it possible to [add another state](https://github.com/electron/fiddle/issues/644) without complicating this UI :smile: 

## Before

![old-filters](https://user-images.githubusercontent.com/70381/114499871-976ca900-9bec-11eb-8e1d-fcb5319d60f7.png)

## After

![new-filters](https://user-images.githubusercontent.com/70381/114499894-a2273e00-9bec-11eb-961a-2403f68fe074.png)

## Discussion

This PR currently disables EOL versions for the reasons listed above but it is a change that could affect users. I'm open to feedback if anyone has reasons that end-of-lifed versions should be shown by default.