### PR TITLE
chore: use Node v16.x for GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.3.0
         with:
-          node-version: 15.x
+          node-version: 16.x
           cache: yarn
       - name: Install
         run: yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.3.0
         with:
-          node-version: 12.x
+          node-version: 16.x
           cache: yarn
       - name: Set MacOS signing certs
         if: matrix.os == 'macOS-latest'

--- a/.github/workflows/electron-releases.yml
+++ b/.github/workflows/electron-releases.yml
@@ -11,7 +11,7 @@ jobs:
       run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - uses: actions/setup-node@v3.3.0
       with:
-        node-version: '12.x'
+        node-version: 16.x
         cache: yarn
     - run: yarn --network-timeout 100000
     - name: Switch to release update branch


### PR DESCRIPTION
Switch to the current Node LTS, newer packages don't support back to 12.x anymore.

This popped out of #1109.