### PR TITLE
fix: add dialog box for when user adds duplicate local electron builds

### DIFF
--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -7,7 +7,6 @@ import {
   Intent,
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
-import { isValid } from 'namor';
 import * as path from 'path';
 import * as React from 'react';
 import * as semver from 'semver';
@@ -203,23 +202,18 @@ export class AddVersionDialog extends React.Component<
   }
 
   private buildDialogText(): string {
-    const {
-      isValidElectron,
-      isValidVersion,
-      existingLocalVersion,
-    } = this.state;
-    const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
+    const { isValidElectron, existingLocalVersion } = this.state;
     const canSwitch = isValidElectron && existingLocalVersion;
 
-    if (canSwitch) {
+    if (canSwitch)
       return `This folder is already in use as version "${
         existingLocalVersion!.version
       }". Would you like to switch to that version now?`;
-    } else if (canAdd) {
+
+    if (isValidElectron)
       return `We found an ${getElectronNameForPlatform()} in this folder.`;
-    } else {
-      return `We did not find a ${getElectronNameForPlatform()} in this folder...`;
-    }
+
+    return `We did not find a ${getElectronNameForPlatform()} in this folder...`;
   }
 
   private renderVersionInput(): JSX.Element | null {

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -136,7 +136,8 @@ export class AddVersionDialog extends React.Component<
       isValidVersion,
       existingLocalVersion,
     } = this.state;
-    const canSubmit = isValidElectron && isValidVersion;
+    const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
+    const canSwitch = isValidElectron && existingLocalVersion;
     // swap to old local electron version if the user adds a new one with the same path
     const shouldSetToPreviousVersion = isValidElectron && existingLocalVersion;
 
@@ -144,9 +145,9 @@ export class AddVersionDialog extends React.Component<
       <Button
         icon="add"
         key="submit"
-        disabled={!shouldSetToPreviousVersion && !canSubmit}
+        disabled={!canAdd && !canSwitch}
         onClick={this.onSubmit}
-        text={shouldSetToPreviousVersion ? 'OK' : 'Add'}
+        text={shouldSetToPreviousVersion ? 'Switch' : 'Add'}
       />,
       <Button icon="cross" key="cancel" onClick={this.onClose} text="Cancel" />,
     ];
@@ -191,13 +192,13 @@ export class AddVersionDialog extends React.Component<
 
   private renderPath(): JSX.Element | null {
     const { isValidElectron, folderPath, existingLocalVersion } = this.state;
-    const shouldSetToPreviousVersion = isValidElectron && existingLocalVersion;
+    const canSwitch = isValidElectron && existingLocalVersion;
 
     if (!folderPath) return null;
     return (
       <Callout>
         {this.buildDialogText()}
-        {!shouldSetToPreviousVersion && this.renderVersionInput()}
+        {!canSwitch && this.renderVersionInput()}
       </Callout>
     );
   }
@@ -206,8 +207,7 @@ export class AddVersionDialog extends React.Component<
     const { existingLocalVersion, isValidElectron } = this.state;
 
     if (isValidElectron && existingLocalVersion) {
-      return `This folder path has already been added as version "${existingLocalVersion.version}".
-      Would you like to set your Electron version to "${existingLocalVersion.version}"? \n \n`;
+      return `This folder is already in use as version "${existingLocalVersion.version}". Would you like to switch to that version now?`;
     } else if (isValidElectron) {
       return `We found an ${getElectronNameForPlatform()} in this folder.`;
     } else {

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -7,6 +7,7 @@ import {
   Intent,
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
+import { isValid } from 'namor';
 import * as path from 'path';
 import * as React from 'react';
 import * as semver from 'semver';
@@ -138,8 +139,6 @@ export class AddVersionDialog extends React.Component<
     } = this.state;
     const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
     const canSwitch = isValidElectron && existingLocalVersion;
-    // swap to old local electron version if the user adds a new one with the same path
-    const shouldSetToPreviousVersion = isValidElectron && existingLocalVersion;
 
     return [
       <Button
@@ -147,7 +146,7 @@ export class AddVersionDialog extends React.Component<
         key="submit"
         disabled={!canAdd && !canSwitch}
         onClick={this.onSubmit}
-        text={shouldSetToPreviousVersion ? 'Switch' : 'Add'}
+        text={canSwitch ? 'Switch' : 'Add'}
       />,
       <Button icon="cross" key="cancel" onClick={this.onClose} text="Cancel" />,
     ];
@@ -204,11 +203,19 @@ export class AddVersionDialog extends React.Component<
   }
 
   private buildDialogText(): string {
-    const { existingLocalVersion, isValidElectron } = this.state;
+    const {
+      isValidElectron,
+      isValidVersion,
+      existingLocalVersion,
+    } = this.state;
+    const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
+    const canSwitch = isValidElectron && existingLocalVersion;
 
-    if (isValidElectron && existingLocalVersion) {
-      return `This folder is already in use as version "${existingLocalVersion.version}". Would you like to switch to that version now?`;
-    } else if (isValidElectron) {
+    if (canSwitch) {
+      return `This folder is already in use as version "${
+        existingLocalVersion!.version
+      }". Would you like to switch to that version now?`;
+    } else if (canAdd) {
       return `We found an ${getElectronNameForPlatform()} in this folder.`;
     } else {
       return `We did not find a ${getElectronNameForPlatform()} in this folder...`;

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -180,6 +180,26 @@ export function addLocalVersion(input: Version): Array<Version> {
 }
 
 /**
+ * Check to see if local version has already been added
+ * for the current folder path
+ *
+ * @param {Version} input
+ * @returns {boolean}
+ */
+export function hasExistingLocalVersion(
+  folderPath: string,
+): Version | undefined {
+  const versions = getLocalVersions();
+  let duplicate;
+
+  versions.find((v) => {
+    if (v.localPath === folderPath) duplicate = v;
+  });
+
+  return duplicate ? (duplicate as Version) : undefined;
+}
+
+/**
  * Retrieves local Electron versions, configured by the user.
  *
  * @returns {Array<Version>}

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -186,15 +186,11 @@ export function addLocalVersion(input: Version): Array<Version> {
  * @param {Version} input
  * @returns {Version | undefined}
  */
-export function hasExistingLocalVersion(
+export function getExistingLocalVersion(
   folderPath: string,
 ): Version | undefined {
   const versions = getLocalVersions();
-  let duplicate;
-
-  versions.find((v) => {
-    if (v.localPath === folderPath) duplicate = v;
-  });
+  const duplicate = versions.find((v) => v.localPath === folderPath);
 
   return duplicate ? (duplicate as Version) : undefined;
 }

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -180,19 +180,15 @@ export function addLocalVersion(input: Version): Array<Version> {
 }
 
 /**
- * Check to see if local version has already been added
- * for the current folder path
+ * Get the Version (if any) that is located at localPath.
  *
- * @param {Version} input
+ * @param {string} input
  * @returns {Version | undefined}
  */
-export function getExistingLocalVersion(
+export function getLocalVersionForPath(
   folderPath: string,
 ): Version | undefined {
-  const versions = getLocalVersions();
-  const duplicate = versions.find((v) => v.localPath === folderPath);
-
-  return duplicate ? (duplicate as Version) : undefined;
+  return getLocalVersions().find((v) => v.localPath === folderPath);
 }
 
 /**

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -184,7 +184,7 @@ export function addLocalVersion(input: Version): Array<Version> {
  * for the current folder path
  *
  * @param {Version} input
- * @returns {boolean}
+ * @returns {Version | undefined}
  */
 export function hasExistingLocalVersion(
   folderPath: string,

--- a/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AddVersionDialog component onSubmit shows dialog warning when adding duplicate local versions 1`] = `
+<Blueprint3.Dialog
+  canOutsideClickClose={true}
+  className="dialog-add-version"
+  isOpen={false}
+  onClose={[Function]}
+  title="Add local Electron build"
+>
+  <div
+    className="bp3-dialog-body"
+  >
+    <Blueprint3.FileInput
+      hasSelection={false}
+      id="custom-electron-version"
+      inputProps={
+        Object {
+          "onClick": [Function],
+        }
+      }
+      text="/test/path"
+    />
+    <br />
+    <Blueprint3.Callout>
+      This folder path has already been added as version "2.2.2". Please remove and re-add.
+    </Blueprint3.Callout>
+  </div>
+  <div
+    className="bp3-dialog-footer"
+  >
+    <div
+      className="bp3-dialog-footer-actions"
+    >
+      <Blueprint3.Button
+        disabled={true}
+        icon="add"
+        key="submit"
+        onClick={[Function]}
+        text="Add"
+      />
+      <Blueprint3.Button
+        icon="cross"
+        key="cancel"
+        onClick={[Function]}
+        text="Cancel"
+      />
+    </div>
+  </div>
+</Blueprint3.Dialog>
+`;
+
 exports[`AddVersionDialog component renders 1`] = `
 <Blueprint3.Dialog
   canOutsideClickClose={true}
@@ -111,6 +161,56 @@ exports[`AddVersionDialog component renders 2`] = `
     >
       <Blueprint3.Button
         disabled={true}
+        icon="add"
+        key="submit"
+        onClick={[Function]}
+        text="Add"
+      />
+      <Blueprint3.Button
+        icon="cross"
+        key="cancel"
+        onClick={[Function]}
+        text="Cancel"
+      />
+    </div>
+  </div>
+</Blueprint3.Dialog>
+`;
+
+exports[`AddVersionDialog component renders 3`] = `
+<Blueprint3.Dialog
+  canOutsideClickClose={true}
+  className="dialog-add-version"
+  isOpen={false}
+  onClose={[Function]}
+  title="Add local Electron build"
+>
+  <div
+    className="bp3-dialog-body"
+  >
+    <Blueprint3.FileInput
+      hasSelection={false}
+      id="custom-electron-version"
+      inputProps={
+        Object {
+          "onClick": [Function],
+        }
+      }
+      text="/test/file"
+    />
+    <br />
+    <Blueprint3.Callout>
+      This folder path has already been added as version "2.2.2". Please remove and re-add.
+    </Blueprint3.Callout>
+  </div>
+  <div
+    className="bp3-dialog-footer"
+  >
+    <div
+      className="bp3-dialog-footer-actions"
+    >
+      <Blueprint3.Button
+        disabled={false}
         icon="add"
         key="submit"
         onClick={[Function]}

--- a/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
@@ -23,10 +23,7 @@ exports[`AddVersionDialog component onSubmit shows dialog warning when adding du
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2".
-      Would you like to set your Electron version to "2.2.2"? 
- 
-
+      This folder is already in use as version "2.2.2". Would you like to switch to that version now?
     </Blueprint3.Callout>
   </div>
   <div
@@ -40,7 +37,7 @@ exports[`AddVersionDialog component onSubmit shows dialog warning when adding du
         icon="add"
         key="submit"
         onClick={[Function]}
-        text="OK"
+        text="Switch"
       />
       <Blueprint3.Button
         icon="cross"
@@ -203,10 +200,7 @@ exports[`AddVersionDialog component renders 3`] = `
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2".
-      Would you like to set your Electron version to "2.2.2"? 
- 
-
+      This folder is already in use as version "2.2.2". Would you like to switch to that version now?
     </Blueprint3.Callout>
   </div>
   <div
@@ -220,7 +214,7 @@ exports[`AddVersionDialog component renders 3`] = `
         icon="add"
         key="submit"
         onClick={[Function]}
-        text="OK"
+        text="Switch"
       />
       <Blueprint3.Button
         icon="cross"

--- a/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
@@ -23,24 +23,10 @@ exports[`AddVersionDialog component onSubmit shows dialog warning when adding du
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2". Would you like to set this path as a new version? 
+      This folder path has already been added as version "2.2.2".
+      Would you like to set your Electron version to "2.2.2"? 
  
 
-      <p>
-        <br />
-        Please specify a version, used for typings and the name. Must be
-         
-        <code>
-          semver
-        </code>
-         compliant.
-      </p>
-      <Blueprint3.InputGroup
-        intent="danger"
-        onChange={[Function]}
-        placeholder="4.0.0"
-        value="3.3.3"
-      />
     </Blueprint3.Callout>
   </div>
   <div
@@ -217,23 +203,10 @@ exports[`AddVersionDialog component renders 3`] = `
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2". Would you like to set this path as a new version? 
+      This folder path has already been added as version "2.2.2".
+      Would you like to set your Electron version to "2.2.2"? 
  
 
-      <p>
-        <br />
-        Please specify a version, used for typings and the name. Must be
-         
-        <code>
-          semver
-        </code>
-         compliant.
-      </p>
-      <Blueprint3.InputGroup
-        onChange={[Function]}
-        placeholder="4.0.0"
-        value=""
-      />
     </Blueprint3.Callout>
   </div>
   <div

--- a/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-add-version-spec.tsx.snap
@@ -23,7 +23,24 @@ exports[`AddVersionDialog component onSubmit shows dialog warning when adding du
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2". Please remove and re-add.
+      This folder path has already been added as version "2.2.2". Would you like to set this path as a new version? 
+ 
+
+      <p>
+        <br />
+        Please specify a version, used for typings and the name. Must be
+         
+        <code>
+          semver
+        </code>
+         compliant.
+      </p>
+      <Blueprint3.InputGroup
+        intent="danger"
+        onChange={[Function]}
+        placeholder="4.0.0"
+        value="3.3.3"
+      />
     </Blueprint3.Callout>
   </div>
   <div
@@ -33,11 +50,11 @@ exports[`AddVersionDialog component onSubmit shows dialog warning when adding du
       className="bp3-dialog-footer-actions"
     >
       <Blueprint3.Button
-        disabled={true}
+        disabled={false}
         icon="add"
         key="submit"
         onClick={[Function]}
-        text="Add"
+        text="OK"
       />
       <Blueprint3.Button
         icon="cross"
@@ -200,7 +217,23 @@ exports[`AddVersionDialog component renders 3`] = `
     />
     <br />
     <Blueprint3.Callout>
-      This folder path has already been added as version "2.2.2". Please remove and re-add.
+      This folder path has already been added as version "2.2.2". Would you like to set this path as a new version? 
+ 
+
+      <p>
+        <br />
+        Please specify a version, used for typings and the name. Must be
+         
+        <code>
+          semver
+        </code>
+         compliant.
+      </p>
+      <Blueprint3.InputGroup
+        onChange={[Function]}
+        placeholder="4.0.0"
+        value=""
+      />
     </Blueprint3.Callout>
   </div>
   <div
@@ -214,7 +247,7 @@ exports[`AddVersionDialog component renders 3`] = `
         icon="add"
         key="submit"
         onClick={[Function]}
-        text="Add"
+        text="OK"
       />
       <Blueprint3.Button
         icon="cross"

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -49,6 +49,18 @@ describe('AddVersionDialog component', () => {
     });
 
     expect(wrapper).toMatchSnapshot();
+
+    wrapper.setState({
+      isValidVersion: true,
+      isValidElectron: true,
+      existingLocalVersion: {
+        version: '2.2.2',
+        localPath: mockFile,
+      },
+      folderPath: mockFile,
+    });
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('overrides default input with Electron dialog', () => {
@@ -124,6 +136,22 @@ describe('AddVersionDialog component', () => {
 
       expect(result.localPath).toBe('/test/path');
       expect(result.version).toBe('3.3.3');
+    });
+
+    it('shows dialog warning when adding duplicate local versions', async () => {
+      const wrapper = shallow(<AddVersionDialog appState={store as any} />);
+
+      wrapper.setState({
+        isValidElectron: true,
+        folderPath: '/test/path',
+        version: '3.3.3',
+        existingLocalVersion: {
+          version: '2.2.2',
+          localPath: '/test/path',
+        },
+      });
+
+      expect(wrapper).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Co-authored-by: VerteDinde <vertedinde@electronjs.org>

Users can be confused when adding a local electron build using the same folder path as a previously added (but not removed) build.

current behaviour checks that the path has been added before and ignores it, without feedback to the user.

This fix aims to resolve any user confusion as to why their local electron build "did not upload"

- [x] added check for existing local version
- [x] added snapshot test to ensure dialog box shows when expected

![image](https://user-images.githubusercontent.com/33054982/123000927-0856dc80-d365-11eb-917a-6f862efb4d51.png)
