### PR TITLE
fix: editors sometimes disappear when loading new fiddle

### DIFF
--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -125,8 +125,12 @@ export class EditorMosaic {
       this.backups.set(id, backup);
     }
 
-    // if the file has nontrivial content, put it in the mosaic to show it.
-    if (value.length && value !== getEmptyContent(id)) this.show(id);
+    // only show the file if it has nontrivial content
+    if (value.length && value !== getEmptyContent(id)) {
+      this.show(id);
+    } else {
+      this.hide(id);
+    }
   }
 
   /// show or hide files in the view

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -334,7 +334,7 @@ describe('EditorMosaic', () => {
         const values = { [id1]: '// potrzebie', [id2]: '' };
         editorMosaic.set(values);
 
-        // test that id1 got recycled by id2 is hidden
+        // test that id1 got recycled but id2 is hidden
         const { files } = editorMosaic;
         expect(files.size).toBe(2);
         expect(files.get(id1 as EditorId)).toBe(EditorPresence.Visible);


### PR DESCRIPTION
Fixes #774 reported by @erickzhao.

When loading a new fiddle, if it has a filename that was in the previous fiddle too, EditorMosaic tries to recycle the MonacoEditor allocated to that file. Unfortunately, does this even if the new fiddle's file is going to be hidden. This corrupts the internal state.

In the repro case described in 744, the state was corrupted when _loading_ https://gist.github.com/e27800f409182981352b68a90690c4a6 because its preload & renderer files were hidden, causing the inconsistent internal state described above. The error that appears when loading another fiddle _after_ that gist is a symptom of that already-inconsistent state.

This PR fixes that bug and adds Yet Another Regression Test for this state too. :slightly_smiling_face: 