### PR TITLE
fix: preload.js and renderer.js files gone on monaco

### DIFF
--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -70,7 +70,7 @@ export class FileManager {
 
     const editorValues = {};
     const files: [string, string][] = Object.entries(
-      await readFiddle(filePath),
+      await readFiddle(filePath, true),
     );
     for (const [name, value] of files) {
       if (name === PACKAGE_NAME) {

--- a/src/utils/read-fiddle.ts
+++ b/src/utils/read-fiddle.ts
@@ -8,14 +8,21 @@ import * as path from 'path';
  * Reads a Fiddle from a directory.
  *
  * @param {string} folder
+ * @param {boolean} includePackageJson
  * @returns {Promise<EditorValues>} the loaded Fiddle
  */
-export async function readFiddle(folder: string): Promise<EditorValues> {
+export async function readFiddle(
+  folder: string,
+  includePackageJson = false,
+): Promise<EditorValues> {
   let got: EditorValues = {};
 
   try {
     const files = await fs.readdir(folder);
-    const names = files.filter((f) => isSupportedFile(f) || f === PACKAGE_NAME);
+    const names = files.filter(
+      (f) => isSupportedFile(f) || (includePackageJson && f === PACKAGE_NAME),
+    );
+
     const values = await Promise.allSettled(
       names.map((name) => fs.readFile(path.join(folder, name), 'utf8')),
     );

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -59,7 +59,7 @@ describe('FileManager', () => {
       app.remoteLoader.confirmAddFile.mockResolvedValue(true);
 
       await fm.openFiddle(filePath);
-      expect(readFiddle).toHaveBeenCalledWith(filePath);
+      expect(readFiddle).toHaveBeenCalledWith(filePath, true);
       expect(app.replaceFiddle).toHaveBeenCalledWith(values, { filePath });
     });
 
@@ -79,7 +79,7 @@ describe('FileManager', () => {
 
       await fm.openFiddle(filePath);
       expect(app.remoteLoader.setElectronVersion).toBeCalledWith('17.0.0');
-      expect(readFiddle).toHaveBeenCalledWith(filePath);
+      expect(readFiddle).toHaveBeenCalledWith(filePath, true);
       expect(app.replaceFiddle).toHaveBeenCalledWith(editorValues, {
         filePath,
       });
@@ -100,7 +100,7 @@ describe('FileManager', () => {
       (readFiddle as jest.Mock).mockResolvedValue(values);
 
       await fm.openFiddle(filePath);
-      expect(readFiddle).toHaveBeenCalledWith(filePath);
+      expect(readFiddle).toHaveBeenCalledWith(filePath, true);
       expect(app.state.modules.get('meaning-of-life')).toBe('*');
       expect(app.replaceFiddle).toHaveBeenCalledWith(editorValues, {
         filePath,


### PR DESCRIPTION
Related PR: https://github.com/electron/fiddle/pull/969

The fix works fine locally.

---

This is because the `addFile` function receives the result of the `readFiddle` function. And `addFile` does not support handling `package.json` files

https://github.com/electron/fiddle/blob/b21e70001412666ff1ec6deaefef881271f50bff/src/renderer/editor-mosaic.ts#L116-L119

The order of the files is.
```
0: "index.html"
1: "main.js"
2: "package.json"
3: "preload.js"
4: "renderer.js"
```

Throw error when the file is `package.json`, `preload.js` and `renderer.js` will not be further processed by the addFile function

---

The `readFiddle` function is called in a number of places and we cannot be sure if it affects other functions.

So I've made this compatible here by adding a default parameter to `readFiddle`.