### PR TITLE
fix(styles): support blueprint variables

### DIFF
--- a/.lessrc
+++ b/.lessrc
@@ -1,0 +1,3 @@
+{
+  "math": "always"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "main": "./dist/src/main/main",
   "scripts": {
     "contributors": "node ./tools/contributors.js",
-    "less": "node ./tools/lessc.js",
     "lint:style": "stylelint  \"./src/less/*.less\" --fix",
     "lint:ts": "eslint \"./**/*.{ts,tsx}\" --fix",
     "lint:templates": "standard \"static/**/*.js\" --fix",

--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -2,7 +2,7 @@
 @import (inline) "~@blueprintjs/select/lib/css/blueprint-select.css";
 @import (inline) "~@blueprintjs/icons/lib/css/blueprint-icons.css";
 @import (inline) "~@blueprintjs/popover2/lib/css/blueprint-popover2.css";
-@import (inline) "~@blueprintjs/core/lib/less/variables.less";
+@import "~@blueprintjs/core/lib/less/variables.less";
 
 // Override some of the colors
 .fiddle.bp3-dark {


### PR DESCRIPTION
BlueprintJS has its own Less pre-processor colour variables (e.g. `@white`, `@red`, `@black`). https://blueprintjs.com/docs/#core/colors

We currently don't use any of them, so I don't think we've ever run into this error. However, trying to add any of these variables will lead to a Less error on main.

```json
{
  message: 'variable @dark-gray1 is undefined',
  stack: undefined,
  name: 'Error',
  type: 'Name',
  filename: '/Users/erick.zhao/Developer/electron/fiddle/src/less/main.less',
  index: 1100,
  line: 79,
  column: 9,
  callLine: NaN,
  callExtract: undefined,
  extract: [
    '  background: @background-1;',
    '  color: @dark-gray1;',
    '  font-size: 10px;'
  ],
  fileName: '/Users/erick.zhao/Developer/electron/fiddle/src/less/root.less'
}
```

After experimenting a bit, I found that:
1. We have a `yarn less` command that refers to a removed file. I deleted it.
1. Importing the `variables.less` file as `(inline)` didn't do anything. Inline imports will add the current file to your CSS outputs without actually processing them through Less. See https://lesscss.org/features/#import-atrules-feature-inline
1. We need to configure a `.lessrc` with Parcel to eagerly process math with Less. Otherwise, a separate error occurs involving the CSS `floor` function. See https://parceljs.org/languages/less/#configuration
```json
{
  message: 'Error evaluating function `floor`: argument must be a number',
  stack: undefined,
  name: 'Error',
  type: 'Argument',
  filename: '/Users/erick.zhao/Developer/electron/fiddle/node_modules/@blueprintjs/core/lib/less/variables.less',
  index: 3848,
  line: 180,
  column: 19,
  callLine: NaN,
  callExtract: undefined,
  extract: [ '', '@pt-border-radius: floor(@pt-grid-size / 3);', '' ],
  fileName: '/Users/erick.zhao/Developer/electron/fiddle/src/less/root.less'
}
```