### PR TITLE
fix: cannot read property 'set' of undefined

### DIFF
--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -80,9 +80,9 @@ export class EditorMosaic {
   }
 
   /** Reset the layout to the initial layout we had when set() was called */
-  @action public resetLayout() {
+  @action resetLayout = () => {
     this.set(this.values());
-  }
+  };
 
   /// set / add / get the files in the model
 


### PR DESCRIPTION
Fixes #771 by making `EditorMosaic.resetLayout()` an arrow function so `this` should always be good.