### PR TITLE
fix: intellisense not working

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -25,7 +25,6 @@ export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions
     webPreferences: {
       webviewTag: false,
       nodeIntegration: true,
-      nodeIntegrationInWorker: true,
       contextIsolation: false,
       preload: path.join(__dirname, '..', 'preload', 'preload'),
     },

--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -1,5 +1,6 @@
 import { EditorValues } from '../interfaces';
 import { exec } from '../utils/exec';
+import decomment from 'decomment';
 
 // Making TypeScript happy and avoiding "esModuleInterop" issues
 const { builtinModules } = require('module');
@@ -111,7 +112,7 @@ export async function findModules(input: string) {
   let match: RegExpMatchArray | null;
 
   /* decomment code with the esprima parser */
-  const code = await decommentWithWorker(input);
+  const code = await decomment(input);
 
   /* grab all global require matches in the text */
   while ((match = requiregx.exec(code) || null)) {
@@ -165,17 +166,4 @@ export function packageRun(
   command: string,
 ): Promise<string> {
   return exec(dir, `${packageManager} run ${command}`);
-}
-
-function decommentWithWorker(input: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker('../utils/decomment.ts');
-    worker.onmessage = function (event: MessageEvent<string>) {
-      resolve(event.data);
-    };
-    worker.postMessage(input);
-    worker.onerror = function (e) {
-      reject(e);
-    };
-  });
 }

--- a/src/utils/decomment.ts
+++ b/src/utils/decomment.ts
@@ -1,5 +1,0 @@
-import decomment from 'decomment';
-
-onmessage = function (event: MessageEvent<string>) {
-  postMessage(decomment(event.data));
-};

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -38,7 +38,6 @@ describe('windows', () => {
       webPreferences: {
         webviewTag: false,
         nodeIntegration: true,
-        nodeIntegrationInWorker: true,
         contextIsolation: false,
         preload: '/fake/path',
       },

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -10,12 +10,9 @@ import {
 } from '../../src/renderer/npm';
 import { exec } from '../../src/utils/exec';
 import { overridePlatform, resetPlatform } from '../utils';
-import MockDecommentWorker from '../mocks/worker';
 import { DefaultEditorId } from '../../src/interfaces';
 jest.mock('decomment');
 jest.mock('../../src/utils/exec');
-
-window.Worker = MockDecommentWorker;
 
 describe('npm', () => {
   const mockBuiltins = `


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/577.

Fixes intellisense not working as a function of setting `nodeIntegrationInWorker: true` in the `BrowserWindow` options.

Ideally i'd like to narrow down the true fix but this shifts calls to `decomment` to `findModule` where they're invoked directly instead of via Worker thread - I think for now it's more important to regain this functionality while we search for a nicer long-term solution.