### PR TITLE
fix: clear installed modules on new fiddle

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -89,7 +89,7 @@ export class App {
   ): Promise<EditorValues> {
     const values = this.state.editorMosaic.values();
 
-    if (options && options.include !== false) {
+    if (options) {
       values[PACKAGE_NAME] = await getPackageJson(this.state, options);
     }
 

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -70,9 +70,12 @@ export class Editors extends React.Component<EditorsProps, EditorsState> {
     );
 
     ipcRendererManager.on(IpcEvents.FS_NEW_FIDDLE, async (_event) => {
-      const { version } = this.props.appState;
+      const { modules, version } = this.props.appState;
       const values = await getTemplate(version);
       const options: SetFiddleOptions = { templateName: version };
+
+      // Clear previously installed modules.
+      modules.clear();
 
       await window.ElectronFiddle.app.replaceFiddle(values, options);
     });

--- a/src/utils/get-package.ts
+++ b/src/utils/get-package.ts
@@ -4,7 +4,6 @@ import { AppState } from '../renderer/state';
 import { getUsername } from './get-username';
 
 export interface PackageJsonOptions {
-  include?: boolean;
   includeElectron?: boolean;
   includeDependencies?: boolean;
 }


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/942.

Also cleans up some other cruft.