### PR TITLE
chore: improve main webpack bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
     "monaco-editor-webpack-plugin": "2.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "resolve-url-loader": "^5.0.0",
     "recursive-readdir": "^2.2.2",
+    "resolve-url-loader": "^5.0.0",
     "rimraf": "^3.0.2",
     "standard": "^16.0.3",
     "stylelint": "^13.11.0",
@@ -130,7 +130,8 @@
     "terser-webpack-plugin": "^5.3.3",
     "ts-jest": "^27.1.4",
     "ts-loader": "^9.3.1",
-    "typescript": "^4.2.2"
+    "typescript": "^4.2.2",
+    "webpack-node-externals": "^3.0.0"
   },
   "lint-staged": {
     "./**/*.{js,ts,tsx}": [

--- a/tools/webpack/webpack.main.config.js
+++ b/tools/webpack/webpack.main.config.js
@@ -2,6 +2,7 @@ const plugins = require('./common/webpack.plugins');
 const rules = require('./common/webpack.rules');
 const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   /**
@@ -28,6 +29,11 @@ module.exports = {
         { from: 'static/show-me', to: '../static/show-me' },
         { from: 'assets/icons/fiddle.png', to: '../assets/icons/fiddle.png' },
       ],
+    }),
+  ],
+  externals: [
+    nodeExternals({
+      modulesFromFile: true,
     }),
   ],
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11401,6 +11401,11 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-node-externals@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
+  integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
+
 webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"


### PR DESCRIPTION
In the previous configuration, we would have packed some dependencies into `index.js`, but this was not really necessary. This is because node_modules will be present in both the development and application environments.

### yarn run start (diff)

#### before:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/8198408/182509042-d86627a7-8e07-4b13-860f-2fd430b793eb.png">

#### now:
<img width="421" alt="image" src="https://user-images.githubusercontent.com/8198408/182507300-76221844-789c-43c5-adfe-f3bbdfe6af88.png">

### yarn run package (diff)

#### before:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/8198408/182508905-0ec971d7-b54a-49b0-8cee-4b9ee4205543.png">


#### now:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/8198408/182508727-5de4dba0-0140-48e5-b321-c236696c52a5.png">

----

#### now file content:
<img width="1658" alt="image" src="https://user-images.githubusercontent.com/8198408/182508215-f0d138f4-dc9c-4aa4-aa79-86c958119fc2.png">

## Problems

- [ ] `node_modules` is empty in pack 😶‍🌫️
