### PR TITLE
perf: faster version tests.

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -20,7 +20,7 @@ import {
   VersionState,
 } from '../../interfaces';
 import { AppState } from '../state';
-import { getReleaseChannel, getOldestSupportedVersion } from '../versions';
+import { getReleaseChannel, getOldestSupportedMajor } from '../versions';
 
 interface ElectronSettingsProps {
   appState: AppState;
@@ -250,7 +250,7 @@ export class ElectronSettings extends React.Component<
           onChange={this.handleStateChange}
         />
         <Tooltip
-          content={`Include versions that have reached end-of-life (older than ${getOldestSupportedVersion()})`}
+          content={`Include versions that have reached end-of-life (older than ${getOldestSupportedMajor()}.0.0)`}
           position="bottom"
           intent="primary"
         >

--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -5,7 +5,6 @@ import { readFiddle } from '../utils/read-fiddle';
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as semver from 'semver';
 import decompress from 'decompress';
 
 // parent directory of all the downloaded template fiddles
@@ -93,14 +92,9 @@ export function getTestTemplate(): Promise<EditorValues> {
  * @param {semver.SemVer} version - Electron version, e.g. 12.0.0
  * @returns {boolean} true if major version is a known release
  */
-function isReleasedMajor(version: semver.SemVer) {
-  const releasedMajors = new Set<number>(
-    getReleasedVersions()
-      .map(({ version }) => semver.parse(version))
-      .filter((sem) => Number.isInteger(sem?.major))
-      .map((sem) => sem!.major),
-  );
-  return releasedMajors.has(version.major);
+function isReleasedMajor(major: number) {
+  const prefix = `${major}.`;
+  return getReleasedVersions().some((ver) => ver.version.startsWith(prefix));
 }
 
 /**
@@ -110,8 +104,8 @@ function isReleasedMajor(version: semver.SemVer) {
  * @returns {Promise<EditorValues>}
  */
 export function getTemplate(version: string): Promise<EditorValues> {
-  const sem = semver.parse(version);
-  return sem && isReleasedMajor(sem)
-    ? getQuickStart(`${sem.major}-x-y`)
+  const major = Number.parseInt(version);
+  return major && isReleasedMajor(major)
+    ? getQuickStart(`${major}-x-y`)
     : readFiddle(STATIC_TEMPLATE_DIR);
 }

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -21,8 +21,8 @@ export function getDefaultVersion(versions: RunnableVersion[]): string {
 
   // newest stable release
   const latestStable = versions
-    .map(({ version }) => semver.parse(version))
-    .filter((sem) => Boolean(sem) && sem!.prerelease.length === 0)
+    .filter((ver) => !ver.version.includes('-')) // stable
+    .map((ver) => semver.parse(ver.version))
     .sort((a, b) => -semver.compare(a!, b!))
     .shift();
   if (latestStable) return latestStable.version;
@@ -112,10 +112,15 @@ function saveVersions(key: VersionKeys, versions: Array<Version>) {
   window.localStorage.setItem(key, stringified);
 }
 
-function sanitizeVersion(ver: RunnableVersion): RunnableVersion {
-  ver.version = normalizeVersion(ver.version);
-  ver.state = getVersionState(ver);
-  return ver;
+export function makeRunnable(ver: Version): RunnableVersion {
+  const ret: RunnableVersion = {
+    ...ver,
+    version: normalizeVersion(ver.version),
+    source: Boolean(ver.localPath) ? VersionSource.local : VersionSource.remote,
+    state: VersionState.unknown,
+  };
+  ret.state = getVersionState(ver);
+  return ret;
 }
 
 /**
@@ -124,23 +129,8 @@ function sanitizeVersion(ver: RunnableVersion): RunnableVersion {
  * @returns {Array<Version>}
  */
 export function getElectronVersions(): Array<RunnableVersion> {
-  const known: Array<RunnableVersion> = getReleasedVersions().map((version) => {
-    return {
-      ...version,
-      source: VersionSource.remote,
-      state: VersionState.unknown,
-    };
-  });
-
-  const local: Array<RunnableVersion> = getLocalVersions().map((version) => {
-    return {
-      ...version,
-      source: VersionSource.local,
-      state: VersionState.ready,
-    };
-  });
-
-  return [...known, ...local].map(sanitizeVersion);
+  const versions = [...getReleasedVersions(), ...getLocalVersions()];
+  return versions.map((ver) => makeRunnable(ver));
 }
 
 /**
@@ -223,44 +213,25 @@ function saveKnownVersions(versions: Array<Version>) {
 }
 
 /**
- * Tries to refresh our known versions and returns whatever we have
- * saved after.
- *
- * @export
- * @returns {Promise<Array<RunnableVersion>>}
- */
-export async function getUpdatedElectronVersions(): Promise<
-  Array<RunnableVersion>
-> {
-  try {
-    await fetchVersions();
-  } catch (error) {
-    console.warn(`Versions: Failed to fetch versions`, { error });
-  }
-
-  return getElectronVersions();
-}
-
-/**
  * Fetch a list of released versions from electronjs.org.
  *
  * @returns {Promise<Version[]>}
  */
 export async function fetchVersions(): Promise<Version[]> {
-  const url = 'https://electronjs.org/headers/index.json';
+  const url = 'https://releases.electronjs.org/releases.json';
   const response = await window.fetch(url);
   const data = (await response.json()) as { version: string }[];
 
-  // pre-0.24.0 versions were technically 'atom-shell' and cannot
-  // be downloaded with @electron/get
-  const MIN_DOWNLOAD_VERSION = semver.parse('0.24.0')!;
-
   const versions: Version[] = data
-    .map(({ version }) => ({ version }))
-    .filter(({ version }) => semver.gte(version, MIN_DOWNLOAD_VERSION));
+    // Don't support anything older than 0.30 (Aug 2015).
+    // The oldest version known to releases.json.org is 0.20,
+    // Pre-0.24.0 versions were technically 'atom-shell' and cannot
+    // be downloaded with @electron/get.
+    .filter((ver) => !ver.version.startsWith('0.2'))
+    .map(({ version }) => ({ version }));
 
   console.log(`Fetched ${versions.length} new Electron versions`);
-  if (versions?.length > 0) saveKnownVersions(versions);
+  if (versions.length > 0) saveKnownVersions(versions);
   return versions;
 }
 
@@ -280,7 +251,7 @@ function isExpectedFormat(input: Array<any>): boolean {
  * @param {Array<any>} input
  * @returns {Array<Version>}
  */
-function migrateVersions(input: Array<any> = []): Array<Version> {
+function migrateVersions(input: Array<any>): Array<Version> {
   return input
     .filter((item) => !!item)
     .map((item) => {
@@ -303,14 +274,13 @@ function isElectronVersion(
   return (input as RunnableVersion).source !== undefined;
 }
 
-export function getOldestSupportedVersion(): string | undefined {
+export function getOldestSupportedMajor(): number | undefined {
   const NUM_STABLE_BRANCHES = process.env.NUM_STABLE_BRANCHES || 4;
 
-  const oldestSupported = getReleasedVersions()
-    .map(({ version }) => version)
-    .filter((version) => /^\d+\.0\.0$/.test(version))
-    .sort(semver.compare)
+  return getReleasedVersions()
+    .filter((ver) => ver.version.endsWith('.0.0'))
+    .map((ver) => Number.parseInt(ver.version))
+    .sort((a, b) => a - b)
     .slice(-NUM_STABLE_BRANCHES)
     .shift();
-  return oldestSupported;
 }

--- a/tests/mocks/versions-mock.json
+++ b/tests/mocks/versions-mock.json
@@ -63,15 +63,5 @@
         },
         "npm_dist_tags": [],
         "total_downloads": 21041
-    },
-    {
-        "node_id": "MDc6UmVsZWFzZTI0ODk2",
-        "tag_name": "v0.3.1",
-        "name": "atom-shell v0.3.1",
-        "prerelease": false,
-        "published_at": "2013-08-12T09:20:23Z",
-        "version": "0.3.1",
-        "npm_dist_tags": [],
-        "total_downloads": 0
     }
 ]

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -36,8 +36,8 @@ describe('ElectronSettings component', () => {
 
   it('renders', () => {
     const spy = jest
-      .spyOn(versions, 'getOldestSupportedVersion')
-      .mockReturnValue('9.0.0');
+      .spyOn(versions, 'getOldestSupportedMajor')
+      .mockReturnValue(9);
 
     const moreVersions: RunnableVersion[] = [
       {

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -4,9 +4,7 @@ import {
   ElectronReleaseChannel,
   RunnableVersion,
   VersionSource,
-  VersionState,
 } from '../../src/interfaces';
-import { getVersionState } from '../../src/renderer/binary';
 import {
   addLocalVersion,
   fetchVersions,
@@ -14,7 +12,6 @@ import {
   getReleasedVersions,
   getLocalVersions,
   getReleaseChannel,
-  getUpdatedElectronVersions,
   saveLocalVersions,
   VersionKeys,
 } from '../../src/renderer/versions';
@@ -202,41 +199,6 @@ describe('versions', () => {
       );
 
       expect(getReleasedVersions().length).toBe(expectedVersionCount);
-    });
-  });
-
-  describe('getUpdatedElectronVersions()', () => {
-    it('gets known versions', async () => {
-      (getVersionState as jest.Mock).mockImplementation((v: any) => {
-        if (v.version === '3.0.5') return VersionState.ready;
-        if (v.version === '3.0.6') return VersionState.unknown;
-        return v.state;
-      });
-
-      (window as any).localStorage.getItem.mockImplementation((key: string) => {
-        if (key === 'known-electron-versions')
-          return '[{ "version": "3.0.5" }]';
-        if (key === 'local-electron-versions')
-          return '[{ "version": "3.0.6" }]';
-        throw new Error(`unexpected key ${key}`);
-      });
-
-      const fetchMock = new FetchMock();
-      fetchMock.add('getUpdatedElectronVersions', '');
-      const result = await getUpdatedElectronVersions();
-
-      expect(result).toEqual([
-        {
-          source: VersionSource.remote,
-          state: VersionState.ready,
-          version: '3.0.5',
-        },
-        {
-          source: VersionSource.local,
-          state: VersionState.unknown,
-          version: '3.0.6',
-        },
-      ]);
     });
   });
 });

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -161,7 +161,7 @@ describe('versions', () => {
   describe('fetchVersions()', () => {
     it('fetches versions >= 0.24.0', async () => {
       const fetchMock = new FetchMock();
-      const url = 'https://electronjs.org/headers/index.json';
+      const url = 'https://releases.electronjs.org/releases.json';
       const filename = path.join(__dirname, '../mocks/versions-mock.json');
       const contents = fs.readFileSync(filename).toString();
       fetchMock.add(url, contents);


### PR DESCRIPTION
- remove getUpdatedElectronVersions(); use fetchVersions() instead since it returns a Version[] instead of the more expensive RunnableVersion[]. Similar to #781.

- don't use semver.parse() if we only need the major version number.


renderer startup in master: 4193 `semver.SemVer` objects created, 2066 `fs.execSync()` calls in `getVersionState()`
renderer startup here: 1033 `semver.SemVer` objects created, 1016 `fs.execSync()` calls in `getVersionState()`