### PR TITLE
chore: upgrade to Electron 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "cross-fetch": "^3.1.0",
-    "electron": "12.0.14",
+    "electron": "15.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.1",

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -22,6 +22,7 @@ export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions
     titleBarStyle: process.platform === 'darwin' ? 'hidden' : undefined,
     acceptFirstMouse: true,
     backgroundColor: '#1d2427',
+    show: false,
     webPreferences: {
       webviewTag: false,
       nodeIntegration: true,

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -34,6 +34,7 @@ describe('windows', () => {
       minWidth: 600,
       acceptFirstMouse: true,
       backgroundColor: '#1d2427',
+      show: false,
       titleBarStyle: undefined,
       webPreferences: {
         webviewTag: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,26 @@
     "@electron-forge/template-base" "6.0.0-beta.59"
     fs-extra "^10.0.0"
 
-"@electron/get@^1.0.1", "@electron/get@^1.12.4", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
+"@electron/get@^1.12.4", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
   version "1.12.4"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.12.4.tgz#a5971113fc1bf8fa12a8789dc20152a7359f06ab"
   integrity sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^9.6.0"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^2.0.2"
+    global-tunnel-ng "^2.7.1"
+
+"@electron/get@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
+  integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
@@ -4625,12 +4641,12 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@12.0.14:
-  version "12.0.14"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.0.14.tgz#7c5547f8248633a4bbbba89c88c57aa9e6410892"
-  integrity sha512-RcU++BiL+DlwhP62sUTasjAOwXOloWQS3oLk4PE0s2eERNs7hr2LoKqbUpbShw9nY+aqNw4mgd+ojyBJsOE2fg==
+electron@15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.0.0.tgz#b1b6244b1cffddf348c27c54b1310b3a3680246e"
+  integrity sha512-LlBjN5nCJoC7EDrgfDQwEGSGSAo/o08nSP5uJxN2m+ZtNA69SxpnWv4yPgo1K08X/iQPoGhoZu6C8LYYlk1Dtg==
   dependencies:
-    "@electron/get" "^1.0.1"
+    "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
As a side effect, this PR hides the window by default (see #822). We already had a handler to `show()` the window when the `webContents` were ready, but it seems like the `show: false` by default was inverted in https://github.com/electron/fiddle/commit/a6e6fad4d901a16c7d76569c627137bb72ef7a11.

This sets it back to avoid the flash of white content described in the aforementioned issue.