### PR TITLE
refactor: add AppState dialog helper functions

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -93,9 +93,10 @@ export interface OutputOptions {
 
 export interface GenericDialogOptions {
   type: GenericDialogType;
-  ok?: string;
+  ok: string;
   cancel?: string;
-  wantsInput?: boolean;
+  wantsInput: boolean;
+  defaultInput?: string;
   label: string | JSX.Element;
   placeholder?: string;
 }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -6,12 +6,7 @@ import * as MonacoType from 'monaco-editor';
 
 import { ipcRenderer } from 'electron';
 import { ipcRendererManager } from './ipc';
-import {
-  EditorValues,
-  GenericDialogType,
-  PACKAGE_NAME,
-  SetFiddleOptions,
-} from '../interfaces';
+import { EditorValues, PACKAGE_NAME, SetFiddleOptions } from '../interfaces';
 import { WEBCONTENTS_READY_FOR_IPC_SIGNAL, IpcEvents } from '../ipc-events';
 import { getPackageJson, PackageJsonOptions } from '../utils/get-package';
 import { FileManager } from './file-manager';
@@ -44,19 +39,20 @@ export class App {
     this.taskRunner = new TaskRunner(this);
   }
 
-  private async confirmReplaceUnsaved() {
-    return this.state.runConfirmationDialog({
-      label: `Opening this Fiddle will replace your unsaved changes. Do you want to proceed?`,
-      ok: 'Yes',
-      type: GenericDialogType.warning,
+  private confirmReplaceUnsaved(): Promise<boolean> {
+    return this.state.showConfirmDialog({
+      cancel: 'Cancel',
+      label:
+        'Opening this Fiddle will replace your unsaved changes. Do you want to proceed?',
+      ok: 'Open',
     });
   }
 
-  private async confirmExitUnsaved() {
-    return this.state.runConfirmationDialog({
+  private confirmExitUnsaved(): Promise<boolean> {
+    return this.state.showConfirmDialog({
+      cancel: 'Cancel',
       label: 'The current Fiddle is unsaved. Do you want to exit anyway?',
       ok: 'Exit',
-      type: GenericDialogType.warning,
     });
   }
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -41,16 +41,13 @@ export class App {
 
   private confirmReplaceUnsaved(): Promise<boolean> {
     return this.state.showConfirmDialog({
-      cancel: 'Cancel',
-      label:
-        'Opening this Fiddle will replace your unsaved changes. Do you want to proceed?',
+      label: `Opening this Fiddle will replace your unsaved changes. Do you want to proceed?`,
       ok: 'Open',
     });
   }
 
   private confirmExitUnsaved(): Promise<boolean> {
     return this.state.showConfirmDialog({
-      cancel: 'Cancel',
       label: 'The current Fiddle is unsaved. Do you want to exit anyway?',
       ok: 'Exit',
     });

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -104,7 +104,6 @@ export class GistActionButton extends React.Component<
   private getFiddleDescriptionFromUser(): Promise<string | undefined> {
     const placeholder = 'Electron Fiddle Gist' as const;
     return this.props.appState.showInputDialog({
-      cancel: 'Cancel',
       defaultInput: placeholder,
       label: 'Please provide a brief description for your Fiddle Gist',
       ok: 'Publish',

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -15,7 +15,6 @@ import { when } from 'mobx';
 import {
   DEFAULT_EDITORS,
   EditorValues,
-  GenericDialogType,
   GistActionState,
   GistActionType,
 } from '../../interfaces';
@@ -102,27 +101,15 @@ export class GistActionButton extends React.Component<
     }
   }
 
-  public async getFiddleDescriptionFromUser(): Promise<string | null> {
-    const { appState } = this.props;
-
-    // Reset potentially non-null last description.
-    appState.genericDialogLastInput = null;
-
-    appState.setGenericDialogOptions({
-      type: GenericDialogType.confirm,
-      label: 'Please provide a brief description for your Fiddle Gist',
-      wantsInput: true,
-      ok: 'Publish',
+  private getFiddleDescriptionFromUser(): Promise<string | undefined> {
+    const placeholder = 'Electron Fiddle Gist' as const;
+    return this.props.appState.showInputDialog({
       cancel: 'Cancel',
-      placeholder: 'Electron Fiddle Gist',
+      defaultInput: placeholder,
+      label: 'Please provide a brief description for your Fiddle Gist',
+      ok: 'Publish',
+      placeholder,
     });
-    appState.isGenericDialogShowing = true;
-    await when(() => !appState.isGenericDialogShowing);
-
-    const cancelled = !appState.genericDialogLastResult;
-    return cancelled
-      ? null
-      : appState.genericDialogLastInput ?? 'Electron Fiddle Gist';
   }
 
   private async publishGist(description: string) {
@@ -175,7 +162,6 @@ export class GistActionButton extends React.Component<
       appState.editorMosaic.isEdited = false;
     }
 
-    appState.genericDialogLastInput = null;
     appState.activeGistAction = GistActionState.none;
   }
 

--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -2,7 +2,7 @@ import { Button } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { GenericDialogType, VersionState } from '../../../src/interfaces';
+import { VersionState } from '../../../src/interfaces';
 import { AppState } from '../state';
 
 interface BisectHandlerProps {
@@ -44,12 +44,7 @@ export class BisectHandler extends React.Component<BisectHandlerProps> {
       );
 
       appState.pushOutput(`[BISECT] Complete: ${minVer}...${maxVer}`);
-      appState.setGenericDialogOptions({
-        type: GenericDialogType.success,
-        label,
-        cancel: undefined,
-      });
-      appState.isGenericDialogShowing = true;
+      appState.showInfoDialog(label);
     } else {
       appState.setVersion(response.version);
     }

--- a/src/renderer/components/commands-editors.tsx
+++ b/src/renderer/components/commands-editors.tsx
@@ -131,7 +131,6 @@ export class EditorDropdown extends React.Component<
 
   private showCustomEditorDialog(): Promise<string | undefined> {
     return this.props.appState.showInputDialog({
-      cancel: 'Cancel',
       label: 'Enter a filename for your custom editor',
       ok: 'Create',
       placeholder: 'file.js',

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -7,7 +7,6 @@ import * as path from 'path';
 import * as React from 'react';
 import { getTheme, THEMES_PATH } from '../themes';
 
-import { GenericDialogType } from '../../../src/interfaces';
 import { AppState } from '../state';
 import { defaultDark, LoadedFiddleTheme } from '../themes-defaults';
 
@@ -78,11 +77,7 @@ export class AddThemeDialog extends React.Component<
       const name = editor.name ? editor.name : file.name;
       await this.createNewThemeFromMonaco(name, newTheme);
     } catch (error) {
-      appState.setGenericDialogOptions({
-        type: GenericDialogType.warning,
-        label: `${error}, please pick a different file.`,
-      });
-      appState.toggleGenericDialog();
+      appState.showErrorDialog(`${error}, please pick a different file.`);
       return;
     }
 

--- a/src/renderer/components/dialog-generic.tsx
+++ b/src/renderer/components/dialog-generic.tsx
@@ -30,7 +30,7 @@ export class GenericDialog extends React.Component<GenericDialogProps> {
     this.props.appState.genericDialogLastInput =
       input && input.value !== '' ? input.value : null;
     this.props.appState.genericDialogLastResult = result;
-    this.props.appState.toggleGenericDialog();
+    this.props.appState.isGenericDialogShowing = false;
   }
 
   public render() {

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -213,7 +213,6 @@ export class RemoteLoader {
    */
   public verifyRemoteLoad(what: string): Promise<boolean> {
     return this.appState.showConfirmDialog({
-      cancel: 'Cancel',
       label: `Are you sure you want to load this ${what}? Only load and run it if you trust the source.`,
       ok: 'Load',
     });
@@ -221,7 +220,6 @@ export class RemoteLoader {
 
   public verifyReleaseChannelEnabled(channel: string): Promise<boolean> {
     return this.appState.showConfirmDialog({
-      cancel: 'Cancel',
       label: `You're loading an example with a version of Electron with an unincluded release
               channel (${channel}). Do you want to enable the release channel to load the
               version of Electron from the example?`,

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -1,8 +1,6 @@
-import { when } from 'mobx';
 import {
   EditorValues,
   ElectronReleaseChannel,
-  GenericDialogType,
   PACKAGE_NAME,
   VersionSource,
   VersionState,
@@ -200,17 +198,12 @@ export class RemoteLoader {
     }
   }
 
-  public async verifyCreateCustomEditor(editorName: string): Promise<boolean> {
-    this.appState.setGenericDialogOptions({
-      type: GenericDialogType.confirm,
-      label: `Do you want to create a custom editor with name: ${editorName}?`,
+  public verifyCreateCustomEditor(editorName: string): Promise<boolean> {
+    return this.appState.showConfirmDialog({
       cancel: 'Skip',
+      label: `Do you want to create a custom editor with name: ${editorName}?`,
+      ok: 'Create',
     });
-
-    this.appState.isGenericDialogShowing = true;
-    await when(() => !this.appState.isGenericDialogShowing);
-
-    return !!this.appState.genericDialogLastResult;
   }
 
   /**
@@ -218,28 +211,22 @@ export class RemoteLoader {
    *
    * @param {string} what What are we loading from (gist, example, etc.)
    */
-  public async verifyRemoteLoad(what: string): Promise<boolean> {
-    this.appState.setGenericDialogOptions({
-      type: GenericDialogType.confirm,
+  public verifyRemoteLoad(what: string): Promise<boolean> {
+    return this.appState.showConfirmDialog({
+      cancel: 'Cancel',
       label: `Are you sure you want to load this ${what}? Only load and run it if you trust the source.`,
+      ok: 'Load',
     });
-    this.appState.isGenericDialogShowing = true;
-    await when(() => !this.appState.isGenericDialogShowing);
-
-    return !!this.appState.genericDialogLastResult;
   }
 
-  public async verifyReleaseChannelEnabled(channel: string): Promise<boolean> {
-    this.appState.setGenericDialogOptions({
-      type: GenericDialogType.warning,
+  public verifyReleaseChannelEnabled(channel: string): Promise<boolean> {
+    return this.appState.showConfirmDialog({
+      cancel: 'Cancel',
       label: `You're loading an example with a version of Electron with an unincluded release
               channel (${channel}). Do you want to enable the release channel to load the
               version of Electron from the example?`,
+      ok: 'Enable',
     });
-    this.appState.isGenericDialogShowing = true;
-    await when(() => !this.appState.isGenericDialogShowing);
-
-    return !!this.appState.genericDialogLastResult;
   }
 
   /**
@@ -266,15 +253,11 @@ export class RemoteLoader {
    */
   private handleLoadingFailed(error: Error): false {
     const failedLabel = `Loading the fiddle failed: ${error.message}`;
-    this.appState.setGenericDialogOptions({
-      type: GenericDialogType.warning,
-      label: navigator.onLine
+    this.appState.showErrorDialog(
+      navigator.onLine
         ? failedLabel
         : `Your computer seems to be offline. ${failedLabel}`,
-      cancel: undefined,
-    });
-
-    this.appState.toggleGenericDialog();
+    );
 
     console.warn(`Loading Fiddle failed`, error);
     return false;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -113,12 +113,12 @@ export class AppState {
   @observable public output: Array<OutputEntry> = [];
   @observable public localPath: string | undefined;
   @observable public genericDialogOptions: GenericDialogOptions = {
-    cancel: 'Cancel',
+    type: GenericDialogType.warning,
     label: '' as string | JSX.Element,
     ok: 'Okay',
-    placeholder: '',
-    type: GenericDialogType.warning,
+    cancel: 'Cancel',
     wantsInput: false,
+    placeholder: '',
   };
   @observable public readonly editorMosaic = new EditorMosaic();
   @observable public genericDialogLastResult: boolean | null = null;
@@ -561,7 +561,7 @@ export class AppState {
   }
 
   @action public async showInputDialog(opts: {
-    cancel: string;
+    cancel?: string;
     defaultInput?: string;
     label: string | JSX.Element;
     ok: string;
@@ -569,6 +569,7 @@ export class AppState {
   }): Promise<string | undefined> {
     const { confirm, input } = await this.showGenericDialog({
       ...opts,
+      cancel: opts.cancel || 'Cancel',
       type: GenericDialogType.confirm,
       wantsInput: true,
     });
@@ -576,12 +577,13 @@ export class AppState {
   }
 
   @action public async showConfirmDialog(opts: {
-    cancel: string;
+    cancel?: string;
     label: string | JSX.Element;
     ok: string;
   }): Promise<boolean> {
     const { confirm } = await this.showGenericDialog({
       ...opts,
+      cancel: opts.cancel || 'Cancel',
       wantsInput: false,
       type: GenericDialogType.confirm,
     });

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -73,20 +73,20 @@ export class StateMock {
   public flushOutput = jest.fn();
   public removeAcceleratorToBlock = jest.fn();
   public removeVersion = jest.fn();
-  public runConfirmationDialog = jest.fn();
-  public setGenericDialogOptions = jest.fn().mockReturnValue({});
   public setTheme = jest.fn();
   public setVersion = jest.fn().mockImplementation((version: string) => {
     this.version = version;
     this.currentElectronVersion = this.versions[version];
   });
   public showChannels = jest.fn();
-  public showCustomEditorDialog = jest.fn();
+  public showConfirmDialog = jest.fn();
+  public showErrorDialog = jest.fn();
+  public showGenericDialog = jest.fn();
+  public showInfoDialog = jest.fn();
+  public showInputDialog = jest.fn();
   public signOutGitHub = jest.fn();
   public toggleAddVersionDialog = jest.fn();
   public toggleAuthDialog = jest.fn();
-  public toggleGenericDialog = jest.fn();
-  public toggleWarningDialog = jest.fn();
   public updateElectronVersions = jest.fn();
 
   constructor() {

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -120,7 +120,7 @@ describe('App component', () => {
       app.state.editorMosaic.isEdited = true;
       app.state.localPath = '/fake/path';
 
-      (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(true);
+      app.state.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
       const editorValues = {
         [DefaultEditorId.html]: 'html-value',
         [DefaultEditorId.main]: 'main-value',
@@ -172,7 +172,7 @@ describe('App component', () => {
         expect(state.gistId).toBe('');
         expect(state.templateName).toBeUndefined();
 
-        (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(false);
+        state.showConfirmDialog = jest.fn().mockResolvedValueOnce(false);
 
         await app.replaceFiddle(
           {},
@@ -198,7 +198,7 @@ describe('App component', () => {
           [DefaultEditorId.renderer]: 'renderer-value',
         };
 
-        (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(true);
+        state.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
 
         await app.replaceFiddle(editorValues, {
           gistId: 'gistId',
@@ -393,11 +393,11 @@ describe('App component', () => {
 
       // set up a reaction to confirm the replacement
       // when it happens
-      (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(confirm);
+      app.state.showConfirmDialog = jest.fn().mockResolvedValueOnce(confirm);
 
       // now try to replace
       await app.replaceFiddle(editorValues2, { gistId });
-      expect(app.state.runConfirmationDialog).toHaveBeenCalled();
+      expect(app.state.showConfirmDialog).toHaveBeenCalled();
     }
 
     it('does not replace the fiddle if not confirmed', async () => {
@@ -420,7 +420,7 @@ describe('App component', () => {
     });
 
     it('can close the window if user accepts the dialog', async () => {
-      (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(true);
+      app.state.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
 
       // expect the app to be watching for exit if the fiddle is edited
       app.state.editorMosaic.isEdited = true;
@@ -432,7 +432,7 @@ describe('App component', () => {
 
     it('can close the app after user accepts dialog', async () => {
       app.state.isQuitting = true;
-      (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(true);
+      app.state.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
 
       // expect the app to be watching for exit if the fiddle is edited
       app.state.editorMosaic.isEdited = true;
@@ -448,7 +448,7 @@ describe('App component', () => {
 
     it('does nothing if user cancels the dialog', async () => {
       app.state.isQuitting = true;
-      (app.state.runConfirmationDialog as jest.Mock).mockResolvedValue(false);
+      app.state.showConfirmDialog = jest.fn().mockResolvedValueOnce(false);
 
       // expect the app to be watching for exit if the fiddle is edited
       app.state.editorMosaic.isEdited = true;

--- a/tests/renderer/components/commands-bisect-spec.tsx
+++ b/tests/renderer/components/commands-bisect-spec.tsx
@@ -78,6 +78,7 @@ describe('Bisect commands component', () => {
       const wrapper = shallow(<BisectHandler appState={store as any} />);
       const instance: BisectHandler = wrapper.instance() as any;
       instance.terminateBisect = jest.fn();
+      store.showInfoDialog = jest.fn().mockResolvedValueOnce(undefined);
 
       // same value is only returned when there is only 1 version left
       store.Bisector.continue.mockReturnValue([
@@ -88,24 +89,19 @@ describe('Bisect commands component', () => {
       expect(store.setVersion).not.toHaveBeenCalled();
       expect(instance.terminateBisect).toHaveBeenCalled();
       expect(store.pushOutput).toHaveBeenCalled();
-      expect(store.isGenericDialogShowing).toEqual(true);
-      expect(store.setGenericDialogOptions).toHaveBeenCalledWith({
-        cancel: undefined,
-        label: (
-          <>
-            Bisect complete. Check the range{' '}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={`https://github.com/electron/electron/compare/vminVer...vmaxVer`}
-            >
-              {'minVer'}...{'maxVer'}
-            </a>
-            .
-          </>
-        ),
-        type: 'success',
-      });
+      expect(store.showInfoDialog).toHaveBeenCalledWith(
+        <>
+          Bisect complete. Check the range{' '}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href={`https://github.com/electron/electron/compare/vminVer...vmaxVer`}
+          >
+            {'minVer'}...{'maxVer'}
+          </a>
+          .
+        </>,
+      );
     });
   });
 

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -74,7 +74,6 @@ describe('EditorDropdown component', () => {
     await dropdown.addCustomEditor();
 
     expect(store.showInputDialog).toHaveBeenCalledWith({
-      cancel: 'Cancel',
       label: 'Enter a filename for your custom editor',
       ok: 'Create',
       placeholder: 'file.js',
@@ -95,7 +94,6 @@ describe('EditorDropdown component', () => {
     await dropdown.addCustomEditor();
 
     expect(store.showInputDialog).toHaveBeenCalledWith({
-      cancel: 'Cancel',
       label: 'Enter a filename for your custom editor',
       ok: 'Create',
       placeholder: 'file.js',
@@ -121,7 +119,6 @@ describe('EditorDropdown component', () => {
     await dropdown.addCustomEditor();
 
     expect(store.showInputDialog).toHaveBeenCalledWith({
-      cancel: 'Cancel',
       label: 'Enter a filename for your custom editor',
       ok: 'Create',
       placeholder: 'file.js',

--- a/tests/renderer/components/commands-editors-spec.tsx
+++ b/tests/renderer/components/commands-editors-spec.tsx
@@ -1,7 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
-import { DefaultEditorId, GenericDialogType } from '../../../src/interfaces';
+import { DefaultEditorId } from '../../../src/interfaces';
 import { EditorDropdown } from '../../../src/renderer/components/commands-editors';
 
 import { EditorMosaicMock, StateMock } from '../../mocks/mocks';
@@ -65,103 +65,75 @@ describe('EditorDropdown component', () => {
   });
 
   it('can add a valid custom editor', async () => {
-    const { editorMosaic } = store;
     const file = 'file.js';
+    store.showInputDialog = jest.fn().mockResolvedValueOnce(file);
+    store.showErrorDialog = jest.fn().mockResolvedValueOnce(undefined);
 
-    store.showCustomEditorDialog = jest
-      .fn()
-      .mockReturnValue({ cancelled: false, result: file });
     const wrapper = mount(<EditorDropdown appState={store as any} />);
     const dropdown = wrapper.instance() as EditorDropdown;
-
-    store.genericDialogLastInput = file;
-    store.genericDialogLastResult = true;
-
     await dropdown.addCustomEditor();
 
-    expect(store.setGenericDialogOptions).toHaveBeenNthCalledWith(1, {
-      type: GenericDialogType.confirm,
-      label: 'Enter a filename for your custom editor',
+    expect(store.showInputDialog).toHaveBeenCalledWith({
       cancel: 'Cancel',
-      placeholder: 'file.js',
+      label: 'Enter a filename for your custom editor',
       ok: 'Create',
-      wantsInput: true,
+      placeholder: 'file.js',
     });
 
+    const { editorMosaic } = store;
     expect(editorMosaic.showMosaic).toHaveBeenCalledTimes(1);
     expect(editorMosaic.customMosaics).toEqual([file]);
-    expect(store.toggleGenericDialog).toHaveBeenCalledTimes(1);
   });
 
   it('errors when trying to add a duplicate custom editor', async () => {
-    const { editorMosaic } = store;
-    const badFile = 'main.js';
+    const dupe = DefaultEditorId.html;
+    store.showInputDialog = jest.fn().mockResolvedValueOnce(dupe);
+    store.showErrorDialog = jest.fn().mockResolvedValueOnce(undefined);
 
-    store.showCustomEditorDialog = jest
-      .fn()
-      .mockReturnValue({ cancelled: false, result: badFile });
     const wrapper = mount(<EditorDropdown appState={store as any} />);
     const dropdown = wrapper.instance() as EditorDropdown;
-
-    store.genericDialogLastInput = badFile;
-    store.genericDialogLastResult = true;
-
     await dropdown.addCustomEditor();
 
-    expect(store.setGenericDialogOptions).toHaveBeenNthCalledWith(1, {
-      type: GenericDialogType.confirm,
-      label: 'Enter a filename for your custom editor',
+    expect(store.showInputDialog).toHaveBeenCalledWith({
       cancel: 'Cancel',
-      placeholder: 'file.js',
+      label: 'Enter a filename for your custom editor',
       ok: 'Create',
-      wantsInput: true,
+      placeholder: 'file.js',
     });
 
-    expect(store.setGenericDialogOptions).toHaveBeenNthCalledWith(2, {
-      type: GenericDialogType.warning,
-      label: `Custom editor name ${badFile} already exists - duplicates are not allowed`,
-      cancel: undefined,
-    });
+    expect(store.showErrorDialog).toHaveBeenCalledWith(
+      `Custom editor name ${dupe} already exists - duplicates are not allowed`,
+    );
 
-    expect(store.toggleGenericDialog).toHaveBeenCalledTimes(2);
+    const { editorMosaic } = store;
     expect(editorMosaic.showMosaic).toHaveBeenCalledTimes(0);
     expect(editorMosaic.customMosaics).toEqual([]);
   });
 
   it('errors when trying to add an invalid custom editor', async () => {
-    const { editorMosaic } = store;
     const badFile = 'bad.bad';
+    store.showInputDialog = jest.fn().mockResolvedValueOnce(badFile);
+    store.showErrorDialog = jest.fn().mockResolvedValueOnce(undefined);
 
-    store.showCustomEditorDialog = jest
-      .fn()
-      .mockReturnValue({ cancelled: false, result: badFile });
     const wrapper = mount(<EditorDropdown appState={store as any} />);
     const dropdown = wrapper.instance() as EditorDropdown;
 
-    store.genericDialogLastInput = badFile;
-    store.genericDialogLastResult = true;
-
     await dropdown.addCustomEditor();
 
-    expect(store.setGenericDialogOptions).toHaveBeenNthCalledWith(1, {
-      type: GenericDialogType.confirm,
-      label: 'Enter a filename for your custom editor',
+    expect(store.showInputDialog).toHaveBeenCalledWith({
       cancel: 'Cancel',
-      placeholder: 'file.js',
+      label: 'Enter a filename for your custom editor',
       ok: 'Create',
-      wantsInput: true,
+      placeholder: 'file.js',
     });
 
-    expect(store.setGenericDialogOptions).toHaveBeenNthCalledWith(2, {
-      type: GenericDialogType.warning,
-      label:
-        'Invalid custom editor name - must be either an html, js, or css file.',
-      cancel: undefined,
-    });
+    expect(store.showErrorDialog).toHaveBeenCalledWith(
+      expect.stringMatching(/invalid editor name/i),
+    );
 
+    const { editorMosaic } = store;
     expect(editorMosaic.customMosaics).toEqual([]);
     expect(editorMosaic.showMosaic).toHaveBeenCalledTimes(0);
-    expect(store.toggleGenericDialog).toHaveBeenCalledTimes(2);
   });
 
   it('can remove a custom editor', () => {

--- a/tests/renderer/components/dialog-add-theme-spec.tsx
+++ b/tests/renderer/components/dialog-add-theme-spec.tsx
@@ -114,6 +114,7 @@ describe('AddThemeDialog component', () => {
     });
 
     it('shows an error dialog for a malformed theme', async () => {
+      store.showErrorDialog = jest.fn().mockResolvedValueOnce(true);
       const wrapper = shallow(<AddThemeDialog appState={store as any} />);
       const instance: AddThemeDialog = wrapper.instance() as any;
 
@@ -126,12 +127,9 @@ describe('AddThemeDialog component', () => {
       await instance.onSubmit();
 
       expect(fs.readJSONSync).toHaveBeenCalledTimes(1);
-      const error = 'File does not match specifications';
-      expect(store.setGenericDialogOptions).toHaveBeenCalledWith({
-        label: `Error: ${error}, please pick a different file.`,
-        type: 'warning',
-      });
-      expect(store.toggleGenericDialog).toHaveBeenCalledTimes(1);
+      expect(store.showErrorDialog).toHaveBeenCalledWith(
+        expect.stringMatching(/file does not match specifications/i),
+      );
     });
   });
 

--- a/tests/renderer/components/dialog-generic-spec.tsx
+++ b/tests/renderer/components/dialog-generic-spec.tsx
@@ -62,6 +62,6 @@ describe('GenericDialog component', () => {
     const instance: GenericDialog = wrapper.instance() as any;
 
     instance.onClose(true);
-    expect(store.toggleGenericDialog).toHaveBeenCalledTimes(1);
+    expect(store.isGenericDialogShowing).toBe(false);
   });
 });

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -282,7 +282,6 @@ describe('RemoteLoader', () => {
       store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
       await instance.verifyReleaseChannelEnabled(ElectronReleaseChannel.beta);
       expect(store.showConfirmDialog).toHaveBeenCalledWith({
-        cancel: 'Cancel',
         label: expect.stringMatching(/enable the release channel/i),
         ok: 'Enable',
       });
@@ -300,7 +299,6 @@ describe('RemoteLoader', () => {
       );
 
       expect(store.showConfirmDialog).toHaveBeenCalledWith({
-        cancel: 'Cancel',
         label: expect.stringMatching(/for version 4.0.0/i),
         ok: 'Load',
       });
@@ -332,7 +330,6 @@ describe('RemoteLoader', () => {
 
       expect(instance.fetchGistAndLoad).toHaveBeenCalledWith('gist');
       expect(store.showConfirmDialog).toHaveBeenCalledWith({
-        cancel: 'Cancel',
         label: expect.stringMatching(/are you sure/i),
         ok: 'Load',
       });

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -201,6 +201,7 @@ describe('RemoteLoader', () => {
     });
 
     it('handles incorrect results', async () => {
+      store.showErrorDialog = jest.fn().mockResolvedValueOnce(true);
       (getOctokit as jest.Mock).mockReturnValue({
         repos: {
           getContents: async () => ({
@@ -211,14 +212,15 @@ describe('RemoteLoader', () => {
 
       const result = await instance.fetchExampleAndLoad('4.0.0', 'test/path');
       expect(result).toBe(false);
-      expect(store.setGenericDialogOptions.mock.calls[0][0].label).toEqual(
-        'Loading the fiddle failed: The example Fiddle tried to launch is not a valid Electron example',
+      expect(store.showErrorDialog).toHaveBeenCalledWith(
+        expect.stringMatching(/not a valid/i),
       );
     });
   });
 
   describe('setElectronVersionFromRef()', () => {
     it('sets version from ref if release channel enabled', async () => {
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
       instance.getPackageVersionFromRef = jest
         .fn()
         .mockReturnValueOnce('4.0.0');
@@ -275,27 +277,21 @@ describe('RemoteLoader', () => {
     });
   });
 
-  describe('verifyRemoteLoad()', () => {
-    it('asks the user if they want to load remote content', (done) => {
-      instance.verifyRemoteLoad('test').then(done);
-      expect(store.isGenericDialogShowing).toBe(true);
-      store.isGenericDialogShowing = false;
-    });
-  });
-
   describe('verifyReleaseChannelEnabled', () => {
-    it('asks the user if they want to enable a release channel', (done) => {
-      instance
-        .verifyReleaseChannelEnabled(ElectronReleaseChannel.beta)
-        .then(done);
-      expect(store.isGenericDialogShowing).toBe(true);
-      store.isGenericDialogShowing = false;
+    it('asks the user if they want to enable a release channel', async () => {
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
+      await instance.verifyReleaseChannelEnabled(ElectronReleaseChannel.beta);
+      expect(store.showConfirmDialog).toHaveBeenCalledWith({
+        cancel: 'Cancel',
+        label: expect.stringMatching(/enable the release channel/i),
+        ok: 'Enable',
+      });
     });
   });
 
   describe('loadFiddleFromElectronExample()', () => {
     it('loads the example with confirmation', async () => {
-      instance.verifyRemoteLoad = jest.fn().mockReturnValue(true);
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
       instance.verifyReleaseChannelEnabled = jest.fn().mockReturnValue(true);
       instance.fetchExampleAndLoad = jest.fn();
       await instance.loadFiddleFromElectronExample(
@@ -303,17 +299,19 @@ describe('RemoteLoader', () => {
         { path: 'test/path', ref: '4.0.0' },
       );
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalledWith<any>(
-        `'test/path' example from the Electron docs for version 4.0.0`,
-      );
-      expect(instance.fetchExampleAndLoad).toHaveBeenCalledWith<any>(
+      expect(store.showConfirmDialog).toHaveBeenCalledWith({
+        cancel: 'Cancel',
+        label: expect.stringMatching(/for version 4.0.0/i),
+        ok: 'Load',
+      });
+      expect(instance.fetchExampleAndLoad).toHaveBeenCalledWith(
         '4.0.0',
         'test/path',
       );
     });
 
     it('does not load the example without confirmation', async () => {
-      instance.verifyRemoteLoad = jest.fn().mockReturnValue(false);
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(false);
       instance.verifyReleaseChannelEnabled = jest.fn();
       instance.fetchExampleAndLoad = jest.fn();
       await instance.loadFiddleFromElectronExample(
@@ -321,28 +319,32 @@ describe('RemoteLoader', () => {
         { path: 'test/path', ref: '4.0.0' },
       );
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalled();
+      expect(store.showConfirmDialog).toHaveBeenCalled();
       expect(instance.fetchExampleAndLoad).toHaveBeenCalledTimes(0);
     });
   });
 
   describe('loadFiddleFromGist()', () => {
     it('loads the example with confirmation', async () => {
-      instance.verifyRemoteLoad = jest.fn().mockReturnValue(true);
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
       instance.fetchGistAndLoad = jest.fn();
       await instance.loadFiddleFromGist({}, { id: 'gist' });
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalledWith<any>('gist');
-      expect(instance.fetchGistAndLoad).toHaveBeenCalledWith<any>('gist');
+      expect(instance.fetchGistAndLoad).toHaveBeenCalledWith('gist');
+      expect(store.showConfirmDialog).toHaveBeenCalledWith({
+        cancel: 'Cancel',
+        label: expect.stringMatching(/are you sure/i),
+        ok: 'Load',
+      });
     });
 
     it('does not load the example without confirmation', async () => {
-      instance.verifyRemoteLoad = jest.fn().mockReturnValue(false);
+      store.showConfirmDialog = jest.fn().mockResolvedValueOnce(false);
       instance.fetchGistAndLoad = jest.fn();
       await instance.loadFiddleFromGist({}, { id: 'gist' });
 
-      expect(instance.verifyRemoteLoad).toHaveBeenCalled();
-      expect(instance.fetchGistAndLoad).toHaveBeenCalledTimes(0);
+      expect(instance.fetchGistAndLoad).not.toHaveBeenCalled();
+      expect(store.showConfirmDialog).toHaveBeenCalled();
     });
   });
 });

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -495,7 +495,6 @@ describe('AppState', () => {
     describe('showInputDialog', () => {
       const input = 'fnord' as const;
       const inputOpts = {
-        cancel: 'Cancel',
         label: 'label',
         ok: 'Close',
         placeholder: 'Placeholder',
@@ -528,7 +527,6 @@ describe('AppState', () => {
           input: undefined,
         });
         const result = await appState.showConfirmDialog({
-          cancel: 'Cancel',
           label,
           ok: 'Confirm',
         });


### PR DESCRIPTION
This PR adds four dialog helper functions that take only the params they need and which return Promises that resolve when the user closes the dialog:

- `AppState.showConfirmDialog: Promise<boolean>`
- `AppState.showErrorDialog: Promise<void>`
- `AppState.showInfoDialog: Promise<void>`
- `AppState.showInputDialog: Promise<string | undefined>`

These all wrap GenericDialog so there's no more messing around with `!!appState.isGenericDialogShowing`, setting `cancel: undefined` to hide the cancel button, or forgetting to clear the last input value.