### PR TITLE
chore: remove accidentally-included console.log() call

### DIFF
--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -167,7 +167,6 @@ export class Output extends React.Component<CommandsProps> {
     // adjust `i` here because the value passed in by monaco starts at 1, not 0
     const lineNumbers = (i: number) => timestrs[i - 1] || '';
     editor.updateOptions({ lineNumbers, lineNumbersMinChars });
-    console.log(lineNumbersMinChars);
     editor.revealLine(editor.getScrollHeight());
   }
 


### PR DESCRIPTION
Looks like this is a tracer call to console.log() that was accidentally included in https://github.com/electron/fiddle/pull/796