### PR TITLE
refactor: remove unused output.editorDidMount

### DIFF
--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -16,7 +16,6 @@ interface CommandsProps {
   readonly appState: AppState;
   readonly monaco: typeof MonacoType;
   monacoOptions: MonacoType.editor.IEditorOptions;
-  editorDidMount?: (editor: MonacoType.editor.IStandaloneCodeEditor) => void;
   // Used to keep testing conform
   renderTimestamp?: (ts: number) => string;
 }
@@ -60,21 +59,6 @@ export class Output extends React.Component<CommandsProps> {
   }
 
   /**
-   * Handle the editor having been mounted. This refers to Monaco's
-   * mount, not React's.
-   */
-  public async editorDidMount(editor: MonacoType.editor.IStandaloneCodeEditor) {
-    const { editorDidMount } = this.props;
-
-    await this.setContent(this.props.appState.output);
-
-    // Notify other editors that the initial editor was mounted
-    if (editorDidMount) {
-      editorDidMount(editor);
-    }
-  }
-
-  /**
    *  Set Monaco Editor's value.
    */
   public async UNSAFE_componentWillReceiveProps(newProps: CommandsProps) {
@@ -99,7 +83,7 @@ export class Output extends React.Component<CommandsProps> {
         ...monacoOptions,
       });
 
-      await this.editorDidMount(this.editor);
+      await this.setContent(this.props.appState.output);
     }
   }
 

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -44,34 +44,21 @@ describe('Output component', () => {
 
   describe('initMonaco()', () => {
     it('attempts to create an editor', async () => {
-      const editorDidMount = jest.fn();
       const wrapper = shallow(
-        <Output
-          appState={store as any}
-          monaco={monaco}
-          monacoOptions={{}}
-          editorDidMount={editorDidMount}
-        />,
+        <Output appState={store as any} monaco={monaco} monacoOptions={{}} />,
       );
       const instance: any = wrapper.instance();
 
       instance.outputRef.current = 'ref';
       await instance.initMonaco();
 
-      expect(editorDidMount).toHaveBeenCalled();
       expect(monaco.editor.create).toHaveBeenCalled();
       expect(monaco.editor.createModel).toHaveBeenCalled();
     });
 
     it('initializes with a fixed tab size', async () => {
-      const didMount = jest.fn();
       const wrapper = shallow(
-        <Output
-          appState={store as any}
-          monaco={monaco}
-          monacoOptions={{}}
-          editorDidMount={didMount}
-        />,
+        <Output appState={store as any} monaco={monaco} monacoOptions={{}} />,
       );
       const instance: any = wrapper.instance();
 
@@ -87,14 +74,8 @@ describe('Output component', () => {
   });
 
   it('componentWillUnmount() attempts to dispose the editor', async () => {
-    const didMount = jest.fn();
     const wrapper = shallow(
-      <Output
-        appState={store as any}
-        monaco={monaco}
-        monacoOptions={{}}
-        editorDidMount={didMount}
-      />,
+      <Output appState={store as any} monaco={monaco} monacoOptions={{}} />,
     );
     const instance: any = wrapper.instance();
 
@@ -152,14 +133,8 @@ describe('Output component', () => {
       },
     ];
 
-    const editorDidMount = jest.fn();
     const wrapper = shallow(
-      <Output
-        appState={store as any}
-        monaco={monaco}
-        monacoOptions={{}}
-        editorDidMount={editorDidMount}
-      />,
+      <Output appState={store as any} monaco={monaco} monacoOptions={{}} />,
     );
     const instance: any = wrapper.instance();
 
@@ -182,14 +157,8 @@ describe('Output component', () => {
 
   it('handles componentDidUpdate', async () => {
     // set up component
-    const editorDidMount = jest.fn();
     const wrapper = shallow(
-      <Output
-        appState={store as any}
-        monaco={monaco}
-        monacoOptions={{}}
-        editorDidMount={editorDidMount}
-      />,
+      <Output appState={store as any} monaco={monaco} monacoOptions={{}} />,
     );
     const instance: any = wrapper.instance();
     const spy = jest.spyOn(instance, 'toggleConsole');


### PR DESCRIPTION
Just a small piece of dead code removal.

`CommandsProps.editorDidMount` exists because the code was cloned from the sibling `EditorProps` class; however, since `editorDidMount` is never using for outputs, it's dead code there and can be removed.

_edit:_ Coveralls is just angry because tested code is being removed. :stuck_out_tongue: 