### PR TITLE
fix: handle missing local version binaries

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -5,7 +5,7 @@ import {
   Checkbox,
   FormGroup,
   HTMLTable,
-  IButtonProps,
+  ButtonProps,
   Icon,
   IconName,
   Tooltip,
@@ -310,7 +310,8 @@ export class ElectronSettings extends React.Component<
    * @returns {JSX.Element}
    */
   private renderHumanState(item: RunnableVersion): JSX.Element {
-    const { state } = item;
+    const { state, source } = item;
+    const isLocal = source === VersionSource.local;
     let icon: IconName = 'box';
     let humanState = 'Downloaded';
 
@@ -318,8 +319,10 @@ export class ElectronSettings extends React.Component<
       icon = 'cloud-download';
       humanState = 'Downloading';
     } else if (state === VersionState.unknown) {
-      icon = 'cloud';
-      humanState = 'Not downloaded';
+      // The only way for a local version to be unknown
+      // is for it to have been deleted. Mark as unavailable.
+      icon = isLocal ? 'issue' : 'cloud';
+      humanState = isLocal ? 'Not available' : 'Not downloaded';
     }
 
     return (
@@ -340,7 +343,8 @@ export class ElectronSettings extends React.Component<
   private renderAction(ver: RunnableVersion): JSX.Element {
     const { state, source } = ver;
     const { appState } = this.props;
-    const buttonProps: IButtonProps = {
+    const isLocal = source === VersionSource.local;
+    const buttonProps: ButtonProps = {
       fill: true,
       small: true,
     };
@@ -349,7 +353,7 @@ export class ElectronSettings extends React.Component<
       case VersionState.ready:
         buttonProps.icon = 'trash';
         buttonProps.onClick = () => appState.removeVersion(ver);
-        buttonProps.text = source === VersionSource.local ? 'Remove' : 'Delete';
+        buttonProps.text = isLocal ? 'Remove' : 'Delete';
         break;
 
       case VersionState.downloading:
@@ -362,10 +366,12 @@ export class ElectronSettings extends React.Component<
 
       case VersionState.unknown:
         buttonProps.disabled = false;
-        buttonProps.icon = 'cloud-download';
         buttonProps.loading = false;
-        buttonProps.onClick = () => appState.downloadVersion(ver);
-        buttonProps.text = 'Download';
+        buttonProps.icon = isLocal ? 'trash' : 'cloud-download';
+        buttonProps.text = isLocal ? 'Remove' : 'Download';
+        buttonProps.onClick = () => {
+          isLocal ? appState.removeVersion(ver) : appState.downloadVersion(ver);
+        };
         break;
     }
 

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -106,6 +106,26 @@ describe('ElectronSettings component', () => {
     expect(store.downloadVersion).toHaveBeenCalledTimes(1);
   });
 
+  it('handles missing local versions', () => {
+    const version = '99999.0.0';
+    const ver = {
+      source: VersionSource.local,
+      state: VersionState.unknown,
+      version,
+    };
+    store.versions = { version: ver };
+    store.versionsToShow = [ver];
+
+    const wrapper = mount(<ElectronSettings appState={store as any} />);
+
+    wrapper
+      .find('.electron-versions-table .bp3-button')
+      .first()
+      .simulate('click');
+
+    expect(store.removeVersion).toHaveBeenCalledTimes(1);
+  });
+
   it('handles the deleteAll()', async () => {
     const wrapper = shallow(<ElectronSettings appState={store as any} />);
     const instance = wrapper.instance() as any;


### PR DESCRIPTION
Fixes an issue where deleted local Electron versions would show up as non-downloaded versions in settings.

Before:

<img width="862" alt="Screen Shot 2021-07-26 at 8 54 17 PM" src="https://user-images.githubusercontent.com/2036040/127043175-ca0f04e2-039d-4d3c-a6e3-2d40260b399b.png">

After:

<img width="852" alt="Screen Shot 2021-07-26 at 8 54 49 PM" src="https://user-images.githubusercontent.com/2036040/127043226-5861515b-b4d3-438c-b780-642f624ea9c9.png">

