### PR TITLE
fix(show-me/notification): refactor to use current Electron security defaults

### DIFF
--- a/static/show-me/notification/index.html
+++ b/static/show-me/notification/index.html
@@ -12,8 +12,5 @@
     notification APIs to display it.
   </p>
   <button>Send Notification</button>
-  <script>
-    require('./renderer.js')
-  </script>
 </body>
 </html>

--- a/static/show-me/notification/main.js
+++ b/static/show-me/notification/main.js
@@ -5,13 +5,16 @@
 // https://electronjs.org/docs/tutorial/notifications
 
 const { app, BrowserWindow, Notification } = require('electron')
+const path = require('path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: false, // default in Electron >= 5
+      contextIsolation: true, // default in Electron >= 12
+      preload: path.join(__dirname, 'preload.js')
     }
   })
 

--- a/static/show-me/notification/preload.js
+++ b/static/show-me/notification/preload.js
@@ -7,4 +7,6 @@ function notifyMe () {
   notification.onclose = () => console.log('Closed')
 }
 
-document.querySelector('button').onclick = notifyMe
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('button').onclick = notifyMe
+})


### PR DESCRIPTION
- Part of #725 
- The current 'Show Me' > Notification example does not work
- Updating to use `nodeIntegration: false` and `contextIsolation: true` similar to https://github.com/electron/fiddle/pull/837