### PR TITLE
ci(electron-releases): remove obsolete file from script

### DIFF
--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
         chmod 600 ~/.netrc
-        git add static/releases.json tests/fixtures/releases-metadata.json
+        git add static/releases.json
         if test -n "$(git status -s)"; then
           git config user.name "Electron Bot"
           git config user.email "electron-bot@users.noreply.github.com"


### PR DESCRIPTION
#937 removed `tests/fixtures/releases-metadata.json` but didn't remove it from the weekly releases updater action, which caused the action to fail.

CC: @ckerr 