### PR TITLE
fix: fallback if current version doesn't exist

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -149,6 +149,17 @@ export class Runner {
     const { appState } = this;
     const { version, localPath } = appState.currentElectronVersion;
 
+    // If the current active version is unavailable when we try to run
+    // the fiddle, show an error and fall back.
+    const { err, ver } = appState.isVersionUsable(version);
+    if (!ver) {
+      console.warn(`Running fiddle with version ('${version}') failed: ${err}`);
+      appState.showErrorDialog(err!);
+      const fallback = appState.findUsableVersion();
+      if (fallback) await appState.setVersion(fallback.version);
+      return RunResult.INVALID;
+    }
+
     if (appState.isClearingConsoleOnRun) {
       appState.clearConsole();
     }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -484,11 +484,11 @@ export class AppState {
   }
 
   /**
-   * Private setVersion() helper to test if setVersion(input) would work.
+   * Helper to test if the current version is available and would work.
    *
    * Returns a RunnableVersion if it would work, or an error string otherwise.
    */
-  private isVersionUsable(
+  public isVersionUsable(
     input: string,
   ): { ver?: RunnableVersion; err?: string } {
     const ver = this.getVersion(input);
@@ -506,9 +506,9 @@ export class AppState {
   }
 
   /**
-   * Private setVersion() helper to find a usable fallback version.
+   * Helper to find a usable fallback version.
    */
-  private findUsableVersion(): RunnableVersion | undefined {
+  public findUsableVersion(): RunnableVersion | undefined {
     return this.versionsToShow.find((ver) => this.isVersionUsable(ver.version));
   }
 

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -83,6 +83,9 @@ export class StateMock {
     this.currentElectronVersion = this.versions[version];
     this.version = version;
   });
+  public isVersionUsable = jest.fn().mockImplementation(() => {
+    return { ver: this.currentElectronVersion };
+  });
   public showChannels = jest.fn();
   public showConfirmDialog = jest.fn();
   public showErrorDialog = jest.fn();

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -86,6 +86,10 @@ export class StateMock {
   public isVersionUsable = jest.fn().mockImplementation(() => {
     return { ver: this.currentElectronVersion };
   });
+  public findUsableVersion = jest.fn().mockImplementation(() => {
+    const { mockVersionsArray } = new VersionsMock();
+    return { ver: this.versions[mockVersionsArray[0].version] };
+  });
   public showChannels = jest.fn();
   public showConfirmDialog = jest.fn();
   public showErrorDialog = jest.fn();


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1035.

Takes the same approach as if a user tried to switch to a nonexistent version.