### PR TITLE
fix: don't exit fiddle if passing flags to binary

### DIFF
--- a/src/main/command-line.ts
+++ b/src/main/command-line.ts
@@ -136,6 +136,11 @@ export async function processCommandLine(argv: string[]) {
   program.exitOverride();
 
   program
+    .command('start', { isDefault: true })
+    .description('Start Fiddle')
+    .allowUnknownOption();
+
+  program
     .command('bisect <goodVersion> <badVersion>')
     .description('Find where regressions were introduced')
     .option('--fiddle <dir|gist>', 'Open a fiddle', process.cwd())

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -30,6 +30,11 @@ describe('processCommandLine()', () => {
     expect(ipcMainManager.send).not.toHaveBeenCalled();
   });
 
+  it('does nothing when passed flags for electron binary', async () => {
+    await processCommandLine([...ARGV_PREFIX, '--no-sandbox']);
+    expect(ipcMainManager.send).not.toHaveBeenCalled();
+  });
+
   it('exits with 2 if called with invalid parameters', async () => {
     const argv = [...ARGV_PREFIX, 'test', '--this-option-is-unknown=true'];
     const exitCode = 2;


### PR DESCRIPTION
Fixes #900 #902

Previously, `processCommandLine()` would throw if any unknown args were passed in via CLI. However, this approach broke existing functionality for users needing to pass flags into the Electron app (e.g. `--no-sandbox`).

With the existence of `fiddle-core`, I'm not sure how needed the CLI within the Fiddle app is, but this approach reduces the LOC needed in a fix.