### PR TITLE
fix: signal exit should be a failure

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -383,10 +383,10 @@ export class Runner {
 
         if (typeof code !== 'number') {
           pushOutput(`Electron exited with signal ${signal}.`);
-          resolve(RunResult.INVALID);
+          resolve(RunResult.FAILURE);
         } else {
           pushOutput(`Electron exited with code ${code}.`);
-          resolve(!code ? RunResult.SUCCESS : RunResult.FAILURE);
+          resolve(code === 0 ? RunResult.SUCCESS : RunResult.FAILURE);
         }
       });
     });

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -161,7 +161,7 @@ describe('Runner component', () => {
       mockChild.emit('close', null, signal);
       const result = await runPromise;
 
-      expect(result).toBe(RunResult.INVALID);
+      expect(result).toBe(RunResult.FAILURE);
       expect(store.isRunning).toBe(false);
       expect(store.flushOutput).toHaveBeenCalledTimes(1);
       expect(store.pushOutput).toHaveBeenCalledTimes(8);
@@ -254,7 +254,7 @@ describe('Runner component', () => {
       instance.stop();
       const runResult = await runPromise;
 
-      expect(runResult).toBe(RunResult.INVALID);
+      expect(runResult).toBe(RunResult.FAILURE);
       expect(store.isRunning).toBe(false);
     });
 


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/957.

Signals like SIGSEGV should be marked as a bisection failure. This corrects that issue.