### PR TITLE
refactor: remove dead code

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,7 +3,6 @@ const { configure: mobxConfigure } = require('mobx');
 const Adapter = require('enzyme-adapter-react-16');
 const { ElectronFiddleMock } = require('./mocks/mocks');
 const { createSerializer } = require('enzyme-to-json');
-const path = require('path');
 
 enzymeConfigure({ adapter: new Adapter() });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
     "noUnusedParameters": true,
     "importHelpers": true,
     "noEmitHelpers": true,
-    "resolveJsonModule": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "pretty": true,


### PR DESCRIPTION
A minor commit which - 

* Removes unused `path` variable in setup.js (had to be removed in #1138)
* Deduplicates the `resolveJsonModule` in tsconfig (was introduced by #988 as well)