### PR TITLE
feat: more descriptive local version names

### DIFF
--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -32,6 +32,31 @@ interface AddVersionDialogState {
 }
 
 /**
+ * Build a default name for a local Electron vresion
+ * from its dirname.
+ *
+ * @param {string} dirname
+ * @return {string} human-readable local build name
+ */
+function makeLocalName(folderPath: string) {
+  // take a dirname like '/home/username/electron/gn/main/src/out/testing'
+  // and return something like 'gn/main - testing'
+  const tokens = folderPath.split(path.sep);
+  const buildType = tokens.pop(); // e.g. 'testing' or 'release'
+  const leader = tokens
+    // remove 'src/out/' -- they are in every local build, so make poor names
+    .slice(0, -2)
+    .join(path.sep)
+    // extract about enough for the end result to be about 20 chars
+    .slice(-20 + buildType!.length)
+    // remove any fragment in case the prev slice cut in the middle of a name
+    .split(path.sep)
+    .slice(1)
+    .join(path.sep);
+  return `${leader} - ${buildType}`;
+}
+
+/**
  * The "add version" dialog allows users to add custom builds of Electron.
  *
  * @class AddVersionDialog
@@ -104,12 +129,10 @@ export class AddVersionDialog extends React.Component<
 
     if (!folderPath) return;
 
-    const name = folderPath.slice(-20).split(path.sep).slice(1).join(path.sep);
-
     const toAdd: Version = {
       localPath: folderPath,
       version,
-      name,
+      name: makeLocalName(folderPath),
     };
 
     // swap to old local electron version if the user adds a new one with the same path


### PR DESCRIPTION
Looking for feedback on this as well as code review -- this PR is better for _my_ workflow but I'd like another opinion not just on the code but on the idea, since other people may have other workflows.

One small annoyance is that Electron Fiddle names all my local builds something like `src/out/release` or `src/out/testing`. Since `src/out/` is literally in every local build, it's not the most useful fragment to identify a version. Usually I keep checkouts in something like `.../main/src/out/...` or `.../13/src/out/...` so that parent directory would be more helpful.

When given a path like `/home/username/electron/gn/main/src/out/testing`, instead of returning `src/out/testing`, this PR returns `gn/main - testing`.

So, like I say -- this is helpful _to me_, but I'd like a sanity check about whether or not this works as a general-purpose change.

What do your folder names look like?