### PR TITLE
fix: "second handler for GET_APP_PATHS" error dialog

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -74,6 +74,8 @@ class IpcMainManager extends EventEmitter {
     channel: IpcEvents,
     listener: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any,
   ) {
+    // there can be only one, so remove previous one first
+    ipcMain.removeHandler(channel);
     ipcMain.handle(channel, listener);
   }
 

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -61,7 +61,7 @@ export function getReleaseChannel(
 ): ElectronReleaseChannel {
   const tag = typeof input === 'string' ? input : input.version || '';
 
-  if (tag.includes('beta')) {
+  if (tag.includes('beta') || tag.includes('alpha')) {
     return ElectronReleaseChannel.beta;
   }
 

--- a/src/utils/sort-versions.ts
+++ b/src/utils/sort-versions.ts
@@ -5,10 +5,12 @@ import { RunnableVersion } from '../interfaces';
 function electronSemVerCompare(a: semver.SemVer, b: semver.SemVer) {
   const l = a.compareMain(b);
   if (l) return l;
-  // Electron's approach is nightly -> beta -> stable.
-  // Account for 'beta' coming before 'nightly' lexicographically
-  if (a.prerelease[0] === 'nightly' && b.prerelease[0] === 'beta') return -1;
-  if (a.prerelease[0] === 'beta' && b.prerelease[0] === 'nightly') return 1;
+  // Electron's approach is nightly -> other prerelease tags -> stable,
+  // so force `nightly` to sort before other prerelease tags.
+  const [prea] = a.prerelease;
+  const [preb] = b.prerelease;
+  if (prea === 'nightly' && preb !== 'nightly') return -1;
+  if (prea !== 'nightly' && preb === 'nightly') return 1;
   return a.comparePre(b);
 }
 

--- a/tests/utils/sort-versions-spec.ts
+++ b/tests/utils/sort-versions-spec.ts
@@ -30,10 +30,12 @@ describe('sort-versions', () => {
     ]);
   });
 
-  it('sorts nightly and beta versions correctly', () => {
+  it('sorts nightly, alpha, and beta versions correctly', () => {
     const unsorted: RunnableVersion[] = [
+      makeVersion('v3.0.0-alpha.1'),
       makeVersion('v2.0.0-nightly.20200101'),
       makeVersion('v2.0.0-beta.1'),
+      makeVersion('v2.0.0-alpha.1'),
       makeVersion('v2.0.0-nightly.20200102'),
       makeVersion('v3.0.0-beta.1'),
       makeVersion('v3.0.0-nightly.20200105'),
@@ -48,11 +50,13 @@ describe('sort-versions', () => {
     expect(sorted).toStrictEqual<any>([
       makeVersion('v3.0.0'),
       makeVersion('v3.0.0-beta.1'),
+      makeVersion('v3.0.0-alpha.1'),
       makeVersion('v3.0.0-nightly.20200105'),
       makeVersion('v2.0.0'),
       makeVersion('v2.0.0-beta.3'),
       makeVersion('v2.0.0-beta.2'),
       makeVersion('v2.0.0-beta.1'),
+      makeVersion('v2.0.0-alpha.1'),
       makeVersion('v2.0.0-nightly.20200102'),
       makeVersion('v2.0.0-nightly.20200101'),
     ]);


### PR DESCRIPTION
Fixes #765 by ensuring there's only one GET_APP_PATHS handler at a time.

*edit:* oops, looks like I didn't have a clean sandbox before doing this patch. I'll close this PR and open a new one.