### PR TITLE
fix: exit with err if the CLI is given a bad gist

### DIFF
--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -69,20 +69,26 @@ async function sendTask(type: IpcEvents, task: any) {
 }
 
 async function bisect(good: string, bad: string, opts: commander.OptionValues) {
-  sendTask(IpcEvents.TASK_BISECT, {
-    setup: getSetup(opts),
-    goodVersion: good,
-    badVersion: bad,
-  });
+  try {
+    await sendTask(IpcEvents.TASK_BISECT, {
+      setup: getSetup(opts),
+      goodVersion: good,
+      badVersion: bad,
+    });
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
 }
 
 async function test(opts: commander.OptionValues) {
   try {
-    sendTask(IpcEvents.TASK_TEST, {
+    await sendTask(IpcEvents.TASK_TEST, {
       setup: getSetup(opts),
     });
   } catch (err) {
     console.error(err);
+    process.exit(1);
   }
 }
 

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -70,7 +70,7 @@ describe('processCommandLine()', () => {
       const argv = [...ARGV, '--fiddle', FIDDLE];
       const consoleExpected = `Unrecognized Fiddle "${FIDDLE}"`;
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const exitExpected = 1;
+      const exitExpected = 2;
       const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
       await processCommandLine(argv);
       expect(ipcMainManager.send).not.toHaveBeenCalled();
@@ -135,10 +135,10 @@ describe('processCommandLine()', () => {
 
     it('handles a --fiddle option that is unrecognizable', async () => {
       const FIDDLE = '✨🤪💎';
-      const argv = [...ARGV, '--fiddle', FIDDLE];
+      const argv = [...ARGV, GOOD, BAD, '--fiddle', FIDDLE];
       const consoleExpected = `Unrecognized Fiddle "${FIDDLE}"`;
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const exitExpected = 1;
+      const exitExpected = 2;
       const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
       await processCommandLine(argv);
       expect(ipcMainManager.send).not.toHaveBeenCalled();

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -31,6 +31,15 @@ describe('processCommandLine()', () => {
     expect(ipcMainManager.send).not.toHaveBeenCalled();
   });
 
+  it('exits with 2 if called with invalid parameters', async () => {
+    const argv = [...ARGV_PREFIX, 'test', '--this-option-is-unknown=true'];
+    const exitCode = 2;
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+    await processCommandLine(argv);
+    expect(exitSpy).toHaveBeenCalledWith(exitCode);
+    exitSpy.mockReset();
+  });
+
   function expectSendCalledOnceWith(event: IpcEvents, payload: string) {
     const send = ipcMainManager.send as jest.Mock;
     expect(send).toHaveBeenCalledTimes(1);

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -68,12 +68,16 @@ describe('processCommandLine()', () => {
     it('handles a --fiddle option that is unrecognizable', async () => {
       const FIDDLE = '✨🤪💎';
       const argv = [...ARGV, '--fiddle', FIDDLE];
-      const expected = `Unrecognized Fiddle "${FIDDLE}"`;
-      const spy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleExpected = `Unrecognized Fiddle "${FIDDLE}"`;
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const exitExpected = 1;
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
       await processCommandLine(argv);
       expect(ipcMainManager.send).not.toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(expected);
-      spy.mockReset();
+      expect(consoleSpy).toHaveBeenCalledWith(consoleExpected);
+      expect(exitSpy).toHaveBeenCalledWith(exitExpected);
+      consoleSpy.mockReset();
+      exitSpy.mockReset();
     });
 
     it('handles a --version option', async () => {
@@ -127,6 +131,21 @@ describe('processCommandLine()', () => {
       const expected = `{"badVersion":"${BAD}","goodVersion":"${GOOD}","setup":{"fiddle":${DEFAULT_FIDDLE},"hideChannels":["${ElectronReleaseChannel.beta}"],"showChannels":[]}}`;
       await processCommandLine(argv);
       expectBisectCalledOnceWith(expected);
+    });
+
+    it('handles a --fiddle option that is unrecognizable', async () => {
+      const FIDDLE = '✨🤪💎';
+      const argv = [...ARGV, '--fiddle', FIDDLE];
+      const consoleExpected = `Unrecognized Fiddle "${FIDDLE}"`;
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const exitExpected = 1;
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+      await processCommandLine(argv);
+      expect(ipcMainManager.send).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(consoleExpected);
+      expect(exitSpy).toHaveBeenCalledWith(exitExpected);
+      consoleSpy.mockReset();
+      exitSpy.mockReset();
     });
 
     describe(`watches for ${IpcEvents.TASK_DONE} events`, () => {


### PR DESCRIPTION
Ensure that we error out quickly if the command line is fed an unparseable gist.