### PR TITLE
feat: handle offline status in version downloads

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -127,6 +127,7 @@ export class App {
     const rendered = render(app, document.getElementById('app'));
 
     this.setupResizeListener();
+    this.setupOfflineListener();
     this.setupThemeListeners();
     this.setupTitleListeners();
     this.setupUnloadListeners();
@@ -218,6 +219,16 @@ export class App {
     } else {
       document.body.classList.remove('bp3-dark');
     }
+  }
+
+  public setupOfflineListener(): void {
+    window.addEventListener('online', async () => {
+      this.state.isOnline = true;
+      this.state.setVersion(this.state.version);
+    });
+    window.addEventListener('offline', () => {
+      this.state.isOnline = false;
+    });
   }
 
   /**

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -19,42 +19,57 @@ interface RunnerProps {
 @observer
 export class Runner extends React.Component<RunnerProps> {
   public render() {
+    const { downloading, unknown, unzipping, ready } = VersionState;
     const {
       isRunning,
       isInstallingModules,
       currentElectronVersion,
+      isOnline,
     } = this.props.appState;
 
-    const state = currentElectronVersion && currentElectronVersion.state;
+    const state = currentElectronVersion?.state;
     const props: ButtonProps = { className: 'button-run', disabled: true };
 
-    if (state === VersionState.downloading) {
-      props.text = 'Downloading';
-      props.icon = (
-        <Spinner size={16} value={currentElectronVersion?.downloadProgress} />
-      );
-    } else if (state === VersionState.unzipping) {
-      props.text = 'Unzipping';
-      props.icon = <Spinner size={16} />;
-    } else if (state === VersionState.ready) {
-      props.disabled = false;
+    if ([downloading, unknown].includes(state) && !isOnline) {
+      props.text = 'Offline';
+      props.icon = 'satellite';
+      return <Button {...props} type={undefined} />;
+    }
 
-      if (isRunning) {
-        props.active = true;
-        props.text = 'Stop';
-        props.onClick = window.ElectronFiddle.app.runner.stop;
-        props.icon = 'stop';
-      } else if (isInstallingModules) {
-        props.text = 'Installing modules';
-        props.icon = <Spinner size={16} />;
-      } else {
-        props.text = 'Run';
-        props.onClick = window.ElectronFiddle.app.runner.run;
-        props.icon = 'play';
+    switch (state) {
+      case downloading: {
+        props.text = 'Downloading';
+        props.icon = (
+          <Spinner size={16} value={currentElectronVersion?.downloadProgress} />
+        );
+        break;
       }
-    } else {
-      props.text = 'Checking status';
-      props.icon = <Spinner size={16} />;
+      case unzipping: {
+        props.text = 'Unzipping';
+        props.icon = <Spinner size={16} />;
+        break;
+      }
+      case ready: {
+        props.disabled = false;
+        if (isRunning) {
+          props.active = true;
+          props.text = 'Stop';
+          props.onClick = window.ElectronFiddle.app.runner.stop;
+          props.icon = 'stop';
+        } else if (isInstallingModules) {
+          props.text = 'Installing modules';
+          props.icon = <Spinner size={16} />;
+        } else {
+          props.text = 'Run';
+          props.onClick = window.ElectronFiddle.app.runner.run;
+          props.icon = 'play';
+        }
+        break;
+      }
+      default: {
+        props.text = 'Checking status';
+        props.icon = <Spinner size={16} />;
+      }
     }
 
     return <Button {...props} type={undefined} />;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -123,6 +123,7 @@ export class AppState {
 
   @observable public activeGistAction: GistActionState = GistActionState.none;
   @observable public isRunning = false;
+  @observable public isOnline = navigator.onLine;
   @observable public isAutoBisecting = false;
   @observable public isInstallingModules = false;
   @observable public isUpdatingElectronVersions = false;

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -37,6 +37,7 @@ export class StateMock {
   @observable public isEnablingElectronLogging = false;
   @observable public isGenericDialogShowing = false;
   @observable public isInstallingModules = false;
+  @observable public isOnline = true;
   @observable public isQuitting = false;
   @observable public isRunning = false;
   @observable public isSettingsShowing = false;


### PR DESCRIPTION
Adds the ability for Fiddle to show an offline status and cancel a download if it loses internet connection. Fixes an issue i've run into before where if the internet dies in the middle of a download, Fiddle goes into "Checking Status" and stays there forever.

<img width="1312" alt="Screen Shot 2021-09-27 at 8 42 42 PM" src="https://user-images.githubusercontent.com/2036040/134966855-0cee0be3-9d30-415a-9cee-533276bb40df.png">


