### PR TITLE
fix: infinite loop on missing local version

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -579,7 +579,10 @@ export class AppState {
    * Helper to find a usable fallback version.
    */
   public findUsableVersion(): RunnableVersion | undefined {
-    return this.versionsToShow.find((ver) => this.isVersionUsable(ver.version));
+    return this.versionsToShow.find((version) => {
+      const { ver } = this.isVersionUsable(version.version);
+      return !!ver;
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes a potential infinite loop when the directory containing a local electron version was removed.

https://github.com/electron/fiddle/blob/d41d5f6319cebf5fcb79f092dbbed84ef404d48a/src/renderer/state.ts#L339 would call https://github.com/electron/fiddle/blob/d41d5f6319cebf5fcb79f092dbbed84ef404d48a/src/renderer/state.ts#L596 which would correctly indicate that the version was invalid. However, we would then call https://github.com/electron/fiddle/blob/d41d5f6319cebf5fcb79f092dbbed84ef404d48a/src/renderer/state.ts#L600 which was **incorrectly** returning true because it was testing for truthiness of an object instead of whether https://github.com/electron/fiddle/blob/d41d5f6319cebf5fcb79f092dbbed84ef404d48a/src/renderer/state.ts#L561 was returning an error or valid version. Correct this by fixing the logic in `findUsableVersion` to check `err` and `ver`