### PR TITLE
test: improve `commands-action-button.tsx` coverage

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -263,7 +263,7 @@ export class GistActionButton extends React.Component<
       return this.handleUpdate();
     }
 
-    if (gistId && actionType == GistActionType.delete) {
+    if (gistId && actionType === GistActionType.delete) {
       return this.handleDelete();
     }
 

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -129,8 +129,8 @@ export class GistActionButton extends React.Component<
   private async publishGist(description: string) {
     const { appState } = this.props;
 
-    const octo = await getOctokit(this.props.appState);
-    const { gitHubPublishAsPublic } = this.props.appState;
+    const octo = await getOctokit(appState);
+    const { gitHubPublishAsPublic } = appState;
     const options = { includeDependencies: true, includeElectron: true };
     const values = await window.ElectronFiddle.app.getEditorValues(options);
 

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -257,17 +257,19 @@ export class GistActionButton extends React.Component<
    */
   public async performGistAction(): Promise<void> {
     const { gistId } = this.props.appState;
-    const { actionType } = this.state;
 
-    if (gistId && actionType === GistActionType.update) {
-      return this.handleUpdate();
+    const actionType = gistId ? this.state.actionType : GistActionType.publish;
+
+    switch (actionType) {
+      case GistActionType.delete:
+        return this.handleDelete();
+
+      case GistActionType.publish:
+        return this.handlePublish();
+
+      case GistActionType.update:
+        return this.handleUpdate();
     }
-
-    if (gistId && actionType === GistActionType.delete) {
-      return this.handleDelete();
-    }
-
-    return this.handlePublish();
   }
 
   /**

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -259,21 +259,15 @@ export class GistActionButton extends React.Component<
     const { gistId } = this.props.appState;
     const { actionType } = this.state;
 
-    if (gistId) {
-      switch (actionType) {
-        case GistActionType.publish:
-          await this.handlePublish();
-          break;
-        case GistActionType.update:
-          await this.handleUpdate();
-          break;
-        case GistActionType.delete:
-          await this.handleDelete();
-          break;
-      }
-    } else {
-      await this.handlePublish();
+    if (gistId && actionType === GistActionType.update) {
+      return this.handleUpdate();
     }
+
+    if (gistId && actionType == GistActionType.delete) {
+      return this.handleDelete();
+    }
+
+    return this.handlePublish();
   }
 
   /**
@@ -425,7 +419,7 @@ export class GistActionButton extends React.Component<
   }
 
   private renderToast = (toast: IToastProps) => {
-    this.toaster.show(toast);
+    this.toaster?.show(toast);
   };
 
   private gistFilesList = (values: EditorValues) => {

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -8,7 +8,7 @@ export class MockState {
   @observable public genericDialogLastInput: string | null = null;
   @observable public genericDialogLastResult: boolean | null = null;
   @observable public gistId = '';
-  @observable public gistPublishAsPublic = true;
+  @observable public gitHubPublishAsPublic = true;
   @observable public gitHubToken: string | null = null;
   @observable public isConsoleShowing = true;
   @observable public isGenericDialogShowing = false;
@@ -16,8 +16,6 @@ export class MockState {
   @observable public output = [];
   @observable public title = 'Electron Fiddle';
   @observable public versionsToShow = [];
-
-  public gitHubPublishAsPublic = true;
 
   public hasVersion = jest.fn();
   public hideChannels = jest.fn();

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -1,18 +1,30 @@
 import { observable } from 'mobx';
+import { EditorId, GistActionState } from '../../src/interfaces';
 
 export class MockState {
+  @observable public activeGistAction = GistActionState.none;
+  @observable public allMosaics: EditorId[] = [];
   @observable public closedPanels = {};
+  @observable public genericDialogLastInput: string | null = null;
+  @observable public genericDialogLastResult: boolean | null = null;
   @observable public gistId = '';
+  @observable public gistPublishAsPublic = true;
+  @observable public gitHubToken: string | null = null;
   @observable public isConsoleShowing = true;
   @observable public isGenericDialogShowing = false;
   @observable public isUsingSystemTheme = true;
-  @observable public title = 'Electron Fiddle';
   @observable public output = [];
+  @observable public title = 'Electron Fiddle';
   @observable public versionsToShow = [];
+
+  public gitHubPublishAsPublic = true;
 
   public hasVersion = jest.fn();
   public hideChannels = jest.fn();
   public pushOutput = jest.fn();
+  public setGenericDialogOptions = jest.fn();
   public setVersion = jest.fn();
+  public setVisibleMosaics = jest.fn();
   public showChannels = jest.fn();
+  public toggleAuthDialog = jest.fn();
 }

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Publish button component renders 1`] = `
+exports[`Action button component renders 1`] = `
 <Fragment>
   <fieldset
-    disabled={true}
+    disabled={false}
   >
     <Blueprint3.ButtonGroup
       className="button-gist-action"
@@ -58,7 +58,7 @@ exports[`Publish button component renders 1`] = `
       </Blueprint3.Popover>
       <Blueprint3.Button
         icon="upload"
-        loading={true}
+        loading={false}
         onClick={[Function]}
         text="Publish"
       />

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -119,15 +119,6 @@ describe('Action button component', () => {
       if (dispose) dispose();
     });
 
-    it('publishes a gist', async () => {
-      instance.getFiddleDescriptionFromUser = jest
-        .fn()
-        .mockReturnValue(description);
-
-      await instance.performGistAction();
-      expect(mocktokit.gists.create).toHaveBeenCalledWith(gistCreateOpts);
-    });
-
     function registerDialogHandler(
       description: string | null,
       result: boolean,
@@ -141,6 +132,12 @@ describe('Action button component', () => {
         },
       );
     }
+
+    it('publishes a gist', async () => {
+      registerDialogHandler(description, true);
+      await instance.performGistAction();
+      expect(mocktokit.gists.create).toHaveBeenCalledWith(gistCreateOpts);
+    });
 
     it('asks the user for a description', async () => {
       const description = 'some non-default description';
@@ -167,11 +164,9 @@ describe('Action button component', () => {
     });
 
     it('handles missing content', async () => {
-      const { instance } = createActionButton();
-      instance.getFiddleDescriptionFromUser = jest
-        .fn()
-        .mockReturnValue(description);
       app.getEditorValues.mockReturnValueOnce({});
+      const { instance } = createActionButton();
+      registerDialogHandler(description, true);
 
       await instance.performGistAction();
 

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -31,18 +31,12 @@ class OctokitMock {
   };
 }
 
-function mockImplementationThrows(mock: jest.Mock, message: string) {
-  mock.mockImplementation(() => {
-    throw new Error(message);
-  });
-}
-
 describe('Action button component', () => {
   const description = 'Electron Fiddle Gist';
   const errorMessage = '💀';
-  let state: MockState;
   let app: AppMock;
   let mocktokit: OctokitMock;
+  let state: MockState;
 
   const gistCreateOpts = {
     description,
@@ -194,7 +188,9 @@ describe('Action button component', () => {
     });
 
     it('handles an error in Gist publishing', async () => {
-      mockImplementationThrows(mocktokit.gists.create, errorMessage);
+      mocktokit.gists.create.mockImplementation(() => {
+        throw new Error(errorMessage);
+      });
 
       const { instance } = createActionButton();
       instance.getFiddleDescriptionFromUser = jest
@@ -246,7 +242,9 @@ describe('Action button component', () => {
     });
 
     it('notifies the user if updating fails', async () => {
-      mockImplementationThrows(mocktokit.gists.update, errorMessage);
+      mocktokit.gists.update.mockImplementation(() => {
+        throw new Error(errorMessage);
+      });
 
       await instance.performGistAction();
 
@@ -278,7 +276,9 @@ describe('Action button component', () => {
     });
 
     it('notifies the user if deleting fails', async () => {
-      mockImplementationThrows(mocktokit.gists.delete, errorMessage);
+      mocktokit.gists.delete.mockImplementation(() => {
+        throw new Error(errorMessage);
+      });
 
       await instance.performGistAction();
 

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,21 +1,27 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
+import { reaction } from 'mobx';
+import { shallow } from 'enzyme';
+
 import {
   DefaultEditorId,
   GistActionState,
   GistActionType,
 } from '../../../src/interfaces';
-
+import { IpcEvents } from '../../../src/ipc-events';
+import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { GistActionButton } from '../../../src/renderer/components/commands-action-button';
 import { getOctokit } from '../../../src/utils/octokit';
 
+import { MockState } from '../../mocks/state';
+
 jest.mock('../../../src/utils/octokit');
 
-describe('Publish button component', () => {
-  let store: any;
+describe('Action button component', () => {
+  let state: MockState;
+  const description = 'Electron Fiddle Gist';
 
   const expectedGistCreateOpts = {
-    description: 'Electron Fiddle Gist',
+    description,
     files: {
       [DefaultEditorId.html]: { content: 'html-content' },
       [DefaultEditorId.renderer]: { content: 'renderer-content' },
@@ -27,228 +33,258 @@ describe('Publish button component', () => {
   };
 
   beforeEach(() => {
-    store = {
-      gitHubPublishAsPublic: true,
-      customMosaics: [],
-    };
+    ({ state } = (window as any).ElectronFiddle.app);
   });
 
+  function createActionButton() {
+    const wrapper = shallow(<GistActionButton appState={state as any} />);
+    const instance = wrapper.instance() as any;
+    return { wrapper, instance };
+  }
+
   it('renders', () => {
-    const wrapper = shallow(<GistActionButton appState={store} />);
+    const { wrapper } = createActionButton();
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('toggles the auth dialog on click if not authed', async () => {
-    store.toggleAuthDialog = jest.fn();
+  it('registers for FS_SAVE_FIDDLE_GIST events', () => {
+    const spyOn = jest.spyOn(ipcRendererManager, 'on');
+    const spyOff = jest.spyOn(ipcRendererManager, 'off');
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
+    const event = IpcEvents.FS_SAVE_FIDDLE_GIST;
+    const { instance, wrapper } = createActionButton();
+    expect(spyOn).toHaveBeenCalledWith(event, instance.handleClick);
+
+    wrapper.unmount();
+    expect(spyOff).toHaveBeenCalledWith(event, instance.handleClick);
+
+    spyOn.mockRestore();
+    spyOff.mockRestore();
+  });
+
+  it('toggles the auth dialog on click if not authed', async () => {
+    state.toggleAuthDialog = jest.fn();
+
+    const { instance } = createActionButton();
     await instance.handleClick();
 
-    expect(store.toggleAuthDialog).toHaveBeenCalled();
+    expect(state.toggleAuthDialog).toHaveBeenCalled();
   });
 
   it('toggles the publish method on click if authed', async () => {
-    store.gitHubToken = 'github-token';
+    state.gitHubToken = 'github-token';
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
+    const { instance } = createActionButton();
     instance.performGistAction = jest.fn();
     await instance.handleClick();
 
     expect(instance.performGistAction).toHaveBeenCalled();
   });
 
-  it('attempts to publish to Gist', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } })),
-      },
-    };
+  describe('publish mode', () => {
+    const gistId = '123';
+    let mockOctokit: any;
+    let instance: any;
 
-    (getOctokit as any).mockReturnValue(mockOctokit);
+    beforeEach(() => {
+      mockOctokit = {
+        authenticate: jest.fn(),
+        gists: {
+          create: jest.fn(async () => ({ data: { id: gistId } })),
+        },
+      };
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
+      (getOctokit as any).mockImplementation(() => mockOctokit);
 
-    instance.getFiddleDescriptionFromUser = jest
-      .fn()
-      .mockReturnValue('Electron Fiddle Gist');
-    await instance.performGistAction();
+      ({ instance } = createActionButton());
+    });
 
-    expect(mockOctokit.gists.create).toHaveBeenCalledWith<any>({
-      description: 'Electron Fiddle Gist',
-      files: {
-        [DefaultEditorId.html]: { content: 'html-content' },
-        [DefaultEditorId.renderer]: { content: 'renderer-content' },
-        [DefaultEditorId.main]: { content: 'main-content' },
-        [DefaultEditorId.preload]: { content: 'preload-content' },
-        [DefaultEditorId.css]: { content: 'css-content' },
-      },
-      public: true,
+    it('publishes a gist', async () => {
+      instance.getFiddleDescriptionFromUser = jest
+        .fn()
+        .mockReturnValue(description);
+
+      await instance.performGistAction();
+      expect(mockOctokit.gists.create).toHaveBeenCalledWith(
+        expectedGistCreateOpts,
+      );
+    });
+
+    function registerDialogHandler(
+      description: string | null,
+      result: boolean,
+    ) {
+      return reaction(
+        () => state.isGenericDialogShowing,
+        () => {
+          state.genericDialogLastInput = description;
+          state.genericDialogLastResult = result;
+          state.isGenericDialogShowing = false;
+        },
+      );
+    }
+
+    it('asks the user for a description', async () => {
+      const description = 'some non-default description';
+      const disposer = registerDialogHandler(description, true);
+      await instance.performGistAction();
+      expect(mockOctokit.gists.create).toHaveBeenCalledWith({
+        ...expectedGistCreateOpts,
+        description,
+      });
+      disposer();
+    });
+
+    it('provides a default description', async () => {
+      const disposer = registerDialogHandler(null, true);
+      await instance.performGistAction();
+      expect(mockOctokit.gists.create).toHaveBeenCalledWith(
+        expectedGistCreateOpts,
+      );
+      disposer();
+    });
+
+    it('publishes only if the user confirms', async () => {
+      const disposer = registerDialogHandler(null, false);
+      await instance.performGistAction();
+      expect(mockOctokit.gists.create).not.toHaveBeenCalled();
+      disposer();
+    });
+
+    it('handles missing content', async () => {
+      const { instance } = createActionButton();
+      instance.getFiddleDescriptionFromUser = jest
+        .fn()
+        .mockReturnValue(description);
+      (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce(
+        {},
+      );
+
+      await instance.performGistAction();
+
+      expect(mockOctokit.gists.create).toHaveBeenCalledWith<any>({
+        ...expectedGistCreateOpts,
+        files: {
+          [DefaultEditorId.html]: { content: '<!-- Empty -->' },
+          [DefaultEditorId.renderer]: { content: '// Empty' },
+          [DefaultEditorId.main]: { content: '// Empty' },
+          [DefaultEditorId.preload]: { content: '// Empty' },
+          [DefaultEditorId.css]: { content: '/* Empty */' },
+        },
+      });
+    });
+
+    it('handles an error in Gist publishing', async () => {
+      mockOctokit.gists.create.mockImplementation(() => {
+        throw new Error('💣');
+      });
+
+      const { instance } = createActionButton();
+      instance.getFiddleDescriptionFromUser = jest
+        .fn()
+        .mockReturnValue(description);
+
+      await instance.performGistAction();
+
+      expect(state.activeGistAction).toBe(GistActionState.none);
     });
   });
 
-  it('can cancel publishing to Gist', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } })),
-      },
-    };
+  describe('update mode', () => {
+    const gistId = '123';
+    let mockOctokit: any;
+    let wrapper: any;
+    let instance: any;
 
-    (getOctokit as any).mockReturnValue(mockOctokit);
+    beforeEach(() => {
+      mockOctokit = {
+        authenticate: jest.fn(),
+        gists: {
+          update: jest.fn(),
+        },
+      };
+      (getOctokit as any).mockReturnValue(mockOctokit);
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    instance.getFiddleDescriptionFromUser = jest.fn().mockReturnValue(null);
-    await instance.performGistAction();
-
-    expect(mockOctokit.gists.create).not.toHaveBeenCalled();
-  });
-
-  it('attempts to update an existing Gist', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        update: jest.fn(),
-      },
-    };
-
-    (getOctokit as any).mockReturnValue(mockOctokit);
-
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    wrapper.setProps({ appState: { gistId: 123, customMosaics: [] } });
-    instance.setState({ actionType: GistActionType.update });
-
-    await instance.performGistAction();
-
-    expect(mockOctokit.gists.update).toHaveBeenCalledWith({
-      gist_id: 123,
-      files: {
-        [DefaultEditorId.html]: { content: 'html-content' },
-        [DefaultEditorId.renderer]: { content: 'renderer-content' },
-        [DefaultEditorId.main]: { content: 'main-content' },
-        [DefaultEditorId.preload]: { content: 'preload-content' },
-        [DefaultEditorId.css]: { content: 'css-content' },
-      },
+      state.gistId = gistId;
+      ({ instance, wrapper } = createActionButton());
+      wrapper.setProps({ appState: state });
+      instance.setState({ actionType: GistActionType.update });
     });
-  });
 
-  it('attempts to delete an existing Gist', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        delete: jest.fn(),
-      },
-    };
+    it('attempts to update an existing Gist', async () => {
+      await instance.performGistAction();
 
-    (getOctokit as any).mockReturnValue(mockOctokit);
-
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    wrapper.setProps({ appState: { gistId: 123 } });
-    instance.setState({ actionType: GistActionType.delete });
-
-    await instance.performGistAction();
-
-    expect(mockOctokit.gists.delete).toHaveBeenCalledWith({
-      gist_id: 123,
+      expect(mockOctokit.gists.update).toHaveBeenCalledWith({
+        gist_id: gistId,
+        files: expectedGistCreateOpts.files,
+      });
     });
-  });
 
-  it('handles missing content', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } })),
-      },
-    };
+    it('notifies the user if updating fails', async () => {
+      const errorMessage = '💀';
+      ipcRendererManager.send = jest.fn();
+      mockOctokit.gists.update.mockImplementation(() => {
+        throw new Error(errorMessage);
+      });
 
-    (getOctokit as any).mockReturnValue(mockOctokit);
+      await instance.performGistAction();
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    instance.getFiddleDescriptionFromUser = jest
-      .fn()
-      .mockReturnValue('Electron Fiddle Gist');
-    (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
-
-    await instance.performGistAction();
-
-    expect(mockOctokit.gists.create).toHaveBeenCalledWith<any>({
-      description: 'Electron Fiddle Gist',
-      files: {
-        [DefaultEditorId.html]: { content: '<!-- Empty -->' },
-        [DefaultEditorId.renderer]: { content: '// Empty' },
-        [DefaultEditorId.main]: { content: '// Empty' },
-        [DefaultEditorId.preload]: { content: '// Empty' },
-        [DefaultEditorId.css]: { content: '/* Empty */' },
-      },
-      public: true,
-    });
-  });
-
-  it('handles a custom description', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        create: jest.fn(async () => ({ data: { id: '123' } })),
-      },
-    };
-
-    (getOctokit as any).mockReturnValue(mockOctokit);
-
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    instance.getFiddleDescriptionFromUser = jest
-      .fn()
-      .mockReturnValue('My Custom Description');
-    (window as any).ElectronFiddle.app.getEditorValues.mockReturnValueOnce({});
-
-    await instance.performGistAction();
-
-    expect(mockOctokit.gists.create).toHaveBeenCalledWith<any>({
-      description: 'My Custom Description',
-      files: {
-        [DefaultEditorId.html]: { content: '<!-- Empty -->' },
-        [DefaultEditorId.renderer]: { content: '// Empty' },
-        [DefaultEditorId.main]: { content: '// Empty' },
-        [DefaultEditorId.preload]: { content: '// Empty' },
-        [DefaultEditorId.css]: { content: '/* Empty */' },
-      },
-      public: true,
-    });
-  });
-
-  it('handles an error in Gist publishing', async () => {
-    const mockOctokit = {
-      authenticate: jest.fn(),
-      gists: {
-        create: jest.fn(() => {
-          throw new Error('bwap bwap');
+      expect(ipcRendererManager.send).toHaveBeenCalledWith<any>(
+        IpcEvents.SHOW_WARNING_DIALOG,
+        expect.objectContaining({
+          detail: expect.stringContaining(errorMessage),
+          message: expect.stringContaining('Updating Fiddle Gist failed.'),
         }),
-      },
-    };
+      );
+    });
+  });
 
-    (getOctokit as any).mockReturnValue(mockOctokit);
+  describe('delete mode', () => {
+    const gistId = '123';
+    let mockOctokit: any;
+    let wrapper: any;
+    let instance: any;
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-    instance.getFiddleDescriptionFromUser = jest
-      .fn()
-      .mockReturnValue('Electron Fiddle Gist');
+    beforeEach(() => {
+      mockOctokit = {
+        authenticate: jest.fn(),
+        gists: {
+          delete: jest.fn(),
+        },
+      };
 
-    await instance.performGistAction();
+      (getOctokit as any).mockReturnValue(mockOctokit);
 
-    expect(store.activeGistAction).toBe(GistActionState.none);
+      ({ instance, wrapper } = createActionButton());
+      wrapper.setProps({ appState: { gistId } });
+      instance.setState({ actionType: GistActionType.delete });
+    });
+
+    it('attempts to delete an existing Gist', async () => {
+      await instance.performGistAction();
+
+      expect(mockOctokit.gists.delete).toHaveBeenCalledWith({
+        gist_id: gistId,
+      });
+    });
+
+    it('notifies the user if deleting fails', async () => {
+      const errorMessage = '🔥';
+      ipcRendererManager.send = jest.fn();
+      mockOctokit.gists.delete.mockImplementation(() => {
+        throw new Error(errorMessage);
+      });
+
+      await instance.performGistAction();
+
+      expect(ipcRendererManager.send).toHaveBeenCalledWith<any>(
+        IpcEvents.SHOW_WARNING_DIALOG,
+        expect.objectContaining({
+          detail: expect.stringContaining(errorMessage),
+          message: expect.stringContaining('Deleting Fiddle Gist failed.'),
+        }),
+      );
+    });
   });
 
   it('uses the privacy setting correctly', async () => {
@@ -263,12 +299,10 @@ describe('Publish button component', () => {
 
     (getOctokit as any).mockReturnValue(mockOctokit);
 
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
+    const { instance } = createActionButton();
     instance.getFiddleDescriptionFromUser = jest
       .fn()
-      .mockReturnValue('Electron Fiddle Gist');
+      .mockReturnValue(description);
 
     instance.setPrivate();
     await instance.performGistAction();
@@ -287,100 +321,49 @@ describe('Publish button component', () => {
     });
   });
 
-  it('disables during gist publishing', async () => {
-    store.activeGistAction = GistActionState.none;
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
+  describe('disables itself', () => {
+    async function testDisabledWhen(gistActionState: GistActionState) {
+      state.activeGistAction = GistActionState.none;
+      const { instance, wrapper } = createActionButton();
+      expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
 
-    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-
-    instance.performGistAction = jest.fn().mockImplementationOnce(() => {
-      return new Promise<void>((resolve) => {
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.publishing } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
-          },
-        );
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.none } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-          },
-        );
-        resolve();
+      instance.performGistAction = jest.fn().mockImplementationOnce(() => {
+        return new Promise<void>((resolve) => {
+          wrapper.setProps(
+            { appState: { state, activeGistAction: gistActionState } },
+            () => expect(wrapper.find('fieldset').prop('disabled')).toBe(true),
+          );
+          wrapper.setProps(
+            { appState: { state, activeGistAction: GistActionState.none } },
+            () => expect(wrapper.find('fieldset').prop('disabled')).toBe(false),
+          );
+          resolve();
+        });
       });
+
+      await instance.performGistAction();
+    }
+
+    it('while publishing', async () => {
+      await testDisabledWhen(GistActionState.publishing);
     });
-
-    await instance.performGistAction();
-  });
-
-  it('disables during gist updating', async () => {
-    store.activeGistAction = GistActionState.none;
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-
-    instance.performGistAction = jest.fn().mockImplementationOnce(() => {
-      return new Promise<void>((resolve) => {
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.updating } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
-          },
-        );
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.none } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-          },
-        );
-        resolve();
-      });
+    it('while updating', async () => {
+      await testDisabledWhen(GistActionState.updating);
     });
-
-    await instance.performGistAction();
-  });
-
-  it('disables during gist deleting', async () => {
-    store.activeGistAction = GistActionState.none;
-    const wrapper = shallow(<GistActionButton appState={store} />);
-    const instance: GistActionButton = wrapper.instance() as any;
-
-    expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-
-    instance.performGistAction = jest.fn().mockImplementationOnce(() => {
-      return new Promise<void>((resolve) => {
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.deleting } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(true);
-          },
-        );
-        wrapper.setProps(
-          { appState: { store, activeGistAction: GistActionState.none } },
-          () => {
-            expect(wrapper.find('fieldset').prop('disabled')).toBe(false);
-          },
-        );
-        resolve();
-      });
+    it('while deleting', async () => {
+      await testDisabledWhen(GistActionState.deleting);
     });
-
-    await instance.performGistAction();
   });
 
   describe('privacy menu', () => {
     it('toggles the privacy setting', () => {
-      const wrapper = shallow(<GistActionButton appState={store} />);
-      const instance: GistActionButton = wrapper.instance() as any;
+      const { instance } = createActionButton();
 
       instance.setPublic();
-      expect(store.gitHubPublishAsPublic).toBe(true);
+      expect(state.gitHubPublishAsPublic).toBe(true);
 
       instance.setPrivate();
-      expect(store.gitHubPublishAsPublic).toBe(false);
+      expect(state.gitHubPublishAsPublic).toBe(false);
     });
   });
 });


### PR DESCRIPTION
no functional changes.

This is a refactor of `tests/renderer/components/commands-publish-button-spec.tsx` that fills in some of the edge cases, e.g. the description dialog and some error handling.

It reduces copy-paste code duplication by nesting 'describe' sections with beforeEach() functions, e.g. in `describe('publish mode'` there is a beforeEach() that creates a publish button ready to be tested.