### PR TITLE
test: reduce copy-paste in get-package

### DIFF
--- a/tests/utils/get-package-spec.ts
+++ b/tests/utils/get-package-spec.ts
@@ -1,7 +1,8 @@
 import * as semver from 'semver';
 
-import { DefaultEditorId } from '../../src/interfaces';
+import { MAIN_JS } from '../../src/interfaces';
 import { getForgeVersion, getPackageJson } from '../../src/utils/get-package';
+import { StateMock } from '../mocks/mocks';
 
 jest.mock('../../src/utils/get-username', () => ({
   getUsername: () => 'test-user',
@@ -11,141 +12,63 @@ jest.mock('../../src/renderer/npm', () => ({
   findModulesInEditors: () => ['say'],
 }));
 
-describe('getForgeVersion', () => {
-  it('returns a semver-compatible version constraint', () => {
-    const version = getForgeVersion();
-    expect(typeof version).toEqual('string');
-    expect(version).toBeTruthy();
-    expect(semver.validRange(version)).toBeTruthy();
-  });
-});
-
 describe('get-package', () => {
-  it('getPackageJson() returns a default package.json', async () => {
-    const result = await getPackageJson(
-      {
-        getName: () => 'test-app',
-      } as any,
-      {
-        [DefaultEditorId.main]: 'app.goDoTheThing()',
-        [DefaultEditorId.renderer]: `const say = require('say')`,
-        [DefaultEditorId.html]: '<html />',
-        [DefaultEditorId.preload]: 'preload',
-        [DefaultEditorId.css]: 'body { color: black }',
-      },
-    );
-
-    expect(result).toEqual(
-      JSON.stringify(
-        {
-          name: 'test-app',
-          productName: 'test-app',
-          description: 'My Electron application description',
-          keywords: [],
-          main: './main.js',
-          version: '1.0.0',
-          author: 'test-user',
-          scripts: {
-            start: 'electron .',
-          },
-          dependencies: {
-            say: '*',
-          },
-          devDependencies: {},
-        },
-        undefined,
-        2,
-      ),
-    );
+  describe('getForgeVersion', () => {
+    it('returns a semver-compatible version constraint', () => {
+      const version = getForgeVersion();
+      expect(typeof version).toEqual('string');
+      expect(version).toBeTruthy();
+      expect(semver.validRange(version)).toBeTruthy();
+    });
   });
 
-  it('getPackageJson() includes electron-nightly if needed', async () => {
-    const result = await getPackageJson(
-      {
-        getName: () => 'test-app',
-        version: '1.0.0-nightly.123456789',
-      } as any,
-      {
-        [DefaultEditorId.main]: 'app.goDoTheThing()',
-        [DefaultEditorId.renderer]: `const say = require('say')`,
-        [DefaultEditorId.html]: '<html />',
-        [DefaultEditorId.preload]: 'preload',
-        [DefaultEditorId.css]: 'body { color: black }',
-      },
-      {
-        includeElectron: true,
-        includeDependencies: true,
-      },
-    );
+  describe('getPackageJson()', () => {
+    const appState = new StateMock();
+    const defaultName = 'test-app' as const;
 
-    expect(result).toEqual(
-      JSON.stringify(
-        {
-          name: 'test-app',
-          productName: 'test-app',
-          description: 'My Electron application description',
-          keywords: [],
-          main: './main.js',
-          version: '1.0.0',
-          author: 'test-user',
-          scripts: {
-            start: 'electron .',
-          },
-          dependencies: {
-            say: '*',
-          },
-          devDependencies: {
-            'electron-nightly': '1.0.0-nightly.123456789',
-          },
-        },
-        undefined,
-        2,
-      ),
-    );
-  });
+    const editorValues = {
+      [MAIN_JS]: `const say = require('say')`,
+    } as const;
 
-  it('getPackageJson() includes electron if needed', async () => {
-    const result = await getPackageJson(
-      {
-        getName: () => 'test-app',
-        version: '1.0.0',
-      } as any,
-      {
-        [DefaultEditorId.main]: 'app.goDoTheThing()',
-        [DefaultEditorId.renderer]: `const say = require('say')`,
-        [DefaultEditorId.html]: '<html />',
-        [DefaultEditorId.preload]: 'preload',
-        [DefaultEditorId.css]: 'body { color: black }',
+    const defaultPackage = {
+      name: defaultName,
+      productName: defaultName,
+      description: 'My Electron application description',
+      keywords: [],
+      main: `./${MAIN_JS}`,
+      version: '1.0.0',
+      author: 'test-user',
+      scripts: {
+        start: 'electron .',
       },
-      {
-        includeElectron: true,
-        includeDependencies: true,
+      dependencies: {
+        say: '*',
       },
-    );
+      devDependencies: {},
+    } as const;
 
-    expect(result).toEqual(
-      JSON.stringify(
-        {
-          name: 'test-app',
-          productName: 'test-app',
-          description: 'My Electron application description',
-          keywords: [],
-          main: './main.js',
-          version: '1.0.0',
-          author: 'test-user',
-          scripts: {
-            start: 'electron .',
-          },
-          dependencies: {
-            say: '*',
-          },
-          devDependencies: {
-            electron: '1.0.0',
-          },
-        },
-        undefined,
-        2,
-      ),
-    );
+    function buildExpectedPackage(opts: Record<string, unknown> = {}) {
+      return JSON.stringify({ ...defaultPackage, ...opts }, null, 2);
+    }
+
+    it('getPackageJson() returns a default package.json', async () => {
+      const name = defaultName;
+      const appState = { getName: () => name };
+      const result = await getPackageJson(appState as any, editorValues);
+      expect(result).toEqual(buildExpectedPackage());
+    });
+
+    it.each([
+      ['can include electron', '13.0.0', 'electron'],
+      ['can include electron-nightly', '13.0.0-nightly.12', 'electron-nightly'],
+    ])('%s', async (_, version: string, electronPkg: string) => {
+      const name = defaultName;
+      appState.getName.mockReturnValue(name);
+      appState.version = version;
+
+      const result = await getPackageJson(appState as any, editorValues);
+      const devDependencies = { [electronPkg]: version };
+      expect(result).toEqual(buildExpectedPackage({ name, devDependencies }));
+    });
   });
 });


### PR DESCRIPTION
Tests only. No functional changes.

Part of a series of small refactors to reduce copy-paste that's built up over time in tests/.

This PR is for get-package.