### PR TITLE
fix: don't add electron-nightly to modules

### DIFF
--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -81,12 +81,17 @@ export class FileManager {
           ...devDependencies,
         };
 
-        if (deps.electron) {
+        // If the project specifies an Electron version, we want to tell Fiddle to run
+        // it with that version by default.
+        const electronDeps = Object.keys(deps).filter((d) =>
+          ['electron-nightly', 'electron'].includes(d),
+        );
+        for (const dep of electronDeps) {
           // Strip off semver range prefixes, e.g:
           // ^1.2.0 -> 1.2.0
           // ~2.3.4 -> 2.3.4
-          const index = deps.electron.search(/\d/);
-          const version = deps.electron.substring(index);
+          const index = deps[dep].search(/\d/);
+          const version = deps[dep].substring(index);
 
           if (!semver.valid(version)) {
             throw new Error(
@@ -94,10 +99,10 @@ export class FileManager {
             );
           }
 
+          // We want to include all dependencies except Electron.
           remoteLoader.setElectronVersion(version);
 
-          // We want to include all dependencies except Electron.
-          delete deps.electron;
+          delete deps[dep];
         }
 
         this.appState.modules = new Map(Object.entries(deps));

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -124,10 +124,15 @@ export class RemoteLoader {
 
           // If the gist specifies an Electron version, we want to tell Fiddle to run
           // it with that version by default.
-          if (deps.electron) {
-            // Strip off semver range prefixes.
-            const index = deps.electron.search(/\d/);
-            const version = deps.electron.substring(index);
+          const electronDeps = Object.keys(deps).filter((d) =>
+            ['electron-nightly', 'electron'].includes(d),
+          );
+          for (const dep of electronDeps) {
+            // Strip off semver range prefixes, e.g:
+            // ^1.2.0 -> 1.2.0
+            // ~2.3.4 -> 2.3.4
+            const index = deps[dep].search(/\d/);
+            const version = deps[dep].substring(index);
 
             if (!semver.valid(version)) {
               throw new Error(
@@ -138,7 +143,7 @@ export class RemoteLoader {
             this.setElectronVersion(version);
 
             // We want to include all dependencies except Electron.
-            delete deps.electron;
+            delete deps[dep];
           }
 
           this.appState.modules = new Map(Object.entries(deps));


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1102.

Also filters out `electron-nightly` from modules in `package.json` so that it doesn't get loaded into the project's modules and instead gets properly selected in the version picker.