### PR TITLE
fix(monaco): tooltips clipping by other editors

### DIFF
--- a/src/less/components/editors.less
+++ b/src/less/components/editors.less
@@ -24,8 +24,9 @@
   }
 }
 
+// TODO: support new file
 // update if list of Editor ID changes
-@editor-ids: main, renderer, html, preload;
+@editor-ids: main\.js, renderer\.js, index\.html, preload\.js;
 
 // takes each editor ID and increase its z-index if the parent Mosaic root
 // has focused__id class for that specific id.

--- a/src/less/components/editors.less
+++ b/src/less/components/editors.less
@@ -26,7 +26,7 @@
 
 // TODO: support new file
 // update if list of Editor ID changes
-@editor-ids: main\.js, renderer\.js, index\.html, preload\.js;
+@editor-ids: main\.js, renderer\.js, index\.html, preload\.js, styles\.css;
 
 // takes each editor ID and increase its z-index if the parent Mosaic root
 // has focused__id class for that specific id.


### PR DESCRIPTION
fixed: https://github.com/electron/fiddle/issues/929

related PR: https://github.com/electron/fiddle/pull/294

Sropped working Reason:

> editor-id changed

```diff
- main
+ main.js

- renderer
+ renderer.js

- html
+ index.html

- preload
+ prelaod.js
```