### PR TITLE
build(webpack): remove webpack definePlugin pointing to static folder

### DIFF
--- a/src/renderer/content.ts
+++ b/src/renderer/content.ts
@@ -6,8 +6,11 @@ import { readFiddle } from '../utils/read-fiddle';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-// Defined in webpack plugins.
-declare const STATIC_DIR: string;
+const STATIC_DIR =
+  process.env.NODE_ENV === 'production'
+    ? path.join(__dirname, '../../static')
+    : path.join(process.cwd(), './static');
+
 // parent directory of all the downloaded template fiddles
 const TEMPLATES_DIR = path.join(USER_DATA_PATH, 'Templates');
 

--- a/src/renderer/templates.ts
+++ b/src/renderer/templates.ts
@@ -2,8 +2,11 @@ import * as path from 'path';
 import { EditorValues } from '../interfaces';
 import { readFiddle } from '../utils/read-fiddle';
 
-// Defined in webpack plugins.
-declare const STATIC_DIR: string;
+const STATIC_DIR =
+  process.env.NODE_ENV === 'production'
+    ? path.join(__dirname, '../../static')
+    : path.join(process.cwd(), './static');
+
 /**
  * Returns expected content for a given name.
  *

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -47,7 +47,6 @@ window.ElectronFiddle = new ElectronFiddleMock();
 window.localStorage.setItem = jest.fn();
 window.localStorage.getItem = jest.fn();
 window.localStorage.removeItem = jest.fn();
-window.STATIC_DIR = path.join(__dirname, '../static');
 
 beforeEach(() => {
   process.env.JEST = true;

--- a/tools/webpack/common/webpack.plugins.js
+++ b/tools/webpack/common/webpack.plugins.js
@@ -1,13 +1,9 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const webpack = require('webpack');
-const path = require('path');
 
 module.exports = [
   new ForkTsCheckerWebpackPlugin(),
   new webpack.ProvidePlugin({
     __importStar: ['tslib', '__importStar'],
-  }),
-  new webpack.DefinePlugin({
-    STATIC_DIR: JSON.stringify(path.join(__dirname, '../../../static/')),
   }),
 ];


### PR DESCRIPTION
Conversations - https://electronhq.slack.com/archives/C03G7RWF6KH/p1658190886702879.

Basically, for some reason (to debug later) github action production release incorrectly computes `STATIC_DIR` global variable defined in webpack plugins.