### PR TITLE
fix: react devtools not loading

### DIFF
--- a/src/main/devtools.ts
+++ b/src/main/devtools.ts
@@ -15,7 +15,9 @@ export async function setupDevTools(): Promise<void> {
   } = require('electron-devtools-installer');
 
   try {
-    const react = await installExtension(REACT_DEVELOPER_TOOLS);
+    const react = await installExtension(REACT_DEVELOPER_TOOLS, {
+      loadExtensionOptions: { allowFileAccess: true },
+    });
     console.log(`installDevTools: Installed ${react}`);
   } catch (error) {
     console.warn(`installDevTools: Error occurred:`, error);


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/454

Refs https://github.com/MarshallOfSound/electron-devtools-installer/issues/143

After:
![Screen Shot 2022-05-26 at 9 35 29 PM](https://user-images.githubusercontent.com/2036040/170563824-689cd8c8-e723-496c-8b8d-5c192b8ba1d3.png)

This might not be the best long-term fix but.....it solves the immediate issue and devtools show up again.