### PR TITLE
test: fix misnamed BlockAcceleratorsSettings spec

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -203,7 +203,7 @@ async function download(ver: RunnableVersion): Promise<string> {
     const percent = Math.round(progress.percent * 100) / 100;
     if (ver.downloadProgress !== percent) {
       ver.downloadProgress = percent;
-      console.debug(`Binary: Version ${version} download progress: ${percent}`);
+      console.info(`Binary: Version ${version} download progress: ${percent}`);
     }
   };
 

--- a/tests/renderer/components/__snapshots__/settings-general-block-accelerators-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-block-accelerators-spec.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BlockAcceleratorsSettings component renders 1`] = `
+<div>
+  <h4>
+    Block Keyboard Shortcuts
+  </h4>
+  <Blueprint3.Callout>
+    <Blueprint3.FormGroup
+      label="Any keyboard shortcuts checked below will be disabled."
+    >
+      <Blueprint3.Checkbox
+        checked={false}
+        label="Save"
+        onChange={[Function]}
+        value="save"
+      />
+      <Blueprint3.Checkbox
+        checked={false}
+        label="Save as"
+        onChange={[Function]}
+        value="saveAs"
+      />
+    </Blueprint3.FormGroup>
+  </Blueprint3.Callout>
+</div>
+`;

--- a/tests/renderer/components/settings-general-block-accelerators-spec.tsx
+++ b/tests/renderer/components/settings-general-block-accelerators-spec.tsx
@@ -8,7 +8,11 @@ describe('BlockAcceleratorsSettings component', () => {
   let store: any;
 
   beforeEach(() => {
-    store = {};
+    store = {
+      acceleratorsToBlock: [],
+      removeAcceleratorToBlock: jest.fn(),
+      addAcceleratorToBlock: jest.fn(),
+    };
   });
 
   it('renders', () => {
@@ -20,17 +24,22 @@ describe('BlockAcceleratorsSettings component', () => {
     it('handles a new selection', async () => {
       const wrapper = shallow(<BlockAcceleratorsSettings appState={store} />);
       const instance = wrapper.instance() as any;
-      await instance.handleBlockAcceleratorChange({
-        currentTarget: { checked: false, value: BlockableAccelerator.save },
-      });
-
-      expect(store.acceleratorsToBlock).toBe([]);
 
       await instance.handleBlockAcceleratorChange({
         currentTarget: { checked: false, value: BlockableAccelerator.save },
       });
 
-      expect(store.acceleratorsToBlock).toBe([BlockableAccelerator.save]);
+      expect(store.removeAcceleratorToBlock).toHaveBeenCalledWith(
+        BlockableAccelerator.save,
+      );
+
+      await instance.handleBlockAcceleratorChange({
+        currentTarget: { checked: true, value: BlockableAccelerator.save },
+      });
+
+      expect(store.addAcceleratorToBlock).toHaveBeenCalledWith(
+        BlockableAccelerator.save,
+      );
     });
   });
 });


### PR DESCRIPTION
This test file wasn't running because it wasn't postfixed with `-spec`. This fixes that and also the tests within the spec, which weren't correct.