### PR TITLE
fix: electron settings style incorrect

### DIFF
--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -7,16 +7,12 @@ header {
 }
 
 .disabled-menu-tooltip {
-  width: 100%;
-}
-
-span.bp3-popover-wrapper {
   display: flex;
   width: 100%;
-}
 
-.bp3-popover-target {
-  width: 100%;
+  .bp3-popover-target {
+    width: 100%;
+  }
 }
 
 .commands.is-mac {


### PR DESCRIPTION
This is caused by https://github.com/electron/fiddle/pull/1019

Problem preview:
<img width="473" alt="图片" src="https://user-images.githubusercontent.com/8198408/163539215-0b73e96e-1c78-4efd-9264-9a86283bc62b.png">
