### PR TITLE
style: add aria-labels for label-less forms

### DIFF
--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -142,7 +142,11 @@ export const AddressBar = observer(
 
       const isPerformingAction = activeGistAction !== GistActionState.none;
       return (
-        <form className={className} onSubmit={this.handleSubmit}>
+        <form
+          className={className}
+          aria-label={'Enter Fiddle Gist URL'}
+          onSubmit={this.handleSubmit}
+        >
           <fieldset disabled={isPerformingAction}>
             <InputGroup
               key="addressbar"

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -205,6 +205,7 @@ export const ExecutionSettings = observer(
           {varsArray.map(([idx, envVar]) => {
             return (
               <InputGroup
+                aria-label={'Set user-provided environment variables'}
                 placeholder='NODE_OPTIONS="--no-warnings --max-old-space-size=2048"'
                 value={envVar}
                 name={idx}
@@ -240,6 +241,7 @@ export const ExecutionSettings = observer(
           {flagsArray.map(([idx, flag]) => {
             return (
               <InputGroup
+                aria-label={'Set user-provided flags'}
                 placeholder="--js-flags=--expose-gc"
                 value={flag}
                 name={idx}

--- a/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-execution-spec.tsx.snap
@@ -73,6 +73,7 @@ exports[`ExecutionSettings component renders 1`] = `
       </p>
       <br />
       <Blueprint3.InputGroup
+        aria-label="Set user-provided flags"
         key="0"
         name="0"
         onChange={[Function]}
@@ -115,6 +116,7 @@ exports[`ExecutionSettings component renders 1`] = `
       </p>
       <br />
       <Blueprint3.InputGroup
+        aria-label="Set user-provided environment variables"
         key="0"
         name="0"
         onChange={[Function]}


### PR DESCRIPTION
issue: https://github.com/electron/fiddle/issues/1088

Form controls should have associated labels to [improve application accessibility](https://dequeuniversity.com/rules/axe/3.5/label). This PR adds aria-labels for form controls that currently do not have visible `label` attributes.


https://dequeuniversity.com/rules/axe/3.5/label