### PR TITLE
chore: make sure static JS files use standard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,8 @@ const config = {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
   },
-  ignorePatterns: ['/out', '/dist', '/coverage'],
+  // the static folder is linted by standard
+  ignorePatterns: ['/out', '/dist', '/coverage', '/static'],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "less": "node ./tools/lessc.js",
     "lint:style": "stylelint  \"./src/less/*.less\" --fix",
     "lint:ts": "eslint \"./**/*.{ts,tsx}\" --fix",
-    "lint:templates": "standard \"static/show-me/**/*.js\" --fix",
+    "lint:templates": "standard \"static/**/*.js\" --fix",
     "lint:links": "node ./tools/check-links.js",
     "lint": "npm-run-all \"lint:*\"",
     "make": "electron-forge make",
@@ -124,7 +124,7 @@
     "./**/*.{js,ts,tsx}": [
       "eslint --fix"
     ],
-    "./static/show-me/**/*.js": [
+    "./static/**/*.js": [
       "standard --fix"
     ],
     "./src/less/*.less": [

--- a/static/electron-quick-start/main.js
+++ b/static/electron-quick-start/main.js
@@ -1,19 +1,19 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow } = require('electron');
-const path = require('path');
+const { app, BrowserWindow } = require('electron')
+const path = require('path')
 
-function createWindow() {
+function createWindow () {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-    },
-  });
+      preload: path.join(__dirname, 'preload.js')
+    }
+  })
 
   // and load the index.html of the app.
-  mainWindow.loadFile('index.html');
+  mainWindow.loadFile('index.html')
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
@@ -23,21 +23,21 @@ function createWindow() {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
-  createWindow();
+  createWindow()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
-});
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
 
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+  if (process.platform !== 'darwin') app.quit()
+})
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/static/electron-quick-start/main.js
+++ b/static/electron-quick-start/main.js
@@ -1,19 +1,19 @@
 // Modules to control application life and create native browser window
-const {app, BrowserWindow} = require('electron')
-const path = require('path')
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
-    }
-  })
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
 
   // and load the index.html of the app.
-  mainWindow.loadFile('index.html')
+  mainWindow.loadFile('index.html');
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
@@ -23,21 +23,21 @@ function createWindow () {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
-  createWindow()
-  
+  createWindow();
+
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
 
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
-})
+  if (process.platform !== 'darwin') app.quit();
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/static/show-me/ipc/main.js
+++ b/static/show-me/ipc/main.js
@@ -5,8 +5,8 @@
 // https://electronjs.org/docs/api/ipc-main
 // https://electronjs.org/docs/api/ipc-renderer
 
-const { app, BrowserWindow, ipcMain } = require('electron');
-const path = require('path');
+const { app, BrowserWindow, ipcMain } = require('electron')
+const path = require('path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
@@ -15,24 +15,24 @@ app.whenReady().then(() => {
     webPreferences: {
       nodeIntegration: false, // default in Electron >= 5
       contextIsolation: true, // default in Electron >= 12
-      preload: path.join(__dirname, 'preload.js'),
-    },
-  });
+      preload: path.join(__dirname, 'preload.js')
+    }
+  })
 
   ipcMain.on('asynchronous-message', (event, arg) => {
-    console.log(arg); // prints "ping"
-    event.sender.send('asynchronous-reply', 'pong');
-  });
+    console.log(arg) // prints "ping"
+    event.sender.send('asynchronous-reply', 'pong')
+  })
 
   ipcMain.on('synchronous-message', (event, arg) => {
-    console.log(arg); // prints "ping"
-    event.returnValue = 'pong';
-  });
+    console.log(arg) // prints "ping"
+    event.returnValue = 'pong'
+  })
 
   ipcMain.handle('invoke-handle-message', (event, arg) => {
-    console.log(arg);
-    return 'pong';
-  });
+    console.log(arg)
+    return 'pong'
+  })
 
-  mainWindow.loadFile('index.html');
-});
+  mainWindow.loadFile('index.html')
+})

--- a/static/show-me/ipc/preload.js
+++ b/static/show-me/ipc/preload.js
@@ -1,13 +1,13 @@
-const { ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron')
 
 // prints "pong"
-console.log(ipcRenderer.sendSync('synchronous-message', 'ping'));
+console.log(ipcRenderer.sendSync('synchronous-message', 'ping'))
 
 // prints "pong"
-ipcRenderer.on('asynchronous-reply', (_, ...args) => console.log(...args));
+ipcRenderer.on('asynchronous-reply', (_, ...args) => console.log(...args))
 
-ipcRenderer.send('asynchronous-message', 'ping');
+ipcRenderer.send('asynchronous-message', 'ping')
 
 ipcRenderer
   .invoke('invoke-handle-message', 'ping')
-  .then((reply) => console.log(reply));
+  .then((reply) => console.log(reply))

--- a/static/show-me/webcontents/main.js
+++ b/static/show-me/webcontents/main.js
@@ -3,22 +3,22 @@
 // For more info, see:
 // https://electronjs.org/docs/api/web-contents
 
-const { app, BrowserWindow, webContents } = require('electron');
+const { app, BrowserWindow, webContents } = require('electron')
 
 app.whenReady().then(() => {
-  const mainWindow = new BrowserWindow({ height: 600, width: 600 });
-  mainWindow.loadFile('index.html');
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  mainWindow.loadFile('index.html')
 
   // This setTimeout is to demonstrate the method firing
   // for the demo, and is not needed in production.
   setTimeout(() => {
-    const contents = webContents.getAllWebContents()[0];
+    const contents = webContents.getAllWebContents()[0]
 
     // The WebContents class has dozens of methods and
     // events available. As an example, we'll call one
     // of them here: loadURL, which loads Electron's
     // home page.
-    const options = { extraHeaders: 'pragma: no-cache\n' };
-    contents.loadURL('https://electronjs.org', options);
-  }, 1000);
-});
+    const options = { extraHeaders: 'pragma: no-cache\n' }
+    contents.loadURL('https://electronjs.org', options)
+  }, 1000)
+})


### PR DESCRIPTION
The lint-staged pre-commit rules ran both ESLint and standard on JS files in `static/show-me`, with ESLint (+ prettier) always winning (and contradicting `yarn lint`). This PR makes ESLint ignore the `static/` folder and fixes up any files that were formatted with prettier due to lint-staged. 