### PR TITLE
fix: Handle protocol links on Windows

### DIFF
--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -92,6 +92,13 @@ export const listenForProtocolHandler = () => {
       handlePotentialProtocolLaunch(url);
     }
   });
+
+  app.removeAllListeners('second-instance');
+  app.on('second-instance', (_event, commandLine, _workingDirectory) => {
+    // Someone tried to run a second instance
+    scanArgv(commandLine);
+  });
+
   app.on('open-file', (_, path) => {
     if (!path || path.length < 1) {
       return;

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -49,7 +49,7 @@ export class AddThemeDialog extends React.Component<
    */
   public async onChangeFile(event: React.FormEvent<HTMLInputElement>) {
     const { files } = event.target as any;
-    const file = files?.[0] ;
+    const file = files?.[0];
 
     this.setState({ file });
   }

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -74,7 +74,7 @@ describe('main', () => {
 
     it('listens to core events', () => {
       main([]);
-      expect(app.on).toHaveBeenCalledTimes(5);
+      expect(app.on).toHaveBeenCalledTimes(6);
     });
   });
 

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -41,6 +41,20 @@ describe('protocol', () => {
   });
 
   describe('listenForProtocolHandler()', () => {
+    it('handles a Fiddle url (second-instance)', () => {
+      overridePlatform('win32');
+
+      listenForProtocolHandler();
+
+      const handler = (app.on as any).mock.calls[1][1];
+
+      handler({}, ['electron-fiddle://gist/hi']);
+      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        IpcEvents.LOAD_GIST_REQUEST,
+        [{ id: 'hi' }],
+      );
+    });
+
     it('handles a Fiddle url (open-url)', () => {
       overridePlatform('darwin');
 


### PR DESCRIPTION
Turns out, we never handled protocol links on Windows. I KNOW. I can't quite believe it, either.