### PR TITLE
chore: fix context menu goto and peek definition

### DIFF
--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -53,7 +53,7 @@ export function getMonacoItems({
       id: 'go_to_definition',
       label: 'Go to Definition',
       click() {
-        const cmd = ['editor.action.goToDeclaration'];
+        const cmd = ['editor.action.revealDefinition'];
         ipcMainManager.send(IpcEvents.MONACO_EXECUTE_COMMAND, cmd);
       },
     },
@@ -61,7 +61,7 @@ export function getMonacoItems({
       id: 'peek_definition',
       label: 'Peek Definition',
       click() {
-        const cmd = ['editor.action.previewDeclaration'];
+        const cmd = ['editor.action.peekDefinition'];
         ipcMainManager.send(IpcEvents.MONACO_EXECUTE_COMMAND, cmd);
       },
     },


### PR DESCRIPTION
This PR addresses: #770 

The "go to definition" and "peek definition" context menu functionalities seem to not have worked for a while. Running `editors.getSupportedActions` seems to produce a list that did not contain the actions previously mapped to these context menu items. These new action events should be more appropriate!


https://user-images.githubusercontent.com/33054982/127208466-b5840054-5e27-494f-bcd1-a65e3f06b362.mov

