### PR TITLE
chore: Remove old module.parent deprecation with require.main

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -149,6 +149,6 @@ export function main(argv_in: string[]) {
 }
 
 // only call main() if this is the main module
-if (typeof module !== 'undefined' && !module.children) {
+if (typeof module !== 'undefined' && require.main !== module) {
   main(process.argv);
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -149,6 +149,6 @@ export function main(argv_in: string[]) {
 }
 
 // only call main() if this is the main module
-if (typeof module !== 'undefined' && !module.parent) {
+if (typeof module !== 'undefined' && !module.children) {
   main(process.argv);
 }


### PR DESCRIPTION
Closes #1023 

NodeJs module.parent is deprecated and nodejs recommends module.children which does same thing as module.parent.