### PR TITLE
feat: local fiddles respect `package.json`

### DIFF
--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import semver from 'semver';
 
 import { Files, FileTransform, PACKAGE_NAME } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
@@ -68,7 +69,39 @@ export class FileManager {
     if (!filePath || typeof filePath !== 'string') return;
 
     const editorValues = {};
-    for (const [name, value] of Object.entries(await readFiddle(filePath))) {
+    const files: [string, string][] = Object.entries(
+      await readFiddle(filePath),
+    );
+    for (const [name, value] of files) {
+      if (name === PACKAGE_NAME) {
+        const { remoteLoader } = window.ElectronFiddle.app;
+        const { dependencies, devDependencies } = JSON.parse(value);
+        const deps: Record<string, string> = {
+          ...dependencies,
+          ...devDependencies,
+        };
+
+        if (deps.electron) {
+          // Strip off semver range prefixes.
+          const index = deps.electron.search(/\d/);
+          const version = deps.electron.substring(index);
+
+          if (!semver.valid(version)) {
+            throw new Error(
+              "This Fiddle's package.json contains an invalid Electron version.",
+            );
+          }
+
+          remoteLoader.setElectronVersion(version);
+
+          // We want to include all dependencies except Electron.
+          delete deps.electron;
+        }
+
+        this.appState.modules = new Map(Object.entries(deps));
+        continue;
+      }
+
       if (isKnownFile(name) || (await app.remoteLoader.confirmAddFile(name))) {
         editorValues[name] = value;
       }

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -82,7 +82,9 @@ export class FileManager {
         };
 
         if (deps.electron) {
-          // Strip off semver range prefixes.
+          // Strip off semver range prefixes, e.g:
+          // ^1.2.0 -> 1.2.0
+          // ~2.3.4 -> 2.3.4
           const index = deps.electron.search(/\d/);
           const version = deps.electron.substring(index);
 

--- a/src/utils/read-fiddle.ts
+++ b/src/utils/read-fiddle.ts
@@ -1,4 +1,4 @@
-import { EditorValues } from '../interfaces';
+import { EditorValues, PACKAGE_NAME } from '../interfaces';
 import { ensureRequiredFiles, isSupportedFile } from './editor-utils';
 
 import * as fs from 'fs-extra';
@@ -14,7 +14,8 @@ export async function readFiddle(folder: string): Promise<EditorValues> {
   let got: EditorValues = {};
 
   try {
-    const names = (await fs.readdir(folder)).filter(isSupportedFile);
+    const files = await fs.readdir(folder);
+    const names = files.filter((f) => isSupportedFile(f) || f === PACKAGE_NAME);
     const values = await Promise.allSettled(
       names.map((name) => fs.readFile(path.join(folder, name), 'utf8')),
     );

--- a/tests/mocks/remote-loader.ts
+++ b/tests/mocks/remote-loader.ts
@@ -3,4 +3,5 @@ export class RemoteLoaderMock {
   public fetchGistAndLoad = jest.fn();
   public loadFiddleFromElectronExample = jest.fn();
   public loadFiddleFromGist = jest.fn();
+  public setElectronVersion = jest.fn();
 }


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/966.
Closes https://github.com/electron/fiddle/issues/965

Follow up to https://github.com/electron/fiddle/pull/967 - ensure that local fiddles loaded from disk also respect modules and the version of Electron optionally specified in `package.json`