### PR TITLE
feat: add editor font zoom in and zoom out accessibility function

### DIFF
--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -100,6 +100,25 @@ export function getMonacoItems({
       },
     },
     { type: 'separator' },
+    {
+      id: 'font_zoom',
+      label: 'Zoom In Font',
+      click() {
+        const cmd = ['editor.action.fontZoomIn'];
+        ipcMainManager.send(IpcEvents.MONACO_EXECUTE_COMMAND, cmd);
+      },
+      accelerator: 'CmdOrCtrl+numadd',
+    },
+    {
+      id: 'font_zoom',
+      label: 'Zoom Out Font',
+      click() {
+        const cmd = ['editor.action.fontZoomOut'];
+        ipcMainManager.send(IpcEvents.MONACO_EXECUTE_COMMAND, cmd);
+      },
+      accelerator: 'CmdOrCtrl+numsub',
+    },
+    { type: 'separator' },
   ];
 }
 

--- a/tests/main/context-menu-spec.ts
+++ b/tests/main/context-menu-spec.ts
@@ -179,7 +179,7 @@ describe('context-menu', () => {
         editFlags: { canPaste: true },
         pageURL: 'index.html',
       } as any);
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(12);
     });
 
     it('executes an IPC send() for each element', () => {


### PR DESCRIPTION
Visual Studio Code allows for its users to increase and decrease its editors' font size through the keyboard shortcut `cmd-numadd` and `cmd-numsub`. This PR aims to bring this accessibility feature to Electron Fiddle. 

In addition to the keyboard shortcut, this PR also adds submenus to the context menu.

![image](https://user-images.githubusercontent.com/33054982/130041564-4b822487-3814-4a61-84ff-ec63f66ab32c.png)

![image](https://user-images.githubusercontent.com/33054982/130043259-f8413530-8d56-4e4b-985b-062f2d2e9978.png)

![image](https://user-images.githubusercontent.com/33054982/130043334-fc725bf2-9910-4f6b-bf0a-906ed09da9ea.png)

note: there is an option to reset an editors' zoom. Wondering if it is preferable to add that option to the context menu (in conjunction with or replacing the `Zoom In Text` and `Zoom Out Text` context menu buttons).