### PR TITLE
feat: add --log-config command-line option

### DIFF
--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -73,8 +73,20 @@ async function sendTask(type: IpcEvents, task: any) {
   ipcMainManager.send(type, [task]);
 }
 
+function logConfig() {
+  const packageJson = require('../../package.json');
+  const { name, version } = packageJson;
+  const { argv, platform } = process;
+  console.log(`${name} started
+   argv: ${JSON.stringify(argv)}
+   date: ${new Date()}
+   platform: ${platform}
+   version: ${version}`);
+}
+
 async function bisect(good: string, bad: string, opts: commander.OptionValues) {
   try {
+    if (opts.logConfig) logConfig();
     await sendTask(IpcEvents.TASK_BISECT, {
       setup: getSetup(opts),
       goodVersion: good,
@@ -88,6 +100,7 @@ async function bisect(good: string, bad: string, opts: commander.OptionValues) {
 
 async function test(opts: commander.OptionValues) {
   try {
+    if (opts.logConfig) logConfig();
     await sendTask(IpcEvents.TASK_TEST, {
       setup: getSetup(opts),
     });
@@ -105,6 +118,7 @@ export async function processCommandLine(argv: string[]) {
     .command('bisect <goodVersion> <badVersion>')
     .description('Find where regressions were introduced')
     .option('--fiddle <dir|gist>', 'Open a fiddle', process.cwd())
+    .option('--log-config', 'Log the fiddle version, platform, and args', false)
     .option('--nightlies', 'Include nightly releases')
     .option('--no-nightlies', 'Omit nightly releases')
     .option('--betas', 'Include beta releases')
@@ -118,6 +132,7 @@ export async function processCommandLine(argv: string[]) {
     .description('Test a fiddle')
     .option('--version <version>', 'Use Electron version')
     .option('--fiddle <dir|gist>', 'Open a fiddle', process.cwd())
+    .option('--log-config', 'Log the fiddle version, platform, and args', false)
     .action(test);
 
   program.addHelpText(

--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -75,13 +75,11 @@ async function sendTask(type: IpcEvents, task: any) {
 
 function logConfig() {
   const packageJson = require('../../package.json');
-  const { name, version } = packageJson;
-  const { argv, platform } = process;
-  console.log(`${name} started
-   argv: ${JSON.stringify(argv)}
+  console.log(`${packageJson.name} started
+   argv: ${JSON.stringify(process.argv)}
    date: ${new Date()}
-   platform: ${platform}
-   version: ${version}`);
+   platform: ${process.platform}
+   version: ${packageJson.version}`);
 }
 
 async function bisect(good: string, bad: string, opts: commander.OptionValues) {

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -52,6 +52,19 @@ describe('processCommandLine()', () => {
     expect(stringify(request)).toBe(payload);
   }
 
+  async function expectLogConfigOptionWorks(argv: string[]) {
+    argv = [...argv, '--log-config'];
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await processCommandLine(argv);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringMatching('electron-fiddle started'),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringMatching(`platform: ${process.platform}`),
+    );
+    consoleSpy.mockReset();
+  }
+
   describe('test', () => {
     const ARGV = [...ARGV_PREFIX, 'test'];
 
@@ -95,6 +108,10 @@ describe('processCommandLine()', () => {
       const expected = `{"setup":{"fiddle":${DEFAULT_FIDDLE},"hideChannels":[],"showChannels":[],"version":"${VERSION}"}}`;
       await processCommandLine(argv);
       expectTestCalledOnceWith(expected);
+    });
+
+    it('handles a --log-config option', async () => {
+      await expectLogConfigOptionWorks([...ARGV, '--log-config']);
     });
   });
 
@@ -169,6 +186,10 @@ describe('processCommandLine()', () => {
       expect(exitSpy).toHaveBeenCalledWith(exitExpected);
       consoleSpy.mockReset();
       exitSpy.mockReset();
+    });
+
+    it('handles a --log-config option', async () => {
+      await expectLogConfigOptionWorks([...ARGV, GOOD, BAD, '--log-config']);
     });
 
     describe(`watches for ${IpcEvents.TASK_DONE} events`, () => {


### PR DESCRIPTION
Add a command-line argument `--log-config` that will show the electron-fiddle version, platform, and argv. This info is something that will be nice-to-have in bugbot's logfiles.