### PR TITLE
perf: prefer getKnownVersions() over getElectronVersions().

### DIFF
--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -1,6 +1,6 @@
-import { EditorValues, VersionSource } from '../interfaces';
+import { EditorValues } from '../interfaces';
 import { USER_DATA_PATH } from './constants';
-import { getElectronVersions } from './versions';
+import { getReleasedVersions } from './versions';
 import { readFiddle } from '../utils/read-fiddle';
 
 import * as fs from 'fs-extra';
@@ -94,12 +94,13 @@ export function getTestTemplate(): Promise<EditorValues> {
  * @returns {boolean} true if major version is a known release
  */
 function isReleasedMajor(version: semver.SemVer) {
-  const newestRelease = getElectronVersions()
-    .filter((version) => version.source === VersionSource.remote)
-    .map((version) => semver.parse(version.version))
-    .filter((version) => !!version)
-    .reduce((acc, cur) => (acc && acc.compare(cur!) > 0 ? acc : cur));
-  return newestRelease && version.major <= newestRelease.major;
+  const releasedMajors = new Set<number>(
+    getReleasedVersions()
+      .map(({ version }) => semver.parse(version))
+      .filter((sem) => Number.isInteger(sem?.major))
+      .map((sem) => sem!.major),
+  );
+  return releasedMajors.has(version.major);
 }
 
 /**

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -142,7 +142,7 @@ function sanitizeVersion(ver: RunnableVersion): RunnableVersion {
  * @returns {Array<Version>}
  */
 export function getElectronVersions(): Array<RunnableVersion> {
-  const known: Array<RunnableVersion> = getKnownVersions().map((version) => {
+  const known: Array<RunnableVersion> = getReleasedVersions().map((version) => {
     return {
       ...version,
       source: VersionSource.remote,
@@ -225,7 +225,7 @@ export function saveLocalVersions(versions: Array<Version | RunnableVersion>) {
  *
  * @returns {Array<Version>}
  */
-export function getKnownVersions(): Array<Version> {
+export function getReleasedVersions(): Array<Version> {
   return getVersions(VersionKeys.known, () =>
     require('../../static/releases.json'),
   );
@@ -324,7 +324,7 @@ function isElectronVersion(
 export function getOldestSupportedVersion(): string | undefined {
   const NUM_STABLE_BRANCHES = process.env.NUM_STABLE_BRANCHES || 4;
 
-  const oldestSupported = getElectronVersions()
+  const oldestSupported = getReleasedVersions()
     .map(({ version }) => version)
     .filter((version) => /^\d+\.0\.0$/.test(version))
     .sort(semver.compare)

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -11,7 +11,7 @@ import {
   addLocalVersion,
   fetchVersions,
   getDefaultVersion,
-  getKnownVersions,
+  getReleasedVersions,
   getLocalVersions,
   getReleaseChannel,
   getUpdatedElectronVersions,
@@ -190,19 +190,19 @@ describe('versions', () => {
     });
   });
 
-  describe('getKnownVersions()', () => {
+  describe('getReleasedVersions()', () => {
     it('tries to get versions from localStorage', () => {
       (window as any).localStorage.getItem.mockReturnValueOnce(
         `[{ "version": "3.0.5" }]`,
       );
 
-      expect(getKnownVersions()).toEqual([{ version: '3.0.5' }]);
+      expect(getReleasedVersions()).toEqual([{ version: '3.0.5' }]);
     });
 
     it('falls back to a local require', () => {
       (window as any).localStorage.getItem.mockReturnValueOnce(`garbage`);
 
-      expect(getKnownVersions().length).toBe(expectedVersionCount);
+      expect(getReleasedVersions().length).toBe(expectedVersionCount);
     });
 
     it('falls back to a local require', () => {
@@ -210,7 +210,7 @@ describe('versions', () => {
         `[{ "garbage": "true" }]`,
       );
 
-      expect(getKnownVersions().length).toBe(expectedVersionCount);
+      expect(getReleasedVersions().length).toBe(expectedVersionCount);
     });
   });
 


### PR DESCRIPTION
- `getKnownVersions()` returns a `Version[]`
- `getElectronVersions()` returns a `RunnableVersion[]`

`RunnableVersion`s are more expensive to create because calculating the RunnableVersion.state property requires checking the disk to see if the version's exec file is present.

`isReleasedMajor()` and `getOldestSupportedVersion()` were using `getElectronVersions()` but don't need that state info. This PR changes them to call `getKnownVersions()` instead, which eliminates 2,057 calls to `fs.existsSync()`. during startup. :tada: 

Also, I think the old code used the wrong function because I was unclear on the meaning of `getKnownVersions()` -- local versions are also 'known' to Electron Fiddle. This PR renames it as `getReleasedVersions()` for clarity.

*Side thought:* if Versions were a singleton object somewhere, things like `oldestSupportedVersion` could be a `@calculated` property instead of having to be recalculated every time we need it. A PR for another day...