### PR TITLE
fix: check for static_dir path at runtime, not build time

### DIFF
--- a/tools/webpack/common/webpack.plugins.js
+++ b/tools/webpack/common/webpack.plugins.js
@@ -8,6 +8,8 @@ module.exports = [
     __importStar: ['tslib', '__importStar'],
   }),
   new webpack.DefinePlugin({
-    STATIC_DIR: JSON.stringify(path.join(__dirname, '../../../static/')),
+    STATIC_DIR: webpack.DefinePlugin.runtimeValue(() => {
+      return JSON.stringify(path.join(__dirname, '../../../static/'));
+    }, true),
   }),
 ];


### PR DESCRIPTION
We're currently checking the __dirname for webpack at build time - we actually need the value that's generated at runtime.

This PR expands on our definePlugin method to use the runtime value (h/t to @codebytere for the find!)