### PR TITLE
fix: infinite loop in AppState.setVersion()

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -488,11 +488,7 @@ export class AppState {
    * Private setVersion() helper to find a usable fallback version.
    */
   private findUsableVersion(): RunnableVersion | undefined {
-    for (const version of this.versionsToShow) {
-      const { ver } = this.isVersionUsable(version.version);
-      if (ver) return ver;
-    }
-    return undefined;
+    return this.versionsToShow.find((ver) => this.isVersionUsable(ver.version));
   }
 
   /**


### PR DESCRIPTION
Fixes #826.

When setVersion() gets an invalid or unusable version, walk through showVersionsToShow to find a version that will be usable. Use the first one that's found, or do nothing if no usable version can be found.