### PR TITLE
chore: add tooltips to file tree actions

### DIFF
--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -8,7 +8,7 @@ import {
   Tree,
   TreeNodeInfo,
 } from '@blueprintjs/core';
-import { ContextMenu2 } from '@blueprintjs/popover2';
+import { ContextMenu2, Tooltip2 } from '@blueprintjs/popover2';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
 import * as React from 'react';
@@ -74,9 +74,15 @@ export class SidebarFileTree extends React.Component<
           ),
           secondaryLabel: (
             <ButtonGroup>
-              <Button minimal onClick={() => this.toggleVisibility(editorId)}>
-                <Icon icon={visibilityIcon} />
-              </Button>
+              <Tooltip2
+                content="Toggle Visibility"
+                minimal={true}
+                hoverOpenDelay={1000}
+              >
+                <Button minimal onClick={() => this.toggleVisibility(editorId)}>
+                  <Icon icon={visibilityIcon} />
+                </Button>
+              </Tooltip2>
             </ButtonGroup>
           ),
         };
@@ -119,12 +125,24 @@ export class SidebarFileTree extends React.Component<
         label: 'Editors',
         secondaryLabel: (
           <ButtonGroup minimal>
-            <Button
-              small
-              icon="add"
-              onClick={() => this.setState({ action: 'add' })}
-            />
-            <Button small icon="grid-view" onClick={this.resetLayout} />
+            <Tooltip2
+              content="Add New File"
+              minimal={true}
+              hoverOpenDelay={1000}
+            >
+              <Button
+                small
+                icon="add"
+                onClick={() => this.setState({ action: 'add' })}
+              />
+            </Tooltip2>
+            <Tooltip2
+              content="Reset Layout"
+              minimal={true}
+              hoverOpenDelay={1000}
+            >
+              <Button small icon="grid-view" onClick={this.resetLayout} />
+            </Tooltip2>
           </ButtonGroup>
         ),
       },

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -251,7 +251,7 @@ export class RemoteLoader {
   private handleLoadingFailed(error: Error): false {
     const failedLabel = `Loading the fiddle failed: ${error.message}`;
     this.appState.showErrorDialog(
-      navigator.onLine
+      this.appState.isOnline
         ? failedLabel
         : `Your computer seems to be offline. ${failedLabel}`,
     );

--- a/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
@@ -36,14 +36,22 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
                 index.html
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -69,14 +77,22 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
                 main.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -102,14 +118,22 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
                 preload.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -135,14 +159,22 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
                 renderer.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -168,14 +200,22 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
                 styles.css
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -205,16 +245,32 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
           >
-            <Blueprint3.Button
-              icon="add"
-              onClick={[Function]}
-              small={true}
-            />
-            <Blueprint3.Button
-              icon="grid-view"
-              onClick={[Function]}
-              small={true}
-            />
+            <Blueprint3.Tooltip2
+              content="Add New File"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="add"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
+            <Blueprint3.Tooltip2
+              content="Reset Layout"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="grid-view"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
           </Blueprint3.ButtonGroup>,
         },
       ]
@@ -259,14 +315,22 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
                 index.html
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-off"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-off"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -292,14 +356,22 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
                 main.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -325,14 +397,22 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
                 preload.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -358,14 +438,22 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
                 renderer.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -391,14 +479,22 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
                 styles.css
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
           ],
@@ -410,16 +506,32 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
           >
-            <Blueprint3.Button
-              icon="add"
-              onClick={[Function]}
-              small={true}
-            />
-            <Blueprint3.Button
-              icon="grid-view"
-              onClick={[Function]}
-              small={true}
-            />
+            <Blueprint3.Tooltip2
+              content="Add New File"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="add"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
+            <Blueprint3.Tooltip2
+              content="Reset Layout"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="grid-view"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
           </Blueprint3.ButtonGroup>,
         },
       ]
@@ -464,14 +576,22 @@ exports[`SidebarFileTree component renders 1`] = `
                 index.html
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -497,14 +617,22 @@ exports[`SidebarFileTree component renders 1`] = `
                 main.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -530,14 +658,22 @@ exports[`SidebarFileTree component renders 1`] = `
                 preload.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -563,14 +699,22 @@ exports[`SidebarFileTree component renders 1`] = `
                 renderer.js
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
             Object {
@@ -596,14 +740,22 @@ exports[`SidebarFileTree component renders 1`] = `
                 styles.css
               </Blueprint.ContextMenu2>,
               "secondaryLabel": <Blueprint3.ButtonGroup>
-                <Blueprint3.Button
+                <Blueprint3.Tooltip2
+                  content="Toggle Visibility"
+                  hoverCloseDelay={0}
+                  hoverOpenDelay={1000}
                   minimal={true}
-                  onClick={[Function]}
+                  transitionDuration={100}
                 >
-                  <Blueprint3.Icon
-                    icon="eye-open"
-                  />
-                </Blueprint3.Button>
+                  <Blueprint3.Button
+                    minimal={true}
+                    onClick={[Function]}
+                  >
+                    <Blueprint3.Icon
+                      icon="eye-open"
+                    />
+                  </Blueprint3.Button>
+                </Blueprint3.Tooltip2>
               </Blueprint3.ButtonGroup>,
             },
           ],
@@ -615,16 +767,32 @@ exports[`SidebarFileTree component renders 1`] = `
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
           >
-            <Blueprint3.Button
-              icon="add"
-              onClick={[Function]}
-              small={true}
-            />
-            <Blueprint3.Button
-              icon="grid-view"
-              onClick={[Function]}
-              small={true}
-            />
+            <Blueprint3.Tooltip2
+              content="Add New File"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="add"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
+            <Blueprint3.Tooltip2
+              content="Reset Layout"
+              hoverCloseDelay={0}
+              hoverOpenDelay={1000}
+              minimal={true}
+              transitionDuration={100}
+            >
+              <Blueprint3.Button
+                icon="grid-view"
+                onClick={[Function]}
+                small={true}
+              />
+            </Blueprint3.Tooltip2>
           </Blueprint3.ButtonGroup>,
         },
       ]


### PR DESCRIPTION
In the new file tree layout, it's not always clear to a new user what each button does. This adds some tooltips after a brief delay to make clearer what the function of each button is.

<img width="370" alt="Screen Shot 2021-10-04 at 11 29 06 AM" src="https://user-images.githubusercontent.com/2036040/135827433-575bebea-693f-4a4c-b525-30be56e621b2.png">
<img width="351" alt="Screen Shot 2021-10-04 at 11 29 03 AM" src="https://user-images.githubusercontent.com/2036040/135827436-754f6f2d-54ef-44a7-9584-fbb21403868b.png">


