### PR TITLE
test: simplify versions.ts logic and improve coverage

### DIFF
--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -120,10 +120,10 @@ function makeRunnableVersion(ver: Version): RunnableVersion {
   const run: RunnableVersion = {
     ...ver,
     source: isLocal ? VersionSource.local : VersionSource.remote,
-    state: isLocal ? VersionState.ready : VersionState.unknown,
+    state: VersionState.unknown,
     version: normalizeVersion(ver.version),
   };
-  run.state = getVersionState(ver);
+  run.state = getVersionState(run);
   return run;
 }
 
@@ -253,6 +253,7 @@ export async function fetchReleasedVersions(): Promise<Version[]> {
     .map(({ version }) => ({ version }))
     .filter(({ version }) => semver.gte(version, MIN_DOWNLOAD_VERSION));
 
+  console.log(`Fetched ${versions.length} new Electron versions`);
   if (versions.length > 0) saveReleasedVersions(versions);
   return versions;
 }


### PR DESCRIPTION
Brings version.ts coverage to 100%

- Remove some logic branches in versions.ts that were unreachable, e.g.  the non-exported function `migrateVersions()` used to have a default param but is always called with a parameter, and `fetchReleasedVersions()` used `versions?.length` after already using `versions` as an array.
- Add tests for the logic branches that had not previously been reached in `versions.ts`.
- Finish work started in adefc33a that renames `known` as `released`, e.g. `saveKnownVersions()` -> `saveReleasedVersions()`.
