### PR TITLE
fix: sorting for non-numeric queries

### DIFF
--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -2,6 +2,7 @@ import { Button, ButtonGroupProps, MenuItem } from '@blueprintjs/core';
 import { ItemListPredicate, ItemRenderer, Select } from '@blueprintjs/select';
 import { observer } from 'mobx-react';
 import * as React from 'react';
+import semver from 'semver';
 
 import { RunnableVersion, VersionSource, VersionState } from '../../interfaces';
 import { highlightText } from '../../utils/highlight-text';
@@ -82,7 +83,16 @@ export const filterItems: ItemListPredicate<RunnableVersion> = (
       version,
     }))
     .filter((item) => item.index !== -1)
-    .sort((a, b) => a.index - b.index)
+    .sort((a, b) => {
+      // If the user is searching for e.g. 'nightly' we
+      // want to sort nightlies by descending major version.
+      if (isNaN(+q)) {
+        const one = semver.coerce(a.version.version);
+        const two = semver.coerce(b.version.version);
+        if (one && two) return semver.rcompare(one, two);
+      }
+      return a.index - b.index;
+    })
     .map((item) => item.version);
 };
 

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -78,18 +78,22 @@ export const filterItems: ItemListPredicate<RunnableVersion> = (
   const q = query.toLowerCase();
 
   return versions
-    .map((version: RunnableVersion) => ({
-      index: version.version.toLowerCase().indexOf(q),
-      version,
-    }))
+    .map((version: RunnableVersion) => {
+      const lowercase = version.version.toLowerCase();
+      return {
+        index: lowercase.indexOf(q),
+        coerced: semver.coerce(lowercase),
+        version,
+      };
+    })
     .filter((item) => item.index !== -1)
     .sort((a, b) => {
       // If the user is searching for e.g. 'nightly' we
       // want to sort nightlies by descending major version.
       if (isNaN(+q)) {
-        const one = semver.coerce(a.version.version);
-        const two = semver.coerce(b.version.version);
-        if (one && two) return semver.rcompare(one, two);
+        if (a.coerced && b.coerced) {
+          return semver.rcompare(a.coerced, b.coerced);
+        }
       }
       return a.index - b.index;
     })

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -141,7 +141,7 @@ describe('VersionSelect component', () => {
   });
 
   describe('filterItems()', () => {
-    it('correctly matches a query', () => {
+    it('correctly matches a numeric query', () => {
       const versions = [
         { version: '14.3.0' },
         { version: '3.0.0' },
@@ -159,6 +159,30 @@ describe('VersionSelect component', () => {
       ] as RunnableVersion[];
 
       expect(filterItems('3', versions)).toEqual(expected);
+    });
+
+    it('sorts in descending order when the query is non-numeric', () => {
+      const versions = [
+        { version: '3.0.0' },
+        { version: '13.2.0' },
+        { version: '14.3.0' },
+        { version: '12.0.0-beta.3' },
+        { version: '3.0.0-nightly.12345678' },
+        { version: '13.2.0-nightly.12345678' },
+        { version: '14.3.0-nightly.12345678' },
+        { version: '9.0.0-nightly.12345678' },
+        { version: '12.0.0-nightly.20210301' },
+      ] as RunnableVersion[];
+
+      const expected = [
+        { version: '14.3.0-nightly.12345678' },
+        { version: '13.2.0-nightly.12345678' },
+        { version: '12.0.0-nightly.20210301' },
+        { version: '9.0.0-nightly.12345678' },
+        { version: '3.0.0-nightly.12345678' },
+      ] as RunnableVersion[];
+
+      expect(filterItems('nightly', versions)).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/785.

The previous logic keyed off index only - assuming that queries passed would be numeric and as such we should be unilaterally choosing the first index of the (presumed) number.

However, when the user passes something like `nightly`, this would result in a poorer UX because it would make it so that versions like `9.0.0-nightly.12345678` would show up _before_  `14.0.0-nightly.12345678` since the index would be lesser for the first version.

This corrects that by adding in some logic for non-numeric queries.