### PR TITLE
chore: update to Electron 17.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "cross-fetch": "^3.1.0",
-    "electron": "15.5.2",
+    "electron": "17.4.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4688,10 +4688,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@15.5.2:
-  version "15.5.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.5.2.tgz#696e20ee29929de8f0d41065f833afb6e1a1c3d0"
-  integrity sha512-2Vfp0KKWhVsJ7wVmYla+4GJ4Dfl88QICgWXngH20fHLPilrT0LFKz+s4+0Tlwznc8F1VODKv7++Sav0KNC9Zxg==
+electron@17.4.1:
+  version "17.4.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.1.tgz#203961ca7551553d6497a1ec61d5f85d64d7e2ef"
+  integrity sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Tested locally on macOS Monterey (12.3.1) and Windows 11.