### PR TITLE
refactor: remove deprecated functions calls.

### DIFF
--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -1,7 +1,6 @@
 import { app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as nodeUrl from 'url';
 
 import { IpcEvents } from '../ipc-events';
 import { isDevMode } from '../utils/devmode';
@@ -21,7 +20,7 @@ const handlePotentialProtocolLaunch = (url: string) => {
     return;
   }
 
-  const parsed = nodeUrl.parse(url.replace(/\/$/, ''));
+  const parsed = new URL(url.replace(/\/$/, ''));
   if (!parsed.pathname || !parsed.hostname) return;
 
   const pathParts = parsed.pathname.split('/').slice(1);


### PR DESCRIPTION
Described the changes in commit description as well!

Basically,
* The [`Tooltip`](https://blueprintjs.com/docs/#core/components/tooltip) and [`Popover`](https://blueprintjs.com/docs/#core/components/popover) components are no longer maintained in `@blueprintjs/core` package and are shifted to `@blueprintjs/popover2`.

* The same goes for `nodeUrl.parse` which throws an deprecation warning - https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost. Instead used the node `URL` API call for the same as suggested in docs.

Tested the changes using `yarn test`.

<img height = 150 width = 300 src='https://user-images.githubusercontent.com/53977614/161591815-448e3a84-453e-4704-b77a-18f0ff3584d2.jpg'/>
