### PR TITLE
feat: set Electron version from gist

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -7,7 +7,7 @@ configure({ adapter: new Adapter() });
 
 global.confirm = jest.fn();
 
-if (!process.env.hasOwnProperty('FIDDLE_VERBOSE_TESTS')) {
+if (!process.env.FIDDLE_VERBOSE_TESTS) {
   jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
   jest.spyOn(global.console, 'info').mockImplementation(() => jest.fn());
   jest.spyOn(global.console, 'log').mockImplementation(() => jest.fn());


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/968.

This PR enables users to preset the Electron version from package.json in a gist if they so choose.

Previously, if a user loaded https://gist.github.com/t57ser/ce254e6e2e828949809bf872ed4168b6 the version number that ran the fiddle would remain the same, even though the Fiddle Gist specifies `v17.0.0`. Loading this gist should take that version into account, and change the version to match what's in the `package.json`.

I plan to follow this up with https://github.com/electron/fiddle/issues/966.