### PR TITLE
fix(linux): enable protocol handler for deb/rpm

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -14,6 +14,13 @@ if (process.env['WINDOWS_CODESIGN_FILE']) {
   }
 }
 
+const commonLinuxConfig = {
+  icon: {
+    scalable: path.resolve(iconDir, 'fiddle.svg'),
+  },
+  mimeType: ['x-scheme-handler/electron-fiddle'],
+};
+
 const config = {
   hooks: {
     generateAssets: require('./tools/generateAssets'),
@@ -87,15 +94,12 @@ const config = {
     {
       name: '@electron-forge/maker-deb',
       platforms: ['linux'],
-      config: {
-        icon: {
-          scalable: path.resolve(iconDir, 'fiddle.svg'),
-        },
-      },
+      config: commonLinuxConfig,
     },
     {
       name: '@electron-forge/maker-rpm',
       platforms: ['linux'],
+      config: commonLinuxConfig,
     },
   ],
   publishers: [


### PR DESCRIPTION
I was in the middle of fixing up the protocol handler guide in the Electron docs and I realized that Fiddle's URLs don't work on Linux. It turns out that you need to [add an `x-scheme-handler` to the `MimeType`](https://specifications.freedesktop.org/shared-mime-info-spec/0.21/ar01s02.html#idm45917071429120) in the Electron app's `.desktop` file (which is generated by the various `electron-installer-*` modules for Linux).

While I was in there I synced the common config for the Linux makers (the rpm was missing the icon).

I tested this on Ubuntu 18.04 by running:

```shell
yarn make --targets=@electron-forge/maker-deb
sudo apt install ./out/make/deb/x64/electron_fiddle_0.26.0_amd64.deb
```

...and then loading an Electron Fiddle URL.