### PR TITLE
chore(scripts): add fetch retry logic in check-links

### DIFF
--- a/tools/check-links.js
+++ b/tools/check-links.js
@@ -2,8 +2,38 @@ const { promises: fs } = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');
 
-const LINK_RGX =
-  /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
+const LINK_RGX = /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?/g;
+
+async function retryFetch(link) {
+  let retryCount = 2;
+  const watingTime = 1000;
+
+  const execute = async () => {
+    const response = await fetch(link, { method: 'HEAD' });
+
+    if (response.ok) {
+      return;
+    }
+
+    // If we're inside GitHub's release asset server, we just ran into AWS not allowing
+    // HEAD requests, which is different from a 404.
+    if (response.url.startsWith('https://github-production-release-asset')) {
+      return;
+    }
+
+    if (retryCount-- === 0) {
+      throw new Error(
+        `HTTP Error Response: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    await new Promise((r) => setTimeout(r, watingTime));
+
+    await execute();
+  };
+
+  await execute();
+}
 
 async function main() {
   const readmePath = path.join(__dirname, '../README.md');
@@ -13,20 +43,7 @@ async function main() {
 
   for (const link of links) {
     try {
-      const response = await fetch(link, { method: 'HEAD' });
-
-      if (!response.ok) {
-        // If we're inside GitHub's release asset server, we just ran into AWS not allowing
-        // HEAD requests, which is different from a 404.
-        if (
-          !response.url.startsWith('https://github-production-release-asset')
-        ) {
-          throw new Error(
-            `HTTP Error Response: ${response.status} ${response.statusText}`,
-          );
-        }
-      }
-
+      await retryFetch(link);
       console.log(`✅ ${link}`);
     } catch (error) {
       failed = true;

--- a/tools/check-links.js
+++ b/tools/check-links.js
@@ -6,7 +6,7 @@ const LINK_RGX = /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/
 
 async function retryFetch(link) {
   let retryCount = 2;
-  const watingTime = 1000;
+  const waitingTime = 1000;
 
   const execute = async () => {
     const response = await fetch(link, { method: 'HEAD' });
@@ -27,7 +27,7 @@ async function retryFetch(link) {
       );
     }
 
-    await new Promise((r) => setTimeout(r, watingTime));
+    await new Promise((r) => setTimeout(r, waitingTime));
 
     await execute();
   };


### PR DESCRIPTION
Making `check-links` more stable

See:
- https://github.com/electron/fiddle/runs/5445191754?check_suite_focus=true#step:5:13
- https://github.com/electron/fiddle/runs/5445670111?check_suite_focus=true#step:5:14