### PR TITLE
chore: v0.27.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-fiddle",
   "productName": "Electron Fiddle",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
   "main": "./dist/src/main/main",


### PR DESCRIPTION
ref #940

Seems like with the current build system, tags need to be pushed before the release artifacts are created. I pushed the tag before creating the PR this time around.