### PR TITLE
fix: publishing gists with empty files to Github

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -409,19 +409,9 @@ export class GistActionButton extends React.Component<
   };
 
   private gistFilesList = (values: EditorValues) => {
-    const filesList: EditorValues = {};
-
-    // Add files for default editors.
-    for (const editor of DEFAULT_EDITORS) {
-      filesList[editor] = {
-        content: values[editor] || getEmptyContent(editor),
-      };
-    }
-
-    for (const id of Object.keys(values)) {
-      filesList[id] = { content: values[id] };
-    }
-
-    return filesList;
+    const ids = [...DEFAULT_EDITORS, ...Object.keys(values)];
+    return Object.fromEntries(
+      ids.map((id) => [id, { content: values[id] || getEmptyContent(id) }]),
+    );
   };
 }

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -5,6 +5,7 @@ import {
   DefaultEditorId,
   GistActionState,
   GistActionType,
+  MAIN_JS,
 } from '../../../src/interfaces';
 import { IpcEvents } from '../../../src/ipc-events';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
@@ -135,8 +136,11 @@ describe('Action button component', () => {
       expect(mocktokit.gists.create).not.toHaveBeenCalled();
     });
 
-    it('handles missing content', async () => {
-      app.getEditorValues.mockReturnValueOnce({});
+    it.each([
+      ['handles missing files', {}],
+      ['handles empty files', { [MAIN_JS]: '' }],
+    ])('%s', async (_, appEditorValues) => {
+      app.getEditorValues.mockReturnValueOnce(appEditorValues);
       const { instance } = createActionButton();
       state.showInputDialog = jest.fn().mockResolvedValueOnce(description);
 


### PR DESCRIPTION
Fixes #776 reported by both @nornagon and @miniak. The problem was that we were trying to submit empty files, which fails.

Add a regression test. The tests already checked for missing files; now also test for existing-but-empty files.

*edit:* no newly-untested LOC or logic branches. Coveralls' negative report is because the code size decreased by a few lines.