### PR TITLE
fix: editorMosaic.layout() called w/ wrong context

### DIFF
--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -201,7 +201,6 @@ export class EditorMosaic {
     this.customMosaics = this.customMosaics.filter((mosaic) => mosaic !== id);
   }
 
-
   /** Wire up a newly-mounted Monaco editor */
   @action public addEditor(id: EditorId, editor: Editor) {
     const backup = this.backups.get(id);
@@ -247,7 +246,7 @@ export class EditorMosaic {
 
   private layoutDebounce: ReturnType<typeof setTimeout> | undefined;
 
-  public layout() {
+  public layout = () => {
     const DEBOUNCE_MSEC = 50;
     if (!this.layoutDebounce) {
       this.layoutDebounce = setTimeout(() => {
@@ -255,7 +254,7 @@ export class EditorMosaic {
         delete this.layoutDebounce;
       }, DEBOUNCE_MSEC);
     }
-  }
+  };
 
   public focusedEditor(): Editor | undefined {
     return [...this.editors.values()].find((editor) => editor.hasTextFocus());


### PR DESCRIPTION
Change EditorMosaic.layout to be an arrow function so that the proper `this` context is baked in.

Fixes #751.

This [resize handler in app.tsx](https://github.com/electron/fiddle/blob/master/src/renderer/app.tsx#L224) is where the bad call was coming from.

I tried a few ways to try to trigger the resize handler in jest to add a regression test here, but wasn't able to find the right recipe. :man_shrugging: 