### PR TITLE
fix: EditorMosaic safeguard against unwanted files

### DIFF
--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -97,6 +97,9 @@ export class EditorMosaic {
     // add the files to the mosaic, recycling existing editors when possible.
     const values = new Map(Object.entries(valuesIn)) as Map<EditorId, string>;
     for (const [id, value] of values) this.addFile(id, value);
+    for (const id of this.editors.keys()) {
+      if (!values.has(id)) this.editors.delete(id);
+    }
 
     this.isEdited = false;
   }

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -330,7 +330,7 @@ describe('EditorMosaic', () => {
 
       afterEach(() => {
         // this is the real test.
-        // the it()s below is setup for the different conditions
+        // the three it()s below each set a different test condition
         editorMosaic.set({});
         expect(editorMosaic.files.has(id)).toBe(false);
         expect(editorMosaic.value(id)).toBe('');

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -325,15 +325,35 @@ describe('EditorMosaic', () => {
       }
     });
 
-    it('does not remember values from the previous call', () => {
+    describe('does not remember files from previous calls', () => {
       const id = MAIN_JS;
-      const content = '// content';
-      editorMosaic.set({ [id]: content });
-      expect(editorMosaic.value(id)).toBe(content);
 
-      editorMosaic.set({});
-      expect(editorMosaic.value(id)).not.toBe(content);
-      expect(editorMosaic.value(id)).toBe('');
+      afterEach(() => {
+        // this is the real test.
+        // the it()s below is setup for the different conditions
+        editorMosaic.set({});
+        expect(editorMosaic.files.has(id)).toBe(false);
+        expect(editorMosaic.value(id)).toBe('');
+      });
+
+      it('even if the file was visible', () => {
+        const content = '// fnord';
+        editorMosaic.set({ [id]: content });
+        editorMosaic.addEditor(id, editor as any);
+        expect(editorMosaic.files.get(id)).toBe(EditorPresence.Visible);
+      });
+
+      it('even if the file was hidden', () => {
+        const content = '';
+        editorMosaic.set({ [id]: content });
+        expect(editorMosaic.files.get(id)).toBe(EditorPresence.Hidden);
+      });
+
+      it('even if the file was pending', () => {
+        const content = '// fnord';
+        editorMosaic.set({ [id]: content });
+        expect(editorMosaic.files.get(id)).toBe(EditorPresence.Pending);
+      });
     });
 
     it('uses the expected layout', () => {


### PR DESCRIPTION
Fixes #768.

This fixes at least one cause of the `added Editor for unexpected file` errors showing up in Sentry. All the ones I see in Sentry look like this, so maybe it fixes them all.

- Fix a logic error in EditorMosaic.set() that accidentally remembered some unwanted files.

- Fix the test in editor-mosaic-spect.ts which did check for this, but didn't test under enough different conditions.