### PR TITLE
fix(show-me/webframe): remove unnecessary link to renderer.js file

### DIFF
--- a/static/show-me/webframe/index.html
+++ b/static/show-me/webframe/index.html
@@ -6,8 +6,5 @@
 <body>
   <h1>WebFrame Example</h1>
   <p>Every 750ms, this page will change the zoom level.</p>
-  <script>
-    require('./renderer.js')
-  </script>
 </body>
 </html>


### PR DESCRIPTION
Added the background in commit description.

Should be a short one to review @erickzhao :)
