### PR TITLE
fix: restore commands padding on Windows/Linux

### DIFF
--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -6,8 +6,6 @@ header {
   -webkit-app-region: drag;
 }
 
-
-
 .commands.is-mac {
   padding:
     10px

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -8,7 +8,7 @@ header {
 
 
 
-header .is-mac{
+.commands.is-mac {
   padding:
     10px
     calc(100vw - (env(titlebar-area-x, 0) + env(titlebar-area-width, 0)))

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -17,7 +17,6 @@ header {
 }
 
 
-
 .commands {
   display: flex;
   justify-content: space-between;

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -11,10 +11,7 @@ header {
   justify-content: space-between;
   height: 50px;
   padding:
-    10px
-    calc(100vw - (env(titlebar-area-x, 0) + env(titlebar-area-width, 0)))
-    10px
-    env(titlebar-area-x, 0);
+    10px;
   box-sizing: border-box;
   font-family: @fonts-common;
 

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -6,6 +6,18 @@ header {
   -webkit-app-region: drag;
 }
 
+
+
+header .is-mac{
+  padding:
+    10px
+    calc(100vw - (env(titlebar-area-x, 0) + env(titlebar-area-width, 0)))
+    10px
+    env(titlebar-area-x, 0);
+}
+
+
+
 .commands {
   display: flex;
   justify-content: space-between;

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -16,7 +16,6 @@ header {
     env(titlebar-area-x, 0);
 }
 
-
 .commands {
   display: flex;
   justify-content: space-between;

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -37,7 +37,12 @@ export class Commands extends React.Component<CommandsProps> {
     const { isBisectCommandShowing: isBisectCommandShowing, title } = appState;
 
     return (
-      <div className="commands" onDoubleClick={this.handleDoubleClick}>
+      <div
+        className={
+          process.platform === 'darwin' ? 'commands is-mac' : 'commands'
+        }
+        onDoubleClick={this.handleDoubleClick}
+      >
         <div>
           <ControlGroup fill={true} vertical={false}>
             <VersionChooser appState={appState} />


### PR DESCRIPTION
This PR Fixes #985. Here's a pic of how the toolbar looks after the changes that have been made.

![Screenshot from 2022-03-14 19-20-52](https://user-images.githubusercontent.com/76606666/158185793-7575b421-2c93-47c5-b20a-7edf628b1969.png)

