### PR TITLE
refactor: improve gist input user experience

### DIFF
--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -28,8 +28,10 @@ export class Commands extends React.Component<CommandsProps> {
     super(props);
   }
 
-  private handleDoubleClick = () => {
-    ipcRendererManager.send(IpcEvents.CLICK_TITLEBAR_MAC);
+  private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target['tagName'] !== 'INPUT') {
+      ipcRendererManager.send(IpcEvents.CLICK_TITLEBAR_MAC);
+    }
   };
 
   public render() {

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -63,9 +63,21 @@ describe('Commands component', () => {
     const wrapper = shallow(<Commands appState={store as any} />);
     const instance = wrapper.instance() as any;
 
-    instance.handleDoubleClick();
+    instance.handleDoubleClick({ target: {} });
 
     expect(spy).toHaveBeenCalledWith(IpcEvents.CLICK_TITLEBAR_MAC);
+    spy.mockRestore();
+  });
+
+  it('handleDoubleClick() should not handle input tag', () => {
+    const spy = jest.spyOn(ipcRendererManager, 'send');
+
+    const wrapper = shallow(<Commands appState={store as any} />);
+    const instance = wrapper.instance() as any;
+
+    instance.handleDoubleClick({ target: { tagName: 'INPUT' } });
+
+    expect(spy).toHaveBeenCalledTimes(0);
     spy.mockRestore();
   });
 


### PR DESCRIPTION
In the previous situation, trying to copy `gist URL` always resulted in accidentally changing the window size.

Before:

https://user-images.githubusercontent.com/8198408/165265529-4d2ba6c8-0315-4e08-9b7a-cacb3166ce90.mp4


After:

https://user-images.githubusercontent.com/8198408/165264808-78ec68ef-34cc-4e10-9bbf-fed2d25b2fa0.mp4

