### PR TITLE
fix: contributors display is incomplete

### DIFF
--- a/tools/contributors.js
+++ b/tools/contributors.js
@@ -10,7 +10,7 @@ const CONTRIBUTORS_FILE_PATH = path.join(
   '../static/contributors.json',
 );
 const CONTRIBUTORS_URL =
-  'https://api.github.com/repos/electron/fiddle/contributors';
+  'https://api.github.com/repos/electron/fiddle/contributors?per_page=100';
 const HEADERS =
   GITHUB_TOKEN || GH_TOKEN
     ? {


### PR DESCRIPTION
the default value is 30.

ref: https://docs.github.com/en/rest/projects/collaborators#list-project-collaborators