### PR TITLE
fix: remove REACT_PERF extension

### DIFF
--- a/src/main/devtools.ts
+++ b/src/main/devtools.ts
@@ -12,15 +12,11 @@ export async function setupDevTools(): Promise<void> {
   const {
     default: installExtension,
     REACT_DEVELOPER_TOOLS,
-    REACT_PERF,
   } = require('electron-devtools-installer');
 
   try {
     const react = await installExtension(REACT_DEVELOPER_TOOLS);
     console.log(`installDevTools: Installed ${react}`);
-
-    const perf = await installExtension(REACT_PERF);
-    console.log(`installDevTools: Installed ${perf}`);
   } catch (error) {
     console.warn(`installDevTools: Error occured:`, error);
   }


### PR DESCRIPTION
fixes #879.

In the following PR:
- https://github.com/MarshallOfSound/electron-devtools-installer/pull/167 REACT_PERF has been removed because REACT_DEVELOPER_TOOLS has integrated perf.

when 
- #688 was merged electron-devtools-installer was upgraded which introduced the error reported in #879, so this PR removes that unneeded extension.