### PR TITLE
feat: try downloading version if missing

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -85,8 +85,8 @@ async function downloadBinary(ver: RunnableVersion): Promise<void> {
     // Ensure the target path is empty
     await fs.emptyDir(extractPath);
 
-    const electronFiles = await unzip(zipPath, extractPath);
-    console.log(`Binary: Unzipped ${version}`, electronFiles);
+    await unzip(zipPath, extractPath);
+    console.log(`Binary: Unzipped ${version}`);
     ver.state = VersionState.ready;
   } catch (error) {
     console.warn(`Binary: Failure while unzipping ${version}`, error);

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -157,6 +157,8 @@ export class RemoteLoader {
           );
           return false;
         }
+      } else {
+        return false;
       }
     }
 
@@ -288,19 +290,14 @@ export class RemoteLoader {
    * @returns {boolean}
    */
   private handleLoadingFailed(error: Error): false {
-    if (navigator.onLine) {
-      this.appState.setGenericDialogOptions({
-        type: GenericDialogType.warning,
-        label: `Loading the fiddle failed: ${error}`,
-        cancel: undefined,
-      });
-    } else {
-      this.appState.setGenericDialogOptions({
-        type: GenericDialogType.warning,
-        label: `Loading the fiddle failed. Your computer seems to be offline. Error: ${error}`,
-        cancel: undefined,
-      });
-    }
+    const failedLabel = `Loading the fiddle failed: ${error.message}`;
+    this.appState.setGenericDialogOptions({
+      type: GenericDialogType.warning,
+      label: navigator.onLine
+        ? failedLabel
+        : `Your computer seems to be offline. ${failedLabel}`,
+      cancel: undefined,
+    });
 
     this.appState.toggleGenericDialog();
 

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -244,14 +244,11 @@ export class RemoteLoader {
   public async askToDownloadMissingVersion(
     missingVersion: string,
   ): Promise<boolean> {
-    this.appState.setGenericDialogOptions({
-      type: GenericDialogType.confirm,
+    return this.appState.runConfirmationDialog({
       label: `It doesn't look like you've previously downloaded ${missingVersion} - Would you like to download it now?`,
+      ok: 'Download',
+      type: GenericDialogType.confirm,
     });
-    this.appState.isGenericDialogShowing = true;
-    await when(() => !this.appState.isGenericDialogShowing);
-
-    return !!this.appState.genericDialogLastResult;
   }
 
   public async verifyReleaseChannelEnabled(channel: string): Promise<boolean> {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -419,7 +419,7 @@ export class AppState {
     this.addNewVersions(getElectronVersions());
   }
 
-  @action private addNewVersions(versions: RunnableVersion[]) {
+  @action public addNewVersions(versions: RunnableVersion[]) {
     for (const ver of versions) {
       this.versions[ver.version] ||= ver;
     }

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -58,6 +58,7 @@ export class StateMock {
   public Bisector = new BisectorMock();
   public addAcceleratorToBlock = jest.fn();
   public addLocalVersion = jest.fn();
+  public addNewVersions = jest.fn();
   public clearConsole = jest.fn();
   public currentElectronVersion = new VersionsMock().mockVersionsArray.shift()!;
   public disableTour = jest.fn();

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -1,7 +1,8 @@
 import {
   DefaultEditorId,
   ElectronReleaseChannel,
-  GenericDialogType,
+  VersionSource,
+  VersionState,
 } from '../../src/interfaces';
 import { ipcRendererManager } from '../../src/renderer/ipc';
 import { RemoteLoader } from '../../src/renderer/remote-loader';
@@ -211,7 +212,7 @@ describe('RemoteLoader', () => {
       const result = await instance.fetchExampleAndLoad('4.0.0', 'test/path');
       expect(result).toBe(false);
       expect(store.setGenericDialogOptions.mock.calls[0][0].label).toEqual(
-        'Loading the fiddle failed: Error: The example Fiddle tried to launch is not a valid Electron example',
+        'Loading the fiddle failed: The example Fiddle tried to launch is not a valid Electron example',
       );
     });
   });
@@ -238,24 +239,43 @@ describe('RemoteLoader', () => {
       expect(store.channelsToShow).toContain(ElectronReleaseChannel.beta);
     });
 
-    it('does not load unsupported versions of Fiddle', async () => {
+    it('tries to download missing versions of Electron', async () => {
+      const version = '5.0.0';
       instance.getPackageVersionFromRef = jest
         .fn()
-        .mockReturnValueOnce('5.0.0');
+        .mockReturnValueOnce(version);
+      instance.askToDownloadMissingVersion = jest
+        .fn()
+        .mockReturnValueOnce(true);
 
-      const result = await instance.setElectronVersionWithRef('5.0.0');
+      const result = await instance.setElectronVersionWithRef(version);
+      expect(result).toBe(true);
+      expect(store.addNewVersions).toBeCalledWith([
+        {
+          source: VersionSource.remote,
+          state: VersionState.unknown,
+          version,
+        },
+      ]);
+      expect(store.setVersion).toBeCalledWith(version);
+    });
+
+    it('does not load unsupported versions of Electron', async () => {
+      const version = '3.0.0';
+      instance.getPackageVersionFromRef = jest
+        .fn()
+        .mockReturnValueOnce(version);
+      instance.askToDownloadMissingVersion = jest
+        .fn()
+        .mockReturnValueOnce(false);
+
+      const result = await instance.setElectronVersionWithRef(version);
       expect(result).toBe(false);
-      expect(store.setGenericDialogOptions).toBeCalledWith({
-        type: GenericDialogType.warning,
-        label:
-          'Loading the fiddle failed: Error: Version of Electron in example not supported',
-        cancel: undefined,
-      });
     });
   });
 
   describe('getPackageFromRef()', () => {
-    it('gets electron version from package.json', async () => {
+    it('gets Electron version from package.json', async () => {
       const versionString = JSON.stringify({ version: '4.0.0' });
       const content = Buffer.from(versionString).toString('base64');
       const mockGetPackageJson = {
@@ -323,15 +343,6 @@ describe('RemoteLoader', () => {
   });
 
   describe('loadFiddleFromGist()', () => {
-    it('loads the example with confirmation', async () => {
-      instance.verifyRemoteLoad = jest.fn().mockReturnValue(true);
-      instance.fetchGistAndLoad = jest.fn();
-      await instance.loadFiddleFromGist({}, { id: 'gist' });
-
-      expect(instance.verifyRemoteLoad).toHaveBeenCalledWith<any>('gist');
-      expect(instance.fetchGistAndLoad).toHaveBeenCalledWith<any>('gist');
-    });
-
     it('loads the example with confirmation', async () => {
       instance.verifyRemoteLoad = jest.fn().mockReturnValue(true);
       instance.fetchGistAndLoad = jest.fn();

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -244,9 +244,6 @@ describe('RemoteLoader', () => {
       instance.getPackageVersionFromRef = jest
         .fn()
         .mockReturnValueOnce(version);
-      instance.askToDownloadMissingVersion = jest
-        .fn()
-        .mockReturnValueOnce(true);
 
       const result = await instance.setElectronVersionWithRef(version);
       expect(result).toBe(true);
@@ -258,19 +255,6 @@ describe('RemoteLoader', () => {
         },
       ]);
       expect(store.setVersion).toBeCalledWith(version);
-    });
-
-    it('does not load unsupported versions of Electron', async () => {
-      const version = '3.0.0';
-      instance.getPackageVersionFromRef = jest
-        .fn()
-        .mockReturnValueOnce(version);
-      instance.askToDownloadMissingVersion = jest
-        .fn()
-        .mockReturnValueOnce(false);
-
-      const result = await instance.setElectronVersionWithRef(version);
-      expect(result).toBe(false);
     });
   });
 


### PR DESCRIPTION
Should ideally land after https://github.com/electron/fiddle/pull/719.

This PR makes it such that if a user tries to launch a fiddle via https://fiddle.electronjs.org/ and the package.json contains an Electron version the user doesn't have downloaded, Fiddle will ask if the user would like to download it before proceeding instead of just failing and exiting.

Tested by running 

```sh
yarn start electron-fiddle://electron/main/docs/fiddles/screen/fit-screen
```