### PR TITLE
fix: handle invalid monaco editor command

### DIFF
--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -126,11 +126,15 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     if (editor) {
       const command = editor.getAction(commandId);
 
+      if (!command) return;
+
       console.log(
-        `Editors: Trying to run ${command.id}. Supported: ${command.isSupported}`,
+        `Editors: Trying to run ${
+          command.id
+        }. Supported: ${command.isSupported()}`,
       );
 
-      if (command && command.isSupported()) {
+      if (command.isSupported()) {
         command.run();
       }
     }


### PR DESCRIPTION
Refs https://github.com/electron/fiddle/issues/770 - We can try to pin down the actual command issues later but this for now ameliorates the error.