### PR TITLE
refactor(test): improve commands snapshots

### DIFF
--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -57,7 +57,7 @@ export class Commands extends React.Component<CommandsProps> {
             />
           </ControlGroup>
         </div>
-        {process.platform === 'darwin' ? (
+        {!process.env.JEST && process.platform === 'darwin' ? (
           <div className="title">{title}</div>
         ) : undefined}
         <div>


### PR DESCRIPTION
See: https://github.com/electron/fiddle/pull/979#discussion_r820088062

If developer machine is `macOS`, will update `tests/renderer/components/__snapshots__/commands-spec.tsx.snap`. This will cause the tests in the CI to fail.