### PR TITLE
refactor: `new-window` -> `setWindowOpenHandler`

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -64,9 +64,9 @@ export function createMainWindow(): Electron.BrowserWindow {
     browserWindow = null;
   });
 
-  browserWindow.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
-    shell.openExternal(url);
+  browserWindow.webContents.setWindowOpenHandler((details) => {
+    shell.openExternal(details.url);
+    return { action: 'deny' };
   });
 
   browserWindow.webContents.on('will-navigate', (event, url) => {


### PR DESCRIPTION
As per the `new-window` webContents event deprecation.

https://www.electronjs.org/docs/latest/breaking-changes#deprecated-webcontents-new-window-event