### PR TITLE
test: fix failing snapshots on Big Sur

### DIFF
--- a/src/renderer/components/chrome-mac.tsx
+++ b/src/renderer/components/chrome-mac.tsx
@@ -14,7 +14,7 @@ interface ChromeMacProps {
  *
  * @returns Whether or not macOS is Big Sur or later.
  */
-const isBigSurOrLater = () =>
+export const isBigSurOrLater = () =>
   Number(require('os').release().split('.')[0]) >= 20;
 
 @observer

--- a/tests/renderer/components/chrome-mac-spec.tsx
+++ b/tests/renderer/components/chrome-mac-spec.tsx
@@ -7,6 +7,9 @@ import { ChromeMac } from '../../../src/renderer/components/chrome-mac';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { overridePlatform, resetPlatform } from '../../utils';
 
+// We do this twice so that we can spy on isBigSurOrLater.
+import * as chrome from '../../../src/renderer/components/chrome-mac';
+
 describe('Chrome-Mac component', () => {
   const store: any = new StateMock();
 
@@ -14,6 +17,10 @@ describe('Chrome-Mac component', () => {
 
   it('renders', () => {
     overridePlatform('darwin');
+
+    // TODO(codebytere): remove this when macos-latest becomes Big Sur.
+    // For now, this fixes snapshots failing for anyone running Big Sur.
+    jest.spyOn(chrome, 'isBigSurOrLater').mockReturnValue(false);
 
     const wrapper = shallow(<ChromeMac appState={store} />);
     expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
This fixes a persistent failure locally for anyone running Big Sur, since the snapshots are calibrated for CI which is still Catalina. 