### PR TITLE
chore: stop building Windows on arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
           arch: ia32
         - os: ubuntu-latest
           arch: armv7l
+        # Publishing artifacts for multiple Windows architectures has
+        # a bug which can cause the wrong architecture to be downloaded
+        # for an update, so until that is fixed, only build Windows x64
         exclude:
         - os: windows-latest
           arch: arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
           arch: ia32
         - os: ubuntu-latest
           arch: armv7l
+        exclude:
+        - os: windows-latest
+          arch: arm64
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Due to an update bug involving multiple architectures and Windows, stop building arm64 builds for Windows to prevent wrong architecture updates.