### PR TITLE
fix: update webcontents demo with loadURL

### DIFF
--- a/static/show-me/webcontents/index.html
+++ b/static/show-me/webcontents/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Print Example</title>
+  <title>Load URL Example</title>
 </head>
 <body>
-  <h1>Print Example</h1>
+  <h1>Load URL Example</h1>
   <p>
-    Almost immediately after opening the page, the print
-    dialog should show up.
+    Almost immediately after opening the page, the Electron
+    homepage should load.
   </p>
 </body>
 </html>

--- a/static/show-me/webcontents/main.js
+++ b/static/show-me/webcontents/main.js
@@ -3,21 +3,22 @@
 // For more info, see:
 // https://electronjs.org/docs/api/web-contents
 
-const { app, BrowserWindow, webContents } = require('electron')
+const { app, BrowserWindow, webContents } = require('electron');
 
 app.whenReady().then(() => {
-  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
-  mainWindow.loadFile('index.html')
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 });
+  mainWindow.loadFile('index.html');
 
+  // This setTimeout is to demonstrate the method firing
+  // for the demo, and is not needed in production.
   setTimeout(() => {
-    // ...later
-    const contents = webContents.getAllWebContents()[0]
+    const contents = webContents.getAllWebContents()[0];
 
     // The WebContents class has dozens of methods and
     // events available. As an example, we'll call one
-    // of them here: print(), which prints the current
-    // page.
-
-    contents.print()
-  }, 1000)
-})
+    // of them here: loadURL, which loads Electron's
+    // home page.
+    const options = { extraHeaders: 'pragma: no-cache\n' };
+    contents.loadURL('https://electronjs.org', options);
+  }, 1000);
+});


### PR DESCRIPTION
Fixes #735

Quick fix for the webContents "Show Me" demo, which currently uses `webContents.print()`. The print method behavior changed in Electron v8.1.0, and a dialog box is no longer shown if there are no printers detected or set. 

While we're determining if this should be the default behavior or if it's a bug, this PR changes the webContents demo to use `webContents.loadURL` as the sample method, which will hopefully be more stable and less prone to breaking in the future.

_Quick lint note: It looks like the linter adds semi-colons to the demo code - do we want that style? If not, I can remove them and commit with --no-verify._ 