### PR TITLE
fix: close popup windows before running batch cmds

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -135,14 +135,14 @@ export class AppState {
   @observable public isQuitting = false;
 
   // -- Various "isShowing" settings ------------------
+  @observable public isAddVersionDialogShowing = false;
   @observable public isBisectCommandShowing: boolean;
+  @observable public isBisectDialogShowing = false;
   @observable public isConsoleShowing = false;
-  @observable public isTokenDialogShowing = false;
   @observable public isGenericDialogShowing = false;
   @observable public isSettingsShowing = false;
-  @observable public isBisectDialogShowing = false;
-  @observable public isAddVersionDialogShowing = false;
   @observable public isThemeDialogShowing = false;
+  @observable public isTokenDialogShowing = false;
   @observable public isTourShowing = !localStorage.getItem('hasShownTour');
 
   // -- Editor Values stored when we close the editor ------------------
@@ -664,24 +664,30 @@ export class AppState {
       ]);
     }
   }
+
   /**
-   * Resets the view, optionally with certain view flags enabled.
-   *
-   * @param {Record<string, boolean>} [additionalOptions]
-   * @memberof AppState
+   * Show or close secondary windows such as settings and dialogs.
    */
-  @action private resetView(additionalOptions: Record<string, boolean> = {}) {
-    this.isAddVersionDialogShowing = false;
-    this.isConsoleShowing = false;
-    this.isSettingsShowing = false;
-    this.isThemeDialogShowing = false;
-    this.isTokenDialogShowing = false;
-    this.isTourShowing = false;
-
-    for (const [key, val] of Object.entries(additionalOptions)) {
-      this[key] = val;
-    }
-
+  @action public resetView(
+    opts: {
+      isAddVersionDialogShowing?: boolean;
+      isBisectDialogShowing?: boolean;
+      isConsoleShowing?: boolean;
+      isGenericDialogShowing?: boolean;
+      isSettingsShowing?: boolean;
+      isThemeDialogShowing?: boolean;
+      isTokenDialogShowing?: boolean;
+      isTourShowing?: boolean;
+    } = {},
+  ) {
+    this.isAddVersionDialogShowing = Boolean(opts.isAddVersionDialogShowing);
+    this.isBisectDialogShowing = Boolean(opts.isBisectDialogShowing);
+    this.isConsoleShowing = Boolean(opts.isConsoleShowing);
+    this.isGenericDialogShowing = Boolean(opts.isGenericDialogShowing);
+    this.isSettingsShowing = Boolean(opts.isSettingsShowing);
+    this.isThemeDialogShowing = Boolean(opts.isThemeDialogShowing);
+    this.isTokenDialogShowing = Boolean(opts.isTokenDialogShowing);
+    this.isTourShowing = Boolean(opts.isTourShowing);
     this.setPageHash();
   }
 

--- a/src/renderer/task-runner.ts
+++ b/src/renderer/task-runner.ts
@@ -104,8 +104,10 @@ export class TaskRunner {
   }
 
   private async setup(req: SetupRequest) {
-    const { log } = this;
+    const { appState, log } = this;
     const { fiddle, hideChannels, showChannels, useObsolete, version } = req;
+
+    appState.resetView();
 
     if (typeof useObsolete === 'boolean') {
       this.showObsoleteVersions(useObsolete);

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -73,6 +73,7 @@ export class StateMock {
   public flushOutput = jest.fn();
   public removeAcceleratorToBlock = jest.fn();
   public removeVersion = jest.fn();
+  public resetView = jest.fn();
   public runConfirmationDialog = jest.fn();
   public setGenericDialogOptions = jest.fn().mockReturnValue({});
   public setTheme = jest.fn();


### PR DESCRIPTION
Partially fixes https://github.com/electron/fiddle/issues/721, although the main symptom of that bug persists even when the welcome dialog is hidden.