### PR TITLE
refactor: improve setting close icon size

### DIFF
--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -130,7 +130,7 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
         </div>
         <div className="settings-content">
           <div className="settings-close" onClick={appState.toggleSettings}>
-            <Icon icon="cross" />
+            <Icon icon="cross" iconSize={25} />
           </div>
           {this.renderContent()}
         </div>

--- a/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-spec.tsx.snap
@@ -66,6 +66,7 @@ exports[`Settings component renders only the menu if page unknown 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
   </div>
@@ -138,6 +139,7 @@ exports[`Settings component renders the Credits page after a click 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
     <settings-credits
@@ -217,6 +219,7 @@ exports[`Settings component renders the Electron page after a click 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
     <settings-electron
@@ -296,6 +299,7 @@ exports[`Settings component renders the Electron page by default 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
     <settings-general
@@ -376,6 +380,7 @@ exports[`Settings component renders the Execution page after a click 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
     <ExecutionSettings
@@ -455,6 +460,7 @@ exports[`Settings component renders the General page after a click 1`] = `
     >
       <Blueprint3.Icon
         icon="cross"
+        iconSize={25}
       />
     </div>
     <settings-general


### PR DESCRIPTION
Before: 16px

<img width="1184" alt="i" src="https://user-images.githubusercontent.com/8198408/164958495-01e1e272-95c9-4118-8ba6-e3abc30a62c8.png">


After: 25px

<img width="1185" alt="i" src="https://user-images.githubusercontent.com/8198408/164959165-13f6bc80-37f0-48c3-920d-1de3a492d6b7.png">
