### PR TITLE
fix: update inspector output from Node

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -653,7 +653,8 @@ export class AppState {
     }
 
     if (strData.startsWith('Debugger listening on ws://')) return;
-    if (strData === 'For help see https://nodejs.org/en/docs/inspector') return;
+    if (strData === 'For help, see: https://nodejs.org/en/docs/inspector')
+      return;
 
     const entry: OutputEntry = {
       isNotPre,

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -670,8 +670,10 @@ describe('AppState', () => {
       expect(appState.output.length).toBe(1);
     });
 
-    it('ignores the "For help see..." output', () => {
-      appState.pushOutput('For help see https://nodejs.org/en/docs/inspector');
+    it('ignores the "For help, see: ..." output', () => {
+      appState.pushOutput(
+        'For help, see: https://nodejs.org/en/docs/inspector',
+      );
       expect(appState.output.length).toBe(1);
     });
 


### PR DESCRIPTION
The output was changed in https://github.com/nodejs/node/commit/f3e107aeef2f75cb3a705fd15260f65dd77e78d4 and was first released in v10.0.0, so every supported version of Electron uses the up-to-date version of the output.