### PR TITLE
perf: remove getUpdatedElectronVersions

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -29,11 +29,12 @@ import { sortVersions } from '../utils/sort-versions';
 import { IPackageManager } from './npm';
 import {
   addLocalVersion,
+  fetchReleasedVersions,
   getDefaultVersion,
   getElectronVersions,
   getOldestSupportedVersion,
   getReleaseChannel,
-  getUpdatedElectronVersions,
+  makeRunnableVersion,
   saveLocalVersions,
 } from './versions';
 
@@ -302,7 +303,15 @@ export class AppState {
     this.isUpdatingElectronVersions = true;
 
     try {
-      this.addNewVersions(await getUpdatedElectronVersions());
+      const all = await fetchReleasedVersions();
+      let newCount = 0;
+      for (const ver of all) {
+        if (!(ver.version in this.versions)) {
+          ++newCount;
+          this.versions[ver.version] = makeRunnableVersion(ver);
+        }
+      }
+      console.log(`Fetched ${all.length} Electron versions (${newCount} new)`);
     } catch (error) {
       console.warn(`State: Could not update Electron versions`, error);
     }

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -17,7 +17,6 @@ import {
   getLocalVersions,
   getReleaseChannel,
   getReleasedVersions,
-  getUpdatedElectronVersions,
   saveLocalVersions,
 } from '../../src/renderer/versions';
 import { FetchMock } from '../utils';
@@ -213,42 +212,6 @@ describe('versions', () => {
       );
 
       expect(getReleasedVersions().length).toBe(expectedVersionCount);
-    });
-  });
-
-  describe('getUpdatedElectronVersions()', () => {
-    it('gets known versions', async () => {
-      (getVersionState as jest.Mock).mockImplementation((v: any) => {
-        if (v.version === '3.0.5') return VersionState.ready;
-        if (v.version === '3.0.6') return VersionState.unknown;
-        return v.state;
-      });
-
-      (window as any).localStorage.getItem.mockImplementation((key: string) => {
-        if (key === 'known-electron-versions')
-          return '[{ "version": "3.0.5" }]';
-        if (key === 'local-electron-versions')
-          return '[{ "version": "3.0.6", "localPath": "/dev/null" }]';
-        throw new Error(`unexpected key ${key}`);
-      });
-
-      const fetchMock = new FetchMock();
-      fetchMock.add('getUpdatedElectronVersions', '');
-      const result = await getUpdatedElectronVersions();
-
-      expect(result).toEqual([
-        {
-          source: VersionSource.remote,
-          state: VersionState.ready,
-          version: '3.0.5',
-        },
-        {
-          localPath: '/dev/null',
-          source: VersionSource.local,
-          state: VersionState.unknown,
-          version: '3.0.6',
-        },
-      ]);
     });
   });
 


### PR DESCRIPTION
**Note: stacks on top of https://github.com/electron/fiddle/pull/788, which should land first.**

Similar goals of adefc33: When possible, prefer operations that create `Version`s over ones that create `RunnableVersion`s because `RunnableVersions` are more expensive.

This PR removes `getUpdatedElectronVersions()`, which created `RunnableVersions`.

`AppState.updateElectronVersions()` was the only place that used it. That code now uses `fetchReleasedVersions()` instead. AppState looks through the `Version`s returned there and converts *only the previously unknown releases* into `RunnableVersion`s.

Since we're at about 1000 Electron versions now, this eliminates another 1000 disk reads at startup.

Any reviewer welcomed. CC'ing @codebytere as she did the adefc33 review.