### PR TITLE
feat: add setting icon to commands UI

### DIFF
--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -45,6 +45,13 @@ export class Commands extends React.Component<CommandsProps> {
       >
         <div>
           <ControlGroup fill={true} vertical={false}>
+            <Button
+              icon="cog"
+              title="Setting"
+              onClick={appState.toggleSettings}
+            />
+          </ControlGroup>
+          <ControlGroup fill={true} vertical={false}>
             <VersionChooser appState={appState} />
             <Runner appState={appState} />
           </ControlGroup>

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -92,6 +92,7 @@ export class StateMock {
   public signOutGitHub = jest.fn();
   public toggleAddVersionDialog = jest.fn();
   public toggleAuthDialog = jest.fn();
+  public toggleSettings = jest.fn();
   public updateElectronVersions = jest.fn();
 
   constructor() {

--- a/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
@@ -10,6 +10,16 @@ exports[`Commands component renders when system is darwin 1`] = `
       fill={true}
       vertical={false}
     >
+      <Blueprint3.Button
+        icon="cog"
+        onClick={[MockFunction]}
+        title="Setting"
+      />
+    </Blueprint3.ControlGroup>
+    <Blueprint3.ControlGroup
+      fill={true}
+      vertical={false}
+    >
       <version-chooser
         appState={"default StateMock"}
       />

--- a/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
@@ -54,6 +54,16 @@ exports[`Commands component renders when system not is darwin 1`] = `
       fill={true}
       vertical={false}
     >
+      <Blueprint3.Button
+        icon="cog"
+        onClick={[MockFunction]}
+        title="Setting"
+      />
+    </Blueprint3.ControlGroup>
+    <Blueprint3.ControlGroup
+      fill={true}
+      vertical={false}
+    >
       <version-chooser
         appState={"default StateMock"}
       />

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -8,6 +8,7 @@ import { IpcEvents } from '../../../src/ipc-events';
 
 import { StateMock } from '../../mocks/mocks';
 import { overridePlatform, resetPlatform } from '../../utils';
+import { Button, ControlGroup } from '@blueprintjs/core';
 
 jest.mock('../../../src/renderer/components/commands-runner', () => ({
   Runner: 'runner',
@@ -66,5 +67,13 @@ describe('Commands component', () => {
 
     expect(spy).toHaveBeenCalledWith(IpcEvents.CLICK_TITLEBAR_MAC);
     spy.mockRestore();
+  });
+
+  it('show setting', () => {
+    const wrapper = shallow(<Commands appState={store as any} />);
+
+    wrapper.find(ControlGroup).at(0).find(Button).simulate('click');
+
+    expect(store.toggleSettings).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Reason: 
* I've received some feedback from users who say they never knew fiddle had a settings page.

> For the above reasons, it would be more user-friendly for us to add a button.

Preview image:

<img width="551" alt="images" src="https://user-images.githubusercontent.com/8198408/164957425-13fc0e1c-bfa1-4606-ae02-60a5ff8a9a3e.png">

Review video:

https://user-images.githubusercontent.com/8198408/164957471-7e7cc7cd-b468-4628-ae16-8f64320ee1d4.mp4