### PR TITLE
chore: remove extraneous text from title

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -343,28 +343,9 @@ export class AppState {
    * @returns {string} the title, e.g. appname, fiddle name, state
    */
   get title(): string {
-    const { gistId, localPath, templateName } = this;
     const { isEdited } = this.editorMosaic;
-    const tokens = [];
 
-    if (localPath) {
-      tokens.push(localPath);
-    } else if (templateName) {
-      tokens.push(templateName);
-    } else if (gistId) {
-      tokens.push(`gist.github.com/${gistId}`);
-    }
-
-    if (isEdited) {
-      tokens.push('Unsaved');
-    }
-
-    if (tokens.length > 0) {
-      tokens.unshift('-');
-    }
-
-    tokens.unshift('Electron Fiddle');
-    return tokens.join(' ');
+    return isEdited ? 'Electron Fiddle - Unsaved' : 'Electron Fiddle';
   }
 
   /**

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -734,40 +734,6 @@ describe('AppState', () => {
       expect(actual).toBe(expected);
     });
 
-    it('shows the name of local fiddles', () => {
-      const localPath = 'path/to/fiddle';
-      const expected = `${APPNAME} - ${localPath}`;
-      appState.localPath = localPath;
-      const actual = appState.title;
-      expect(actual).toBe(expected);
-    });
-
-    it('shows the name of gist fiddles', () => {
-      const gistId = 'abcdef';
-      const expected = `${APPNAME} - gist.github.com/${gistId}`;
-      appState.gistId = gistId;
-      const actual = appState.title;
-      expect(actual).toBe(expected);
-    });
-
-    it('prefers to display localPath', () => {
-      const gistId = 'abcdef';
-      const templateName = 'BrowserWindow';
-      const localPath = 'path/to/fiddle';
-      const expected = `${APPNAME} - ${localPath}`;
-      Object.assign(appState, { gistId, localPath, templateName });
-      const actual = appState.title;
-      expect(actual).toBe(expected);
-    });
-
-    it('shows the name of template fiddles', () => {
-      const templateName = 'BrowserWindow';
-      const expected = `${APPNAME} - ${templateName}`;
-      appState.templateName = templateName;
-      const actual = appState.title;
-      expect(actual).toBe(expected);
-    });
-
     it('flags unsaved fiddles', () => {
       const expected = `${APPNAME} - Unsaved`;
       appState.editorMosaic.isEdited = true;


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1065.

Removes extra cruft around title such that it only flags save state. The rest is, imo, not particularly necessary and results in buttons being cut off.