### PR TITLE
fix: proper release sorting in get-version-range

### DIFF
--- a/src/utils/get-version-range.ts
+++ b/src/utils/get-version-range.ts
@@ -2,6 +2,56 @@ import * as semver from 'semver';
 
 import { RunnableVersion } from '../interfaces';
 
+const preTags = ['nightly', 'alpha', 'beta'];
+
+/**
+ * Sorts prerelease tags such that nightly -> alpha -> beta.
+ *
+ * @param a Prerelease tag data for the old version.
+ * @param b Prerelease tag data for the new version.
+ * @returns 0 | 1 | -1
+ */
+const preCompare = (
+  a: readonly (string | number)[],
+  b: readonly (string | number)[],
+) => {
+  const one = preTags.indexOf(a[0] as string);
+  const two = preTags.indexOf(b[0] as string);
+  if (one === two) {
+    // Whether the prerelease tag number is the same
+    // e.g. alpha.1 & alpha.1.
+    if (a[1] === b[1]) return 0;
+    return a[1] > b[1] ? 1 : -1;
+  }
+
+  return one > two ? 1 : -1;
+};
+
+/**
+ * Custom semver comparator which takes into account Electron's prerelease
+ * tag hierarchy.
+ *
+ * Sorts in ascending order when passed to Array.sort().
+ *
+ * @param a The old Electron version.
+ * @param b The new Electron version.
+ * @returns 0 | 1 | -1
+ */
+export function semverCompare(a: string, b: string) {
+  const hasPre = (v: string) => preTags.some((tag) => v.includes(tag));
+
+  // Check that major.minor.patch are the same for a and b.
+  if (semver.coerce(a)?.raw === semver.coerce(b)?.raw) {
+    if (hasPre(a) && hasPre(b)) {
+      const { prerelease: aPre } = semver.parse(a) as semver.SemVer;
+      const { prerelease: bPre } = semver.parse(b) as semver.SemVer;
+      return preCompare(aPre, bPre);
+    }
+  }
+
+  return semver.compare(a, b);
+}
+
 /**
  * An subset of `versions` sorted from oldest to newest and bounded in the range of [oldVersion..newVersion]
  *
@@ -17,7 +67,7 @@ export function getVersionRange(
   versions: RunnableVersion[],
 ): RunnableVersion[] {
   // ensure that oldVersion is old than newVersion
-  if (semver.compare(oldVersion, newVersion) > 0) {
+  if (semverCompare(oldVersion, newVersion) > 0) {
     [oldVersion, newVersion] = [newVersion, oldVersion];
   }
 

--- a/tests/utils/get-version-range-spec.ts
+++ b/tests/utils/get-version-range-spec.ts
@@ -2,7 +2,10 @@ import * as semver from 'semver';
 
 import { VersionsMock } from '../mocks/electron-versions';
 
-import { getVersionRange } from '../../src/utils/get-version-range';
+import {
+  getVersionRange,
+  semverCompare,
+} from '../../src/utils/get-version-range';
 
 describe('getVersionRange', () => {
   const { mockVersionsArray } = new VersionsMock();
@@ -67,5 +70,39 @@ describe('getVersionRange', () => {
 
     versions = getVersionRange(lowerBound, upperBound, newestToOldest);
     expect(versions).toEqual(oldestToNewest);
+  });
+
+  describe('semverCompare', () => {
+    it('can handle prerelease sorting', () => {
+      const versions = [
+        'v2.0.0-nightly.20210103',
+        'v2.0.0-alpha.1',
+        'v1.0.0',
+        'v2.0.0-nightly.20210101',
+        'v2.0.0-beta.1',
+        'v2.0.0-beta.2',
+        'v2.0.0-alpha.3',
+        'v3.0.0',
+        'v14.0.0-nightly.20210901',
+        'v14.1.2-beta.1',
+        'v14.3.2-beta.2',
+      ];
+
+      const expected = [
+        'v1.0.0',
+        'v2.0.0-nightly.20210101',
+        'v2.0.0-nightly.20210103',
+        'v2.0.0-alpha.1',
+        'v2.0.0-alpha.3',
+        'v2.0.0-beta.1',
+        'v2.0.0-beta.2',
+        'v3.0.0',
+        'v14.0.0-nightly.20210901',
+        'v14.1.2-beta.1',
+        'v14.3.2-beta.2',
+      ];
+
+      expect(versions.sort(semverCompare)).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/790.

Updates our logic in `get-version-range` to augment `semver.compare`. The new logic takes into account Electron's prerelease tag hierarchy, whereby `nightly -> alpha -> beta`.