### PR TITLE
feat: allow obsolete versions to be toggled in cli

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,6 +62,7 @@ export interface SetupRequest {
   version?: string;
   showChannels: ElectronReleaseChannel[];
   hideChannels: ElectronReleaseChannel[];
+  useObsolete?: boolean;
 }
 
 export interface BisectRequest {

--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -18,7 +18,7 @@ function getSetup(opts: commander.OptionValues): SetupRequest {
     hideChannels: [],
   };
 
-  const { fiddle, version, betas, nightlies } = opts;
+  const { fiddle, version, betas, nightlies, obsolete } = opts;
 
   if (fs.existsSync(fiddle)) {
     config.fiddle = { filePath: fiddle };
@@ -34,6 +34,10 @@ function getSetup(opts: commander.OptionValues): SetupRequest {
 
   if (version) {
     config.version = version;
+  }
+
+  if (obsolete === true || obsolete === false) {
+    config.useObsolete = obsolete;
   }
 
   if (betas) {
@@ -97,6 +101,8 @@ export async function processCommandLine(argv: string[]) {
     .option('--no-nightlies', 'Omit nightly releases')
     .option('--betas', 'Include beta releases')
     .option('--no-betas', 'Omit beta releases')
+    .option('--obsolete', 'Include obsolete releases')
+    .option('--no-obsolete', 'Omit obsolete releases')
     .action(bisect);
 
   program

--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -36,7 +36,7 @@ function getSetup(opts: commander.OptionValues): SetupRequest {
     config.version = version;
   }
 
-  if (obsolete === true || obsolete === false) {
+  if (typeof obsolete === 'boolean') {
     config.useObsolete = obsolete;
   }
 

--- a/src/renderer/task-runner.ts
+++ b/src/renderer/task-runner.ts
@@ -27,6 +27,7 @@ export class TaskRunner {
   private readonly run: () => Promise<RunResult>;
   private readonly setVersion: (ver: string) => Promise<void>;
   private readonly show: (channels: ElectronReleaseChannel[]) => Promise<void>;
+  private readonly showObsoleteVersions: (show: boolean) => void;
 
   constructor(app: App) {
     const { runner, state } = app;
@@ -36,6 +37,8 @@ export class TaskRunner {
     this.autobisect = runner.autobisect.bind(runner);
     this.done = (r: RunResult) => ipc.send(IpcEvents.TASK_DONE, r);
     this.hide = state.hideChannels.bind(state);
+    this.showObsoleteVersions = (use: boolean) =>
+      (state.showObsoleteVersions = use);
     this.log = state.pushOutput.bind(state);
     this.open = app.openFiddle.bind(app);
     this.run = runner.run.bind(runner);
@@ -102,7 +105,11 @@ export class TaskRunner {
 
   private async setup(req: SetupRequest) {
     const { log } = this;
-    const { fiddle, hideChannels, showChannels, version } = req;
+    const { fiddle, hideChannels, showChannels, useObsolete, version } = req;
+
+    if (useObsolete === true || useObsolete === false) {
+      this.showObsoleteVersions(useObsolete);
+    }
 
     if (hideChannels.length > 0) {
       log(`Task: Hide channels ${hideChannels.join(', ')}`);

--- a/src/renderer/task-runner.ts
+++ b/src/renderer/task-runner.ts
@@ -107,7 +107,7 @@ export class TaskRunner {
     const { log } = this;
     const { fiddle, hideChannels, showChannels, useObsolete, version } = req;
 
-    if (useObsolete === true || useObsolete === false) {
+    if (typeof useObsolete === 'boolean') {
       this.showObsoleteVersions(useObsolete);
     }
 

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -129,6 +129,20 @@ describe('processCommandLine()', () => {
       expectBisectCalledOnceWith(expected);
     });
 
+    it('handles a --obsolete option', async () => {
+      const argv = [...ARGV, GOOD, BAD, '--obsolete'];
+      const expected = `{"badVersion":"${BAD}","goodVersion":"${GOOD}","setup":{"fiddle":${DEFAULT_FIDDLE},"hideChannels":[],"showChannels":[],"useObsolete":true}}`;
+      await processCommandLine(argv);
+      expectBisectCalledOnceWith(expected);
+    });
+
+    it('handles a --no-obsolete option', async () => {
+      const argv = [...ARGV, GOOD, BAD, '--no-obsolete'];
+      const expected = `{"badVersion":"${BAD}","goodVersion":"${GOOD}","setup":{"fiddle":${DEFAULT_FIDDLE},"hideChannels":[],"showChannels":[],"useObsolete":false}}`;
+      await processCommandLine(argv);
+      expectBisectCalledOnceWith(expected);
+    });
+
     describe(`watches for ${IpcEvents.TASK_DONE} events`, () => {
       async function expectDoneCausesExit(result: RunResult, exitCode: number) {
         const argv = [...ARGV, GOOD, BAD];

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -46,6 +46,7 @@ export class StateMock {
   @observable public isUsingSystemTheme = true;
   @observable public isWarningDialogShowing = false;
   @observable public output = [];
+  @observable public showObsoleteVersions = false;
   @observable public showUndownloadedVersions = false;
   @observable public theme: string | null;
   @observable public title = 'Electron Fiddle';

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -88,6 +88,7 @@ exports[`ElectronSettings component renders 1`] = `
         transitionDuration={100}
       >
         <Blueprint3.Checkbox
+          checked={false}
           id="showObsoleteVersions"
           inline={true}
           label="Obsolete"

--- a/tests/renderer/task-runner-spec.tsx
+++ b/tests/renderer/task-runner-spec.tsx
@@ -57,6 +57,7 @@ describe('Task Runner component', () => {
     const GIST_ID = '8c5fc0c6a5153d49b5a4a56d3ed9da8f';
     const SHOW = [ElectronReleaseChannel.stable];
     const HIDE = [ElectronReleaseChannel.beta, ElectronReleaseChannel.nightly];
+    const USE_OBSOLETE = true;
     const VERSIONS = [
       '12.0.0',
       '11.2.0',
@@ -77,6 +78,7 @@ describe('Task Runner component', () => {
       setup: {
         showChannels: SHOW,
         hideChannels: HIDE,
+        useObsolete: USE_OBSOLETE,
         fiddle: {
           gistId: GIST_ID,
         },
@@ -98,6 +100,7 @@ describe('Task Runner component', () => {
 
       expect(app.openFiddle).toHaveBeenCalledTimes(1);
       expect(app.openFiddle).toHaveBeenCalledWith(req.setup.fiddle);
+      expect(appState.showObsoleteVersions).toBe(USE_OBSOLETE);
       expect(appState.setVersion).not.toHaveBeenCalled();
       expect(appState.showChannels).toHaveBeenCalledTimes(1);
       expect(appState.showChannels).toHaveBeenCalledWith(SHOW);


### PR DESCRIPTION
When bisecting from the command line, it's possible that the last known good version is an obsolete release. Thus, it's necessary to be able to re-enable obsolete releases from the command line.