### PR TITLE
fix: show console.log output on Windows

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -619,7 +619,7 @@ export class AppState {
    * @returns {void}
    */
   @action public flushOutput(): void {
-    this.pushOutput('\r\n', { bypassBuffer: false });
+    this.pushOutput('\n', { bypassBuffer: false });
   }
 
   /**
@@ -638,7 +638,7 @@ export class AppState {
     if (process.platform === 'win32' && bypassBuffer === false) {
       this.outputBuffer += strData;
       strData = this.outputBuffer;
-      const parts = strData.split('\r\n');
+      const parts = strData.split(/\r?\n/);
       for (let partIndex = 0; partIndex < parts.length; partIndex++) {
         const part = parts[partIndex];
         if (partIndex === parts.length - 1) {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -678,10 +678,11 @@ describe('AppState', () => {
     it('handles a complex buffer on Win32', () => {
       overridePlatform('win32');
 
-      appState.pushOutput(Buffer.from('Buffer\r\nStuff'), {
+      appState.pushOutput(Buffer.from('Buffer\r\nStuff\nMore'), {
         bypassBuffer: false,
       });
       expect(appState.output[1].text).toBe('Buffer');
+      expect(appState.output[2].text).toBe('Stuff');
 
       resetPlatform();
     });


### PR DESCRIPTION
Fixes #699.

On Windows, `console.log("Hello World")` will send `Hello World\n` to `pushOutput`, so it was being buffered indefinitely, since it would never include `\r\n` which is when the buffer would be outputted.

This PR should handle both `\r\n` and `\n` line endings on Windows.

cc @felixrieseberg 