### PR TITLE
refactor: merge version sorting logic

### DIFF
--- a/src/utils/get-version-range.ts
+++ b/src/utils/get-version-range.ts
@@ -1,56 +1,5 @@
-import * as semver from 'semver';
-
 import { RunnableVersion } from '../interfaces';
-
-const preTags = ['nightly', 'alpha', 'beta'];
-
-/**
- * Sorts prerelease tags such that nightly -> alpha -> beta.
- *
- * @param a Prerelease tag data for the old version.
- * @param b Prerelease tag data for the new version.
- * @returns 0 | 1 | -1
- */
-const preCompare = (
-  a: readonly (string | number)[],
-  b: readonly (string | number)[],
-) => {
-  const one = preTags.indexOf(a[0] as string);
-  const two = preTags.indexOf(b[0] as string);
-  if (one === two) {
-    // Whether the prerelease tag number is the same
-    // e.g. alpha.1 & alpha.1.
-    if (a[1] === b[1]) return 0;
-    return a[1] > b[1] ? 1 : -1;
-  }
-
-  return one > two ? 1 : -1;
-};
-
-/**
- * Custom semver comparator which takes into account Electron's prerelease
- * tag hierarchy.
- *
- * Sorts in ascending order when passed to Array.sort().
- *
- * @param a The old Electron version.
- * @param b The new Electron version.
- * @returns 0 | 1 | -1
- */
-export function semverCompare(a: string, b: string) {
-  const hasPre = (v: string) => preTags.some((tag) => v.includes(tag));
-
-  // Check that major.minor.patch are the same for a and b.
-  if (semver.coerce(a)?.raw === semver.coerce(b)?.raw) {
-    if (hasPre(a) && hasPre(b)) {
-      const { prerelease: aPre } = semver.parse(a) as semver.SemVer;
-      const { prerelease: bPre } = semver.parse(b) as semver.SemVer;
-      return preCompare(aPre, bPre);
-    }
-  }
-
-  return semver.compare(a, b);
-}
+import { semverCompare } from './sort-versions';
 
 /**
  * An subset of `versions` sorted from oldest to newest and bounded in the range of [oldVersion..newVersion]

--- a/src/utils/sort-versions.ts
+++ b/src/utils/sort-versions.ts
@@ -2,28 +2,54 @@ import * as semver from 'semver';
 
 import { RunnableVersion } from '../interfaces';
 
-function electronSemVerCompare(a: semver.SemVer, b: semver.SemVer) {
-  const l = a.compareMain(b);
-  if (l) return l;
-  // Electron's approach is nightly -> other prerelease tags -> stable,
-  // so force `nightly` to sort before other prerelease tags.
-  const [prea] = a.prerelease;
-  const [preb] = b.prerelease;
-  if (prea === 'nightly' && preb !== 'nightly') return -1;
-  if (prea !== 'nightly' && preb === 'nightly') return 1;
-  return a.comparePre(b);
-}
+const preTags = ['nightly', 'alpha', 'beta'];
 
-function compare(a: semver.SemVer | string, b: semver.SemVer | string) {
-  // non-semver goes first, sorted lexicographically
-  const astr = typeof a === 'string';
-  const bstr = typeof b === 'string';
-  if (astr && bstr) return (a as string).localeCompare(b as string);
-  if (astr) return -1;
-  if (bstr) return 1;
+/**
+ * Sorts prerelease tags such that nightly -> alpha -> beta.
+ *
+ * @param a Prerelease tag data for the old version.
+ * @param b Prerelease tag data for the new version.
+ * @returns 0 | 1 | -1
+ */
+const preCompare = (
+  a: readonly (string | number)[],
+  b: readonly (string | number)[],
+) => {
+  const one = preTags.indexOf(a[0] as string);
+  const two = preTags.indexOf(b[0] as string);
+  if (one === two) {
+    // Whether the prerelease tag number is the same
+    // e.g. alpha.1 & alpha.1.
+    if (a[1] === b[1]) return 0;
+    return a[1] > b[1] ? 1 : -1;
+  }
 
-  // then semver, sorted newest-to-oldest
-  return -electronSemVerCompare(a as semver.SemVer, b as semver.SemVer);
+  return one > two ? 1 : -1;
+};
+
+/**
+ * Custom semver comparator which takes into account Electron's prerelease
+ * tag hierarchy.
+ *
+ * Sorts in ascending order when passed to Array.sort().
+ *
+ * @param a The old Electron version.
+ * @param b The new Electron version.
+ * @returns 0 | 1 | -1
+ */
+export function semverCompare(a: string, b: string) {
+  const hasPre = (v: string) => preTags.some((tag) => v.includes(tag));
+
+  // Check that major.minor.patch are the same for a and b.
+  if (semver.coerce(a)?.raw === semver.coerce(b)?.raw) {
+    if (hasPre(a) && hasPre(b)) {
+      const { prerelease: aPre } = semver.parse(a) as semver.SemVer;
+      const { prerelease: bPre } = semver.parse(b) as semver.SemVer;
+      return preCompare(aPre, bPre);
+    }
+  }
+
+  return semver.compare(a, b);
 }
 
 /**
@@ -33,14 +59,15 @@ function compare(a: semver.SemVer | string, b: semver.SemVer | string) {
  * @returns {RunnableVersion[]}
  */
 export function sortVersions(versions: RunnableVersion[]): RunnableVersion[] {
-  type VerSemRun = [
-    ver: string,
-    sem: semver.SemVer | null,
-    run: RunnableVersion,
-  ];
-  const sorted = versions
-    .map((run): VerSemRun => [run.version, semver.parse(run.version), run])
-    .sort(([vera, sema], [verb, semb]) => compare(sema || vera, semb || verb));
-  sorted.forEach(([_1, _2, run], idx) => (versions[idx] = run));
-  return versions;
+  type VerSemRun = [ver: string, run: RunnableVersion];
+
+  const filtered = versions.filter((runnable) =>
+    semver.valid(runnable.version),
+  );
+  const sorted = filtered
+    .map((run): VerSemRun => [run.version, run])
+    .sort(([vera], [verb]) => -semverCompare(vera, verb));
+  sorted.forEach(([_1, run], idx) => (filtered[idx] = run));
+
+  return filtered;
 }

--- a/tests/utils/get-version-range-spec.ts
+++ b/tests/utils/get-version-range-spec.ts
@@ -2,10 +2,7 @@ import * as semver from 'semver';
 
 import { VersionsMock } from '../mocks/electron-versions';
 
-import {
-  getVersionRange,
-  semverCompare,
-} from '../../src/utils/get-version-range';
+import { getVersionRange } from '../../src/utils/get-version-range';
 
 describe('getVersionRange', () => {
   const { mockVersionsArray } = new VersionsMock();
@@ -70,39 +67,5 @@ describe('getVersionRange', () => {
 
     versions = getVersionRange(lowerBound, upperBound, newestToOldest);
     expect(versions).toEqual(oldestToNewest);
-  });
-
-  describe('semverCompare', () => {
-    it('can handle prerelease sorting', () => {
-      const versions = [
-        'v2.0.0-nightly.20210103',
-        'v2.0.0-alpha.1',
-        'v1.0.0',
-        'v2.0.0-nightly.20210101',
-        'v2.0.0-beta.1',
-        'v2.0.0-beta.2',
-        'v2.0.0-alpha.3',
-        'v3.0.0',
-        'v14.0.0-nightly.20210901',
-        'v14.1.2-beta.1',
-        'v14.3.2-beta.2',
-      ];
-
-      const expected = [
-        'v1.0.0',
-        'v2.0.0-nightly.20210101',
-        'v2.0.0-nightly.20210103',
-        'v2.0.0-alpha.1',
-        'v2.0.0-alpha.3',
-        'v2.0.0-beta.1',
-        'v2.0.0-beta.2',
-        'v3.0.0',
-        'v14.0.0-nightly.20210901',
-        'v14.1.2-beta.1',
-        'v14.3.2-beta.2',
-      ];
-
-      expect(versions.sort(semverCompare)).toEqual(expected);
-    });
   });
 });

--- a/tests/utils/sort-versions-spec.ts
+++ b/tests/utils/sort-versions-spec.ts
@@ -61,20 +61,4 @@ describe('sort-versions', () => {
       makeVersion('v2.0.0-nightly.20200101'),
     ]);
   });
-
-  it('handles invalid versions', () => {
-    const unsorted: RunnableVersion[] = [
-      makeVersion('moreGarbage'),
-      makeVersion('v1.0.0'),
-      makeVersion('v3.0.0'),
-      makeVersion('garbage'),
-    ];
-
-    const sorted = sortVersions([...unsorted]);
-
-    expect(sorted).toStrictEqual<any>([
-      makeVersion('v3.0.0'),
-      makeVersion('v1.0.0'),
-    ]);
-  });
 });

--- a/tests/utils/sort-versions-spec.ts
+++ b/tests/utils/sort-versions-spec.ts
@@ -73,8 +73,6 @@ describe('sort-versions', () => {
     const sorted = sortVersions([...unsorted]);
 
     expect(sorted).toStrictEqual<any>([
-      makeVersion('garbage'),
-      makeVersion('moreGarbage'),
       makeVersion('v3.0.0'),
       makeVersion('v1.0.0'),
     ]);


### PR DESCRIPTION
Follow-up to https://github.com/electron/fiddle/pull/797#pullrequestreview-711926906 - merges and cleans up similar sorting logic in `src/utils/get-version-range.ts` and `src/utils/sort-versions.ts`

Notes:
 * In looking at the logic in https://github.com/electron/fiddle/pull/786 i think it's semantically different enough to stay as-is for now 🤔
 * Added an extra filter to the logic in `sortVersions` to remove versions that don't coerce to a valid semver version - there's no use case I see where we'd want to keep them around so imo it's better just to get rid of them.
     * Tests updated accordingly
