### PR TITLE
fix: GET_APP_PATHS handler undefined on reload

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -79,7 +79,7 @@ export function createMainWindow(): Electron.BrowserWindow {
     }
   });
 
-  ipcMainManager.handleOnce(IpcEvents.GET_APP_PATHS, () => {
+  ipcMainManager.handle(IpcEvents.GET_APP_PATHS, () => {
     const paths = {};
     const pathsToQuery = [
       'home',

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -127,7 +127,7 @@ describe('windows', () => {
       // to instantly call the listener.
       let result: any;
       (electron.app.getPath as jest.Mock).mockImplementation((name) => name);
-      (electron.ipcMain.handleOnce as jest.Mock).mockImplementation(
+      (electron.ipcMain.handle as jest.Mock).mockImplementation(
         (event, listener) => {
           if (event === IpcEvents.GET_APP_PATHS) {
             result = listener();


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/737.

Fixes an issue where reloading the window could cause an error and crash.