### PR TITLE
fix: console output being dropping on Windows

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -327,6 +327,7 @@ export class Runner {
     const {
       currentElectronVersion,
       isEnablingElectronLogging,
+      flushOutput,
       pushOutput,
       executionFlags,
       environmentVariables,
@@ -368,6 +369,8 @@ export class Runner {
         pushOutput(data, { bypassBuffer: false }),
       );
       this.child.on('close', async (code) => {
+        flushOutput();
+
         this.appState.isRunning = false;
         this.child = null;
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -616,6 +616,16 @@ export class AppState {
   }
 
   /**
+   * Ensure that any buffered console output is
+   * printed before a running Fiddle is stopped.
+   *
+   * @returns {void}
+   */
+  @action public flushOutput(): void {
+    this.pushOutput('\r\n', { bypassBuffer: false });
+  }
+
+  /**
    * Push output to the application's state. Accepts a buffer or a string as input,
    * attaches a timestamp, and pushes into the store.
    *
@@ -628,12 +638,11 @@ export class AppState {
     let strData = data.toString();
     const { isNotPre, bypassBuffer } = options;
 
-    // TODO: This drops the first part of the buffer... is that fully expected?
     if (process.platform === 'win32' && bypassBuffer === false) {
       this.outputBuffer += strData;
       strData = this.outputBuffer;
       const parts = strData.split('\r\n');
-      for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      for (let partIndex = 0; partIndex < parts.length; partIndex++) {
         const part = parts[partIndex];
         if (partIndex === parts.length - 1) {
           this.outputBuffer = part;

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -78,6 +78,7 @@ export class StateMock {
   public hideChannels = jest.fn();
   public pushError = jest.fn();
   public pushOutput = jest.fn();
+  public flushOutput = jest.fn();
   public removeAcceleratorToBlock = jest.fn();
   public removeCustomMosaic = jest.fn();
   public removeVersion = jest.fn();


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/668.

Refs https://github.com/electron/fiddle/commit/5c98534cd89fc4cabbe4512ee9d758696b09882a.

This was previously dropping output if `parts.length` was 1. Now it doesn't.