### PR TITLE
fix: silent failure on file creation

### DIFF
--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -148,9 +148,13 @@ export class SidebarFileTree extends React.Component<
   };
 
   public createEditor = (editorId: EditorId) => {
-    const { editorMosaic } = this.props.appState;
-    editorMosaic.addNewFile(editorId);
-    editorMosaic.show(editorId);
+    const { appState } = this.props;
+    try {
+      appState.editorMosaic.addNewFile(editorId);
+      appState.editorMosaic.show(editorId);
+    } catch (err) {
+      appState.showErrorDialog(err.message);
+    }
   };
 
   public resetLayout = () => {


### PR DESCRIPTION
Fixes an issue where if a user tried to make a new file with a disallowed file extension there would be a silent failure.

After this fix:

<img width="1512" alt="Screen Shot 2021-10-04 at 10 34 35 AM" src="https://user-images.githubusercontent.com/2036040/135819495-df33f349-375d-45af-be68-48417f1bfa07.png">


