### PR TITLE
fix: fs.watch not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "monaco-editor": "^0.21.3",
     "monaco-loader": "1.0.0",
     "namor": "^2.0.2",
+    "node-watch": "^0.7.3",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-mosaic-component": "^4.1.1",

--- a/src/renderer/electron-types.ts
+++ b/src/renderer/electron-types.ts
@@ -1,6 +1,7 @@
 import * as MonacoType from 'monaco-editor';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import watch from 'node-watch';
 
 import { RunnableVersion, VersionSource } from '../interfaces';
 
@@ -32,7 +33,7 @@ export class ElectronTypes {
       const file = path.join(dir, 'gen/electron/tsc/typings', ELECTRON_DTS);
       this.setTypesFromFile(file, ver);
       try {
-        this.watcher = fs.watch(file, () => this.setTypesFromFile(file, ver));
+        this.watcher = watch(file, () => this.setTypesFromFile(file, ver));
       } catch (err) {
         console.debug(`Unable to watch "${file}" for changes: ${err}`);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8619,6 +8619,11 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
+node-watch@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.7.3.tgz#6d4db88e39c8d09d3ea61d6568d80e5975abc7ab"
+  integrity sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==
+
 nopt@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"


### PR DESCRIPTION
There is a problem with `fs.watch` on macOS systems and it does not trigger. See: https://github.com/nodejs/node-v0.x-archive/issues/1986

Influence:
* Business logic does not execute as expected on macOS
* Test failed(It's annoying because every time I run a test locally, it reports an error.). e.g. 
    <img width="752" alt="image" src="https://user-images.githubusercontent.com/8198408/156922403-c8f8ffe7-c8a0-4abf-abdf-8d63b2a37c0a.png">
