### PR TITLE
fix: show warning dialog for missing local versions

### DIFF
--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -1,4 +1,4 @@
-import { Button, IButtonProps, Spinner } from '@blueprintjs/core';
+import { Button, ButtonProps, Spinner } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
@@ -26,7 +26,7 @@ export class Runner extends React.Component<RunnerProps> {
     } = this.props.appState;
 
     const state = currentElectronVersion && currentElectronVersion.state;
-    const props: IButtonProps = { className: 'button-run', disabled: true };
+    const props: ButtonProps = { className: 'button-run', disabled: true };
 
     if (state === VersionState.downloading) {
       props.text = 'Downloading';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -497,7 +497,24 @@ export class AppState {
       return;
     }
 
-    const { version } = ver;
+    const { localPath, version } = ver;
+
+    if (localPath && !fs.existsSync(localPath)) {
+      console.error(
+        `State: setVersion() got a version ${version} with missing binary`,
+      );
+
+      this.setGenericDialogOptions({
+        type: GenericDialogType.warning,
+        label: `Local Electron build missing for version ${version} - please verify it is in the correct location or remove and re-add it.`,
+        cancel: undefined,
+      });
+      this.toggleGenericDialog();
+
+      await this.setVersion(this.versionsToShow[0].version);
+      return;
+    }
+
     console.log(`State: Switching to Electron ${version}`);
 
     // Should we update the editor?


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/723.

if a local build is now selected but it's missing, Fiddle will now show a warning dialog indicating that the version can't be selected and that the user should verify it.

<img width="485" alt="Screen Shot 2021-06-19 at 10 26 11 AM" src="https://user-images.githubusercontent.com/2036040/122636294-c883c100-d0e8-11eb-89a2-05e795035721.png">
