### PR TITLE
chore: allow check-links tool to run in Node 12

### DIFF
--- a/tools/check-links.js
+++ b/tools/check-links.js
@@ -1,4 +1,4 @@
-const fs = require('fs/promises');
+const { promises: fs } = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 


### PR DESCRIPTION
Noticed this when I ran `yarn lint` (I run Node 12 by default for all of the Electron tooling development). It looks like `fs/promises` was added in Node 14?

Alternatively, we could just require the development of the repo to use Node >= 14.