### PR TITLE
chore: update to Electron 15.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "cross-fetch": "^3.1.0",
-    "electron": "15.3.7",
+    "electron": "15.5.2",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4696,10 +4696,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@15.3.7:
-  version "15.3.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.7.tgz#9907f98f65b0fe012187cf4f84b10a48e5af7541"
-  integrity sha512-Wld3yR9KWqgUz9Db6/+ocABXknhonFWB8JlA05QhgJYSnonZn5gggMpWYgLAs85YCGa1nuWWQmx5kDna2CLGCg==
+electron@15.5.2:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.5.2.tgz#696e20ee29929de8f0d41065f833afb6e1a1c3d0"
+  integrity sha512-2Vfp0KKWhVsJ7wVmYla+4GJ4Dfl88QICgWXngH20fHLPilrT0LFKz+s4+0Tlwznc8F1VODKv7++Sav0KNC9Zxg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Follow up to #975. Tested locally on macOS Monterey (12.3.1)