### PR TITLE
fix: don't exclude first line on clear

### DIFF
--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -137,9 +137,7 @@ export class Output extends React.Component<CommandsProps> {
     }
 
     // The last 1000 lines
-    const lines = output
-      .slice(Math.max(output.length - 1000, 1))
-      .map(this.renderEntry);
+    const lines = output.slice(-1000).map(this.renderEntry);
 
     return (
       <div className="output" ref={this.outputRef}>

--- a/tests/renderer/components/__snapshots__/output-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/output-spec.tsx.snap
@@ -5,7 +5,22 @@ exports[`Output component renders with output 1`] = `
   className="output"
 >
   <div
-    key="1532704073130--0--0"
+    key="1532704072127--0--0"
+  >
+    <span
+      className="output-message"
+      style={Object {}}
+    >
+      <span
+        className="timestamp"
+      >
+        1532704072127
+      </span>
+      Hello!
+    </span>
+  </div>
+  <div
+    key="1532704073130--1--0"
   >
     <span
       className="output-message"
@@ -20,7 +35,7 @@ exports[`Output component renders with output 1`] = `
     </span>
   </div>
   <div
-    key="1532704073130--1--0"
+    key="1532704073130--2--0"
   >
     <span
       className="output-message"


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/709.

```js
const lines = output
  .slice(Math.max(output.length - 1000, 1))
  .map(this.renderEntry);
```

excludes the first element, which we wouldn't want to do especially when clearing Fiddles as it would lead to single dropped lines. Correct that.