### PR TITLE
ci: refactor GitHub Actions for caching / network timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - name: Setup Node.js
         uses: actions/setup-node@v2.4.0
         with:
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: [ macOS-latest, ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - name: Setup Node.js
         uses: actions/setup-node@v2.4.0
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
           fileName: 'win-certificate.pfx'
           encodedString: ${{ secrets.WINDOWS_CODESIGN_P12 }}
       - name: Install
-        run: yarn
+        run: yarn --network-timeout 100000
       - name: Make
         if: startsWith(github.ref, 'refs/tags/')
         run: yarn make --arch=all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,19 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: 15.x
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - name: Install
         run: yarn --network-timeout 100000
       - name: lint
@@ -47,20 +38,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: 12.x
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        if: matrix.os != 'macOS-latest'
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
       - name: Set MacOS signing certs
         if: matrix.os == 'macOS-latest'
         run: chmod +x tools/add-macos-cert.sh && ./tools/add-macos-cert.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: test
         run: yarn test:ci
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   build:

--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -6,23 +6,14 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - name: Fetch git branches
       run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2.4.0
       with:
         node-version: '12.x'
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-    - uses: actions/cache@v2
-      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - run: yarn
+        cache: yarn
+    - run: yarn --network-timeout 100000
     - name: Switch to release update branch
       run: |
         if git branch --remotes | grep -q origin/update-releases; then


### PR DESCRIPTION
* Adds Dependabot config for GitHub Actions
  * I deliberately didn't want to update JS dependencies here. If we want to do that we should tackle that in a separate PR (and also discuss whether those PRs should get auto-merged when tests pass)
*  Refactor the setup-node/cache config since setup-node now comes with caching built-into it
* Add yarn network timeout from #833 to the build step (it failed [here](https://github.com/electron/fiddle/runs/3326328222?check_suite_focus=true))