### PR TITLE
fix: ensure gist input value is trimmed

### DIFF
--- a/src/utils/gist.ts
+++ b/src/utils/gist.ts
@@ -9,10 +9,12 @@
  *-  https://gist.github.com/ckerr/8c5fc0c6a5153d49b5a4a56d3ed9da8f
  *-  https://gist.github.com/ckerr/8c5fc0c6a5153d49b5a4a56d3ed9da8f/
  *
- * @pararm {string} input
+ * @pararm {string} rawInput
  * returns {(string | null)}
  */
-export function getGistId(input: string): string | null {
+export function getGistId(rawInput: string): string | null {
+  let input = rawInput.trim();
+
   let id: string | undefined = input;
   if (input.startsWith('https://gist.github.com')) {
     if (input.endsWith('/')) {
@@ -20,10 +22,8 @@ export function getGistId(input: string): string | null {
     }
     id = input.split('/').pop();
   }
-  if (id && id.match(/[0-9A-Fa-f]{32}/)) {
-    return id;
-  }
-  return null;
+
+  return id?.match(/[0-9A-Fa-f]{32}/) ? id : null;
 }
 
 /**

--- a/tests/utils/gist-spec.ts
+++ b/tests/utils/gist-spec.ts
@@ -55,6 +55,13 @@ describe('gist', () => {
       expect(actual).toBe(expected);
     });
 
+    it('trims extra spaces from the gist url', () => {
+      const expected = GIST_ID;
+      const input = `   https://gist.github.com/${expected} `;
+      const actual = getGistId(input);
+      expect(actual).toBe(expected);
+    });
+
     it('recognizes gist URLs without usernames', () => {
       const expected = GIST_ID;
       const input = `https://gist.github.com/${expected}`;


### PR DESCRIPTION
Sometimes i'll paste in a gist link with a space at the beginning, which triggers a 404 not found error. Make this functionality a little more fault-tolerant by ensuring the url gets trimmed.