### PR TITLE
fix: use shell-env to fetch PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-dom": "^16.14.0",
     "react-mosaic-component": "^4.1.1",
     "semver": "^7.3.4",
-    "shell-path": "^2.1.0",
+    "shell-env": "^3.0.1",
     "tmp": "0.2.1",
     "tslib": "^2.1.0",
     "update-electron-app": "^2.0.1"

--- a/src/ambient-modules.d.ts
+++ b/src/ambient-modules.d.ts
@@ -1,2 +1,1 @@
 declare module 'namor';
-declare module 'shell-path';

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,4 +1,6 @@
-// Singleton: We don't want to do this more than once
+import shellEnv from 'shell-env';
+
+// Singleton: We don't want to do this more than once.
 let _shellPathCalled = false;
 
 /**
@@ -12,9 +14,8 @@ export async function exec(dir: string, cliArgs: string): Promise<string> {
   return new Promise<string>(async (resolve, reject) => {
     await maybeFixPath();
 
-    const { exec: cpExec } = await import('child_process');
-
-    cpExec(
+    const { exec } = await import('child_process');
+    exec(
       cliArgs,
       {
         cwd: dir,
@@ -39,10 +40,9 @@ export async function exec(dir: string, cliArgs: string): Promise<string> {
  */
 export async function maybeFixPath(): Promise<void> {
   if (!_shellPathCalled && process.platform !== 'win32') {
-    const shellPaths = require('shell-path');
-    const paths = await shellPaths();
-    if (paths) {
-      process.env.PATH = paths;
+    const { PATH } = await shellEnv();
+    if (PATH) {
+      process.env.PATH = PATH;
     }
   }
 

--- a/tests/utils/exec-spec.ts
+++ b/tests/utils/exec-spec.ts
@@ -12,6 +12,7 @@ describe('exec', () => {
   beforeEach(() => {
     jest.resetModules();
     execModule = require('../../src/utils/exec');
+    mockShellEnv.mockResolvedValue({ PATH: '/some/path' });
   });
 
   afterEach(() => {

--- a/tests/utils/exec-spec.ts
+++ b/tests/utils/exec-spec.ts
@@ -1,7 +1,7 @@
 jest.mock('child_process');
 
-const mockShellPath = jest.fn();
-jest.mock('shell-path', () => mockShellPath);
+const mockShellEnv = jest.fn();
+jest.mock('shell-env', () => mockShellEnv);
 
 describe('exec', () => {
   const oldPlatform = process.platform;
@@ -68,27 +68,27 @@ describe('exec', () => {
 
       await execModule.maybeFixPath();
 
-      expect(mockShellPath).toHaveBeenCalledTimes(0);
+      expect(mockShellEnv).toHaveBeenCalledTimes(0);
     });
 
-    it('calls shell-path on macOS', async () => {
+    it('calls shell-env on macOS', async () => {
       Object.defineProperty(process, 'platform', {
         value: 'darwin',
       });
 
       await execModule.maybeFixPath();
 
-      expect(mockShellPath).toHaveBeenCalledTimes(1);
+      expect(mockShellEnv).toHaveBeenCalledTimes(1);
     });
 
-    it('calls shell-path on Linux', async () => {
+    it('calls shell-env on Linux', async () => {
       Object.defineProperty(process, 'platform', {
         value: 'linux',
       });
 
       await execModule.maybeFixPath();
 
-      expect(mockShellPath).toHaveBeenCalledTimes(1);
+      expect(mockShellEnv).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,14 +3867,6 @@ cross-fetch@^3.1.0:
   dependencies:
     node-fetch "2.6.1"
 
-cross-spawn@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
 cross-spawn@^6.0.0, cross-spawn@^6.0.4, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4251,7 +4243,7 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
-default-shell@^1.0.0:
+default-shell@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
   integrity sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=
@@ -5255,19 +5247,6 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
   integrity sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
 
-execa@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
-  integrity sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=
-  dependencies:
-    cross-spawn "^4.0.0"
-    get-stream "^2.2.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -5903,14 +5882,6 @@ get-stdin@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
-
-get-stream@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
-  dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
@@ -8034,14 +8005,6 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^4.0.1:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -10098,11 +10061,6 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -11121,21 +11079,14 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-env@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
-  integrity sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=
+shell-env@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-3.0.1.tgz#515a62f6cbd5e139365be2535745e8e53438ce77"
+  integrity sha512-b09fpMipAQ9ObwvIeKoQFLDXcEcCpYUUZanlad4OYQscw2I49C/u97OPQg9jWYo36bRDn62fbe07oWYqovIvKA==
   dependencies:
-    default-shell "^1.0.0"
-    execa "^0.5.0"
-    strip-ansi "^3.0.0"
-
-shell-path@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/shell-path/-/shell-path-2.1.0.tgz#ea7d06ae1070874a1bac5c65bb9bdd62e4f67a38"
-  integrity sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=
-  dependencies:
-    shell-env "^0.3.0"
+    default-shell "^1.0.1"
+    execa "^1.0.0"
+    strip-ansi "^5.2.0"
 
 shell-quote@^1.6.1:
   version "1.7.2"
@@ -11591,7 +11542,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
+strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -12845,11 +12796,6 @@ yaku@^0.16.6:
   version "0.16.7"
   resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.16.7.tgz#1d195c78aa9b5bf8479c895b9504fd4f0847984e"
   integrity sha1-HRlceKqbW/hHnIlblQT9TwhHmE4=
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
For some strange reason `await shellPath()` will no longer resolve on my macOS device. This fixes that.