### PR TITLE
style: switch from overflow: scroll to overflow: auto

### DIFF
--- a/src/less/components/settings.less
+++ b/src/less/components/settings.less
@@ -62,7 +62,7 @@
     height: 100%;
     width: 100%;
     padding: 20px;
-    overflow: scroll;
+    overflow: auto;
     color: @text-color-3;
     box-sizing: border-box;
   }
@@ -169,7 +169,7 @@
 
       .details {
         max-width: 190px;
-        overflow: scroll;
+        overflow: auto;
       }
     }
   }


### PR DESCRIPTION
The settings dialog uses `overflow: scroll`, which always renders scrollbars even when they're not needed (and sometimes, because the scrollbars do get rendered and they take up space, they cause scrolling to be needed). On operating systems that show scrollbars (e.g. not mac), this is what that looks like:

![Selection_999(188)](https://user-images.githubusercontent.com/41970/141273399-4e60e7c1-2760-4e34-ae9d-e0f0c31fdc93.png)

By switching to `overflow: auto`, we only render scrollbars when needed, making everything look a little nicer, only the elements that need scrollbars get them:

![Selection_999(189)](https://user-images.githubusercontent.com/41970/141273701-da2a806a-b54b-448e-96b9-41b4f2c8e47b.png)


