### PR TITLE
chore: improve macOS 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
     "ts-jest": "^26.5.2",
     "typescript": "^4.2.2"
   },
+  "resolutions": {
+    "macos-release": "^2.5.0"
+  },
   "lint-staged": {
     "./**/*.{js,ts,tsx}": [
       "eslint --fix"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8046,10 +8046,10 @@ lzma-native@^6.0.1:
     readable-stream "^2.3.5"
     rimraf "^2.7.1"
 
-macos-release@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
-  integrity sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==
+macos-release@^2.2.0, macos-release@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
+  integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
 
 magic-string@^0.22.4:
   version "0.22.5"


### PR DESCRIPTION
Fixes #905.

It looks like in certain situations, there can be an error on macOS 12 due to an older version of `macos-release` (transitive dependency) which doesn't include macOS 12 in the list of known macOS versions.

This is a band-aid fix using ["resolutions" in `yarn`](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) to bump the version of `macos-release` (still within the supported range) despite it being a transitive dependency. A real fix would be to upgrade Fiddle's direct dependency, `@octokit/rest` to a newer version, probably v18, since `macos-release` is pulled in transitively through it.

However, upgrading `@octokit/rest` may be a larger task (I didn't attempt it), where as this PR could fix the issue on macOS 12 right away.

@ckerr, @erickzhao