### PR TITLE
refactor: remove Sync() calls from readFiddle()

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "lib": [
-      "es2019",
+      "es2020",
       "dom",
       "WebWorker"
     ],


### PR DESCRIPTION
No feature changes.

This is a small refactor to try to reduce startup jank by making some previously-blocking calls yield.

*edit:*  read-fiddle.ts is still at 100% coverage and the LOC in src/ did not change. I don't know what Coveralls is complaining about. :thinking: 