### PR TITLE
chore: run "npx browserslist@latest --update-db" to fix console warnings

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,9 +3334,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001223"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz#39b49ff0bfb3ee3587000d2f66c47addc6e14443"
-  integrity sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==
+  version "1.0.30001296"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz"
+  integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
running `yarn start` on master currently gives a bunch of warnings:

<details>
<summary>caniuse-lite is outdated. Please run: `npx browserslist@latest --update-db`</summary>

```
> ℹ Fetching contributors
⠸ Building main.tsx...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
> Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
⠴ Building ipc.ts...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
> Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
⠦ Building ipc.ts...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
>Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
>Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
⠧ Building app.tsx...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
>Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
>Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
⠋ Building check-first-run.ts...✔ 12 Contributors fetched
⠼ Building exec.ts...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
>
>Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
</details>
```

This PR has the yarn.lock updated by running that suggested command.