### PR TITLE
fix: don't use GitHub access token when loading from docs

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -59,7 +59,7 @@ export class RemoteLoader {
     path: string,
   ): Promise<boolean> {
     try {
-      const octo = await getOctokit(this.appState);
+      const octo = await getOctokit();
       const folder = await octo.repos.getContents({
         owner: ELECTRON_REPO,
         repo: ELECTRON_ORG,
@@ -202,7 +202,7 @@ export class RemoteLoader {
   }
 
   public async getPackageVersionFromRef(ref: string): Promise<string> {
-    const octo = await getOctokit(this.appState);
+    const octo = await getOctokit();
     const { data: packageJsonData } = await octo.repos.getContents({
       owner: ELECTRON_ORG,
       repo: ELECTRON_REPO,


### PR DESCRIPTION
Fixes #1008.

This could also be fixed by authorizing the access token with the Electron org, but that seems like a bad idea to me, I'm loading publicly visible resources. I want as little surface area as possible as far as Electron org authorization goes.

There is a comment that non-auth API access gets worse rate-limiting, but I think this is a reasonable tradeoff, given the above.