### PR TITLE
feat: add recentDocuments to fiddle

### DIFF
--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -1,4 +1,4 @@
-import { dialog } from 'electron';
+import { dialog, app } from 'electron';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { DefaultEditorId } from '../interfaces';
@@ -28,7 +28,7 @@ export async function showOpenDialog() {
   if (!filePaths || filePaths.length < 1) {
     return;
   }
-
+  app.addRecentDocument(filePaths[0]);
   ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, [filePaths[0]]);
 }
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,3 +1,4 @@
+import { show } from '@blueprintjs/core/lib/esm/components/context-menu/contextMenu';
 import {
   app,
   BrowserWindow,
@@ -234,6 +235,17 @@ function getFileMenu(
       label: 'Open',
       click: showOpenDialog,
       accelerator: 'CmdOrCtrl+O',
+    },
+    {
+      label: 'Open Recent',
+      role: 'recentDocuments',
+      // click: ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, what is my file path),
+      submenu: [
+        {
+          label: 'Clear Recent',
+          role: 'clearRecentDocuments',
+        },
+      ],
     },
     {
       type: 'separator',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,3 @@
-import { show } from '@blueprintjs/core/lib/esm/components/context-menu/contextMenu';
 import {
   app,
   BrowserWindow,
@@ -239,7 +238,6 @@ function getFileMenu(
     {
       label: 'Open Recent',
       role: 'recentDocuments',
-      // click: ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, what is my file path),
       submenu: [
         {
           label: 'Clear Recent',

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -92,6 +92,12 @@ export const listenForProtocolHandler = () => {
       handlePotentialProtocolLaunch(url);
     }
   });
+  app.on('open-file', (_, url) => {
+    if (!url || url.length < 1) {
+      return;
+    }
+    ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, [url]);
+  });
 
   // pass protocol URL via npm start args in dev mode
   if (isDevMode() && process.env.npm_config_argv) {

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -92,11 +92,11 @@ export const listenForProtocolHandler = () => {
       handlePotentialProtocolLaunch(url);
     }
   });
-  app.on('open-file', (_, url) => {
-    if (!url || url.length < 1) {
+  app.on('open-file', (_, path) => {
+    if (!path || path.length < 1) {
       return;
     }
-    ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, [url]);
+    ipcMainManager.send(IpcEvents.FS_OPEN_FIDDLE, [path]);
   });
 
   // pass protocol URL via npm start args in dev mode

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../../src/main/files';
 import { ipcMainManager } from '../../src/main/ipc';
 
-import { dialog } from 'electron';
+import { app, dialog } from 'electron';
 import * as fs from 'fs-extra';
 import { getOrCreateMainWindow } from '../../src/main/windows';
 
@@ -67,6 +67,12 @@ describe('files', () => {
       await showOpenDialog();
 
       expect(mockTarget.webContents.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('adds the opened file path to recent files', async () => {
+      await showOpenDialog();
+      // (app.addRecentDocument as jest.Mock).mock.calls[0];
+      expect(app.addRecentDocument).toHaveBeenCalled();
     });
   });
 

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -70,8 +70,8 @@ describe('files', () => {
     });
 
     it('adds the opened file path to recent files', async () => {
+      (app.addRecentDocument as jest.Mock).mock.calls[0];
       await showOpenDialog();
-      // (app.addRecentDocument as jest.Mock).mock.calls[0];
       expect(app.addRecentDocument).toHaveBeenCalled();
     });
   });

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -74,7 +74,7 @@ describe('main', () => {
 
     it('listens to core events', () => {
       main([]);
-      expect(app.on).toHaveBeenCalledTimes(4);
+      expect(app.on).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -277,10 +277,11 @@ describe('menu', () => {
         NEW_TEST = 1,
         NEW_WINDOW = 2,
         OPEN = 4,
-        SAVE = 6,
-        SAVE_AS = 7,
-        PUBLISH = 9,
-        FORGE = 10,
+        OPEN_RECENT = 5,
+        SAVE = 7,
+        SAVE_AS = 8,
+        PUBLISH = 10,
+        FORGE = 11,
       }
 
       beforeEach(() => {

--- a/tests/mocks/electron.ts
+++ b/tests/mocks/electron.ts
@@ -104,6 +104,7 @@ function CreateWindowStub() {
 }
 
 const app = {
+  addRecentDocument: jest.fn(),
   getName: jest.fn().mockReturnValue('Electron Fiddle'),
   exit: jest.fn(),
   hide: jest.fn(),


### PR DESCRIPTION
fixes: #316

This adds functionality to open and clear recent documents- either through the 'file' menu or the app context menu.

![image](https://user-images.githubusercontent.com/33054982/120385246-08bb0500-c2dc-11eb-990a-8cfcc5e025f1.png)

![image](https://user-images.githubusercontent.com/33054982/120385269-107aa980-c2dc-11eb-8739-781afb4b1bf8.png)
