### PR TITLE
fix: disable downloads for Electron below 6.0.8 and 7.0.0 on Windows arm64

### DIFF
--- a/src/utils/disable-download.ts
+++ b/src/utils/disable-download.ts
@@ -1,7 +1,9 @@
 import semver from 'semver';
 
 /**
- * disables download button for versions below 11.0.0 on Apple Silicon.
+ * disables download button for versions:
+ * - below 11.0.0 on Apple Silicon.
+ * - below 6.0.8 and 7.0.0 on Windows arm64
  * Reference: {@link https://www.electronjs.org/blog/apple-silicon}
  *
  * @param {string} version - electron version
@@ -9,8 +11,11 @@ import semver from 'semver';
  */
 export function disableDownload(version: string) {
   return (
-    process.platform === 'darwin' &&
-    process.arch === 'arm64' &&
-    semver.lt(version, '11.0.0')
+    (process.platform === 'darwin' &&
+      process.arch === 'arm64' &&
+      semver.lt(version, '11.0.0')) ||
+    (process.platform === 'win32' &&
+      process.arch === 'arm64' &&
+      !semver.satisfies(version, '>=6.0.8 || >=7.0.0'))
   );
 }

--- a/tests/utils/disable-download-spec.ts
+++ b/tests/utils/disable-download-spec.ts
@@ -12,12 +12,24 @@ describe('disableDownload', () => {
     resetArch();
   });
 
-  it('always return false when the system is windows', () => {
+  it('always return false when the system is windows and the arch is not arm64', () => {
     overridePlatform('win32');
+    overrideArch('x64');
 
-    expect(disableDownload('10.0.0')).toBe(false);
-    expect(disableDownload('11.0.0')).toBe(false);
-    expect(disableDownload('12.0.0')).toBe(false);
+    expect(disableDownload('6.0.0')).toBe(false);
+    expect(disableDownload('6.0.8')).toBe(false);
+    expect(disableDownload('7.0.0')).toBe(false);
+    expect(disableDownload('8.0.0')).toBe(false);
+  });
+
+  it('returns true if the system is windows and the arch is arm64', () => {
+    overridePlatform('win32');
+    overrideArch('arm64');
+
+    expect(disableDownload('6.0.0')).toBe(true);
+    expect(disableDownload('6.0.8')).toBe(false);
+    expect(disableDownload('7.0.0')).toBe(false);
+    expect(disableDownload('8.0.0')).toBe(false);
   });
 
   it('always return false when the system is linux', () => {


### PR DESCRIPTION
Windows arm64 builds of Electron were only added in [v6.0.8](https://github.com/electron/electron/releases/tag/v6.0.8) by [#20113](https://github.com/electron/electron/pull/20113) and [v7.0.0](https://github.com/electron/electron/releases/tag/v7.0.0) by [#20112](https://github.com/electron/electron/pull/20112)
Follow-up to #1019