### PR TITLE
deps: use cross-fetch in tools/

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "less": "^4.1.1",
     "lint-staged": "^10.5.4",
     "log-symbols": "^4.0.0",
-    "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "parcel-bundler": "^1.12.4",
     "prettier": "^2.2.1",

--- a/tools/check-links.js
+++ b/tools/check-links.js
@@ -1,8 +1,9 @@
 const { promises: fs } = require('fs');
 const path = require('path');
-const fetch = require('node-fetch');
+const fetch = require('cross-fetch');
 
-const LINK_RGX = /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
+const LINK_RGX =
+  /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
 
 async function main() {
   const readmePath = path.join(__dirname, '../README.md');

--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const fetch = require('cross-fetch');
 const fs = require('fs-extra');
 const util = require('util');
 const path = require('path');

--- a/tools/fetch-releases.js
+++ b/tools/fetch-releases.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
-const fetch = require('node-fetch');
+const fetch = require('cross-fetch');
 
 const file = path.join(__dirname, '..', 'static', 'releases.json');
 


### PR DESCRIPTION
Have tools/ use cross-fetch, which we already had a devDep on for spec code. This lets us remove the direct node-fetch devDep, sidestepping the problems in https://github.com/electron/fiddle/pull/953