### PR TITLE
docs: update number of supported versions to reflect release cadence migration

### DIFF
--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -314,7 +314,7 @@ function isElectronVersion(
 }
 
 export function getOldestSupportedVersion(): string | undefined {
-  const NUM_STABLE_BRANCHES = process.env.NUM_STABLE_BRANCHES || 3;
+  const NUM_STABLE_BRANCHES = process.env.NUM_STABLE_BRANCHES || 4;
 
   const oldestSupported = getElectronVersions()
     .map(({ version }) => version)


### PR DESCRIPTION
This PR changes the number of supported releases from 3 to 4 to reflect the change in Electron's release cadence