### PR TITLE
build: increase yarn network timeout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
-        run: yarn
+        run: yarn --network-timeout 100000
       - name: lint
         run: yarn lint
       - name: test


### PR DESCRIPTION
Attempt at fixing #749. Not sure if it'll work, as we'll only see if the flake rate on macOS decreases through CI runs.

