### PR TITLE
fix: close version chooser if settings open

### DIFF
--- a/src/less/components/dialogs.less
+++ b/src/less/components/dialogs.less
@@ -1,7 +1,7 @@
 @import "../variables.less";
 
 .dialogs {
-  z-index: 21;
+  z-index: 10;
   position: fixed;
   height: 100vh;
   width: 100vw;

--- a/src/renderer/components/commands-version-chooser.tsx
+++ b/src/renderer/components/commands-version-chooser.tsx
@@ -18,6 +18,7 @@ export const VersionChooser = observer((props: VersionChooserProps) => {
     Bisector,
     currentElectronVersion,
     isAutoBisecting,
+    isSettingsShowing,
     setVersion,
   } = props.appState;
 
@@ -27,7 +28,7 @@ export const VersionChooser = observer((props: VersionChooserProps) => {
         appState={props.appState}
         onVersionSelect={({ version }) => setVersion(version)}
         currentVersion={currentElectronVersion}
-        disabled={!!Bisector || isAutoBisecting}
+        disabled={!!Bisector || isAutoBisecting || isSettingsShowing}
       />
     </ButtonGroup>
   );


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1066.
Refs https://github.com/electron/fiddle/issues/1031.

We shouldn't be messing with the z-indexes - instead we should simply disable the version chooser if Settings panes are open.