### PR TITLE
ci: Run yarn with --frozen-lockfile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
           node-version: 15.x
           cache: yarn
       - name: Install
-        run: yarn --network-timeout 100000
+        run: yarn --frozen-lockfile --network-timeout 100000
       - name: lint
         run: yarn lint
       - name: test


### PR DESCRIPTION
This is the [recommended](https://classic.yarnpkg.com/en/docs/cli/install/) way to run Yarn in CI, in order to catch pull requests like #813 that leave package.json and yarn.lock out of sync.