### PR TITLE
fix(show-me/screen): refactor to use current Electron security defaults

### DIFF
--- a/static/show-me/screen/index.html
+++ b/static/show-me/screen/index.html
@@ -6,8 +6,5 @@
 <body>
   <h1>Screen Example</h1>
   <pre></pre>
-  <script>
-    require('./renderer.js')
-  </script>
 </body>
 </html>

--- a/static/show-me/screen/main.js
+++ b/static/show-me/screen/main.js
@@ -26,8 +26,8 @@ app.whenReady().then(() => {
     }
   })
 
-  ipcMain.on('get-displays', (event) => {
-    event.returnValue = screen.getAllDisplays()
+  ipcMain.handle('get-displays', () => {
+    return screen.getAllDisplays()
   })
   mainWindow.loadFile('index.html')
 })

--- a/static/show-me/screen/main.js
+++ b/static/show-me/screen/main.js
@@ -3,7 +3,8 @@
 // For more info, see:
 // https://electronjs.org/docs/api/screen
 
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, ipcMain } = require('electron')
+const path = require('path')
 
 app.whenReady().then(() => {
   // We cannot require the screen module until the
@@ -19,9 +20,14 @@ app.whenReady().then(() => {
     width,
     height,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: false, // default in Electron >= 5
+      contextIsolation: true, // default in Electron >= 12
+      preload: path.join(__dirname, 'preload.js')
     }
   })
 
+  ipcMain.on('get-displays', (event) => {
+    event.returnValue = screen.getAllDisplays()
+  })
   mainWindow.loadFile('index.html')
 })

--- a/static/show-me/screen/preload.js
+++ b/static/show-me/screen/preload.js
@@ -1,6 +1,9 @@
 const { ipcRenderer } = require('electron')
 
 window.addEventListener('DOMContentLoaded', () => {
-  const screens = ipcRenderer.sendSync('get-displays')
-  document.querySelector('pre').innerText = JSON.stringify(screens, undefined, 2)
+  ipcRenderer
+    .invoke('get-displays')
+    .then((screens) => {
+      document.querySelector('pre').innerText = JSON.stringify(screens, undefined, 2)
+    })
 })

--- a/static/show-me/screen/preload.js
+++ b/static/show-me/screen/preload.js
@@ -1,0 +1,6 @@
+const { ipcRenderer } = require('electron')
+
+window.addEventListener('DOMContentLoaded', () => {
+  const screens = ipcRenderer.sendSync('get-displays')
+  document.querySelector('pre').innerText = JSON.stringify(screens, undefined, 2)
+})

--- a/static/show-me/screen/renderer.js
+++ b/static/show-me/screen/renderer.js
@@ -1,6 +1,0 @@
-const { screen } = require('electron')
-
-const screens = screen.getAllDisplays()
-const pre = document.querySelector('pre')
-
-pre.innerText = JSON.stringify(screens, undefined, 2)


### PR DESCRIPTION
- Part of https://github.com/electron/fiddle/issues/725
- The current 'Show Me' > Screen example does not work
- Used IPC to get `screen.getAllDisplays()` values from `main.js`values
   - `screen` was showing as null in the `preload.js` page
   - If there is a better way to achieve this? 

**Preview of code change working**
![image](https://user-images.githubusercontent.com/892961/140935360-33deb183-5614-45d1-8072-4e5e33b64a1e.png)
