### PR TITLE
fix: work around bug in readdir in graceful-fs

### DIFF
--- a/src/utils/read-fiddle.ts
+++ b/src/utils/read-fiddle.ts
@@ -18,9 +18,9 @@ export async function readFiddle(
   let got: EditorValues = {};
 
   try {
-    // TODO(dsanders11): Remove empty options once issue fixed:
+    // TODO(dsanders11): Remove options once issue fixed:
     // https://github.com/isaacs/node-graceful-fs/issues/223
-    const files = await fs.readdir(folder, {});
+    const files = await fs.readdir(folder, { encoding: 'utf8' });
     const names = files.filter(
       (f) => isSupportedFile(f) || (includePackageJson && f === PACKAGE_NAME),
     );

--- a/src/utils/read-fiddle.ts
+++ b/src/utils/read-fiddle.ts
@@ -18,7 +18,9 @@ export async function readFiddle(
   let got: EditorValues = {};
 
   try {
-    const files = await fs.readdir(folder);
+    // TODO(dsanders11): Remove empty options once issue fixed:
+    // https://github.com/isaacs/node-graceful-fs/issues/223
+    const files = await fs.readdir(folder, {});
     const names = files.filter(
       (f) => isSupportedFile(f) || (includePackageJson && f === PACKAGE_NAME),
     );


### PR DESCRIPTION
Subtle bug got introduced by #1119, due to shifting the version of `graceful-fs` from 4.2.6 to 4.2.10. That version of `graceful-fs` [doesn't play nice with Electron](https://github.com/isaacs/node-graceful-fs/issues/223). Rather than muck around with versions of `graceful-fs` (transitive dependency), just use a workaround for the issue until it is fixed in a later version of `graceful-fs`.