### PR TITLE
fix: focus the window when loading fiddle with protocol

### DIFF
--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -6,6 +6,7 @@ import * as nodeUrl from 'url';
 import { IpcEvents } from '../ipc-events';
 import { isDevMode } from '../utils/devmode';
 import { ipcMainManager } from './ipc';
+import { getOrCreateMainWindow } from './windows';
 
 const PROTOCOL = 'electron-fiddle';
 const squirrelPath = path.resolve(
@@ -66,6 +67,8 @@ const handlePotentialProtocolLaunch = (url: string) => {
     default:
       return;
   }
+  const win = getOrCreateMainWindow();
+  win.show();
 };
 
 const isProtocolString = (arg: string) => arg.startsWith(`${PROTOCOL}://`);

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -67,8 +67,7 @@ const handlePotentialProtocolLaunch = (url: string) => {
     default:
       return;
   }
-  const win = getOrCreateMainWindow();
-  win.show();
+  getOrCreateMainWindow().focus();
 };
 
 const isProtocolString = (arg: string) => arg.startsWith(`${PROTOCOL}://`);

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -180,12 +180,13 @@ describe('protocol', () => {
 
     it('focuses window when loading a fiddle', () => {
       listenForProtocolHandler();
-      getOrCreateMainWindow().blur();
+
+      const mainWindow = getOrCreateMainWindow();
       const handler = (app.on as any).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://electron/4.0.0/test/path');
 
-      expect(getOrCreateMainWindow().focus).toHaveBeenCalled();
+      expect(mainWindow.focus).toHaveBeenCalled();
     });
   });
 });

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -4,6 +4,7 @@
 
 import { app } from 'electron';
 import * as fs from 'fs';
+import { getOrCreateMainWindow } from '../../src/main/windows';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { ipcMainManager } from '../../src/main/ipc';
@@ -175,6 +176,16 @@ describe('protocol', () => {
       handler({}, 'electron-fiddle://');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
+    });
+
+    it('focuses window when loading a fiddle', () => {
+      listenForProtocolHandler();
+      getOrCreateMainWindow().blur();
+      const handler = (app.on as any).mock.calls[0][1];
+
+      handler({}, 'electron-fiddle://electron/4.0.0/test/path');
+
+      expect(getOrCreateMainWindow().focus).toHaveBeenCalled();
     });
   });
 });

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -4,7 +4,6 @@
 
 import { app } from 'electron';
 import * as fs from 'fs';
-import { getOrCreateMainWindow } from '../../src/main/windows';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { ipcMainManager } from '../../src/main/ipc';
@@ -12,6 +11,7 @@ import {
   listenForProtocolHandler,
   setupProtocolHandler,
 } from '../../src/main/protocol';
+import { getOrCreateMainWindow } from '../../src/main/windows';
 import { overridePlatform, resetPlatform } from '../utils';
 
 jest.mock('fs');


### PR DESCRIPTION
Fixes #1007.
 
Previously when loading fiddle and if a fiddle is already loaded then the window doesn't come to foreground. This behaviour is seen on windows. This PR fixes that issue.

**Quick Demo :**

https://user-images.githubusercontent.com/51379307/159056900-837972f6-0373-426a-977f-4dea867ffac1.mp4

I am new here and my solution may not be the best and efficient one,😅 So I request you to provide the valuable feedback to me.

**What I did**
I used the `BrowserWindow` API and called its show method whenever any potential protocol launch occurs.
