### PR TITLE
fix: don't timeout a slow version download

### DIFF
--- a/src/renderer/binary.ts
+++ b/src/renderer/binary.ts
@@ -220,7 +220,12 @@ async function download(ver: RunnableVersion): Promise<string> {
     downloadOptions: {
       quiet: true,
       getProgressCallback,
-      timeout: 10000,
+      timeout: {
+        lookup: 15000,
+        connect: 15000,
+        response: 15000,
+        socket: 15000,
+      },
     },
   });
 


### PR DESCRIPTION
Fixes #909.

This fixes the current timeout behavior, which will cause a timeout for any request lasting over 10 seconds, even if it is an in-progress download which is simply a bit slow. Change bumps time outs to 15s, and breaks out [individual `got` timeout values](https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md) since `socket` is the timeout that makes the most sense to set (resets time out each time data is received), but once you break out one timeout you need to give the others values as well or they will have no timeout.

I tested these changes on macOS with the "Network Link Conditioner" so that I could try different network conditions. With these changes it could successfully download with the "3G" profile, and it could start downloading with the "Edge" and "Very Bad Network" profiles as well, although I did not wait for those to complete as it would have taken hours.

cc @erickzhao