### PR TITLE
fix: loading gists with deps/devDeps

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -115,8 +115,18 @@ export class RemoteLoader {
 
       for (const [id, data] of Object.entries(gist.data.files)) {
         if (id === PACKAGE_NAME) {
-          const { dependencies } = JSON.parse(data.content);
-          this.appState.modules = new Map(Object.entries(dependencies));
+          const { dependencies, devDependencies } = JSON.parse(data.content);
+          const allDeps: Record<string, string> = {
+            ...dependencies,
+            ...devDependencies,
+          };
+
+          // We want to include all dependencies except Electron.
+          const parsedDeps = Object.entries(allDeps).filter(
+            ([key, _]) => key !== 'electron',
+          );
+
+          this.appState.modules = new Map(parsedDeps);
         }
         if (!isSupportedFile(id)) {
           continue;


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/962.

Fixes an issue whereby Fiddle assumes [dependencies are non-null](https://github.com/electron/fiddle/blob/a593bb6ef05af9915ac6cf6ab27128a4f3a6d908/src/renderer/remote-loader.ts#L117-L120) and errors in the case where there are no dependencies or there are only devDependencies.