### PR TITLE
fix(style): Preference Page style is incorrect on macOS

### DIFF
--- a/src/less/components/dialogs.less
+++ b/src/less/components/dialogs.less
@@ -12,12 +12,6 @@
   }
 }
 
-.darwin {
-  .dialogs {
-    padding-top: 23px;
-  }
-}
-
 .dialog {
   background-color: @background-3;
   border: @border;


### PR DESCRIPTION
Fiex #1024

PR #961 in order to use WCO on macOS then remove old style code, but there is still some old style was left behind

old style code: https://github.com/electron/fiddle/commit/befa3192f4f12a561e12c56c669e9dfea6caae00.
remove old style address: https://github.com/electron/fiddle/pull/961/files#diff-aa82273862a162ec96de7bbd7bbb5fbcbd412d5f577fc209fafcb7ad943dc2f9