### PR TITLE
feat: add publishGistAsRevision()

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -140,12 +140,12 @@ export const GistActionButton = observer(
           files: gistFilesList as any, // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface
         });
 
+        appState.gistId = gist.data.id;
+        appState.localPath = undefined;
+
         if (appState.isPublishingGistAsRevision) {
           await this.handleUpdate(appState.isPublishingGistAsRevision);
         }
-
-        appState.gistId = gist.data.id;
-        appState.localPath = undefined;
 
         console.log(`Publish Button: Publishing complete`, { gist });
         this.renderToast({
@@ -203,10 +203,7 @@ export const GistActionButton = observer(
       const values = await window.ElectronFiddle.app.getEditorValues(options);
 
       appState.activeGistAction = GistActionState.updating;
-      console.log('hi i am here');
-      await new Promise((r) => setTimeout(r, 5000));
 
-      console.log('hi i am here 2');
       try {
         const {
           data: { files: oldFiles },
@@ -217,6 +214,8 @@ export const GistActionButton = observer(
           // Gist files are deleted by setting content to an empty string.
           if (!(id in files)) files[id] = { content: '' };
         }
+
+        console.log({ gist_id: appState.gistId! });
 
         const gist = await octo.gists.update({
           gist_id: appState.gistId!,

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -215,8 +215,6 @@ export const GistActionButton = observer(
           if (!(id in files)) files[id] = { content: '' };
         }
 
-        console.log({ gist_id: appState.gistId! });
-
         const gist = await octo.gists.update({
           gist_id: appState.gistId!,
           files,

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -25,7 +25,6 @@ import { getOctokit } from '../../utils/octokit';
 import { getTemplate } from '../content';
 import { ipcRendererManager } from '../ipc';
 import { AppState } from '../state';
-// import { FIDDLE_GIST_DESCRIPTION_PLACEHOLDER } from '../constants';
 
 interface GistActionButtonProps {
   appState: AppState;

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -127,14 +127,14 @@ export const GistActionButton = observer(
       );
 
       try {
-        const filesList = appState.isPublishingGistAsRevision
+        const gistFilesList = appState.isPublishingGistAsRevision
           ? this.gistFilesList(defaultGistValues)
           : this.gistFilesList(currentEditorValues);
 
         const gist = await octo.gists.create({
           public: !!gitHubPublishAsPublic,
           description,
-          files: filesList as any, // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface
+          files: gistFilesList as any, // Note: GitHub messed up, GistsCreateParamsFiles is an incorrect interface
         });
 
         if (appState.isPublishingGistAsRevision) {

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -126,6 +126,8 @@ export const GistActionButton = observer(
         options,
       );
 
+      defaultGistValues['package.json'] = currentEditorValues['package.json'];
+
       try {
         const gistFilesList = appState.isPublishingGistAsRevision
           ? this.gistFilesList(defaultGistValues)
@@ -139,7 +141,7 @@ export const GistActionButton = observer(
         });
 
         if (appState.isPublishingGistAsRevision) {
-          this.handleUpdate(appState.isPublishingGistAsRevision);
+          await this.handleUpdate(appState.isPublishingGistAsRevision);
         }
 
         appState.gistId = gist.data.id;
@@ -192,15 +194,19 @@ export const GistActionButton = observer(
 
     /**
      * Update an existing GitHub gist.
+     * silently updates the gist when publishing as a revision
      */
-    public async handleUpdate(isPublishingGistAsRevision = false) {
+    public async handleUpdate(silent = false) {
       const { appState } = this.props;
       const octo = await getOctokit(this.props.appState);
       const options = { includeDependencies: true, includeElectron: true };
       const values = await window.ElectronFiddle.app.getEditorValues(options);
 
       appState.activeGistAction = GistActionState.updating;
+      console.log('hi i am here');
+      await new Promise((r) => setTimeout(r, 5000));
 
+      console.log('hi i am here 2');
       try {
         const {
           data: { files: oldFiles },
@@ -220,7 +226,7 @@ export const GistActionButton = observer(
         appState.editorMosaic.isEdited = false;
         console.log('Updating: Updating done', { gist });
 
-        if (!isPublishingGistAsRevision) {
+        if (!silent) {
           this.renderToast({
             message: 'Successfully updated gist!',
             action: {

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -131,6 +131,7 @@ export const GistActionButton = observer(
           ? this.gistFilesList(defaultGistValues)
           : this.gistFilesList(currentEditorValues);
 
+        // TODO: remove as any when octo is fixed
         const gist = await octo.gists.create({
           public: !!gitHubPublishAsPublic,
           description,

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -26,6 +26,10 @@ export const GitHubSettings = observer(
       );
     }
 
+    private static publishGistAsRevisionInstructions = `
+    Enable this option to always publish your fiddle as a revision of the
+    default fiddle gist values.`.trim();
+
     /**
      * Render the "logged out" settings experience.
      *
@@ -85,17 +89,13 @@ export const GitHubSettings = observer(
         ? this.renderSignedIn()
         : this.renderNotSignedIn();
 
-      const publishGistAsRevisionInstructions = `
-        Enable this option to always publish your fiddle as a revision of the
-        default fiddle gist values.`.trim();
-
       return (
         <div>
           <h4>GitHub</h4>
           {maybeSignedIn}
           <Callout>
             <FormGroup>
-              <p>{publishGistAsRevisionInstructions}</p>
+              <p>{GitHubSettings.publishGistAsRevisionInstructions}</p>
               <Checkbox
                 checked={isPublishingGistAsRevision}
                 label="Publish as revision."

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, Callout } from '@blueprintjs/core';
+import { Button, Callout, Checkbox, FormGroup } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
 import { AppState } from '../state';
@@ -21,6 +21,9 @@ export const GitHubSettings = observer(
       super(props);
 
       this.signIn = this.signIn.bind(this);
+      this.handlePublishGistAsRevisionChange = this.handlePublishGistAsRevisionChange.bind(
+        this,
+      );
     }
 
     /**
@@ -61,17 +64,46 @@ export const GitHubSettings = observer(
       );
     }
 
+    /**
+     * Handles a change on whether or not the gist should be published
+     * as a revision on top of the default fiddle gist.
+     *
+     * @param {React.FormEvent<HTMLInputElement>} event
+     */
+    public handlePublishGistAsRevisionChange(
+      event: React.FormEvent<HTMLInputElement>,
+    ) {
+      const { checked } = event.currentTarget;
+      this.props.appState.isPublishingGistAsRevision = checked;
+    }
+
     public render() {
       const { gitHubToken } = this.props.appState;
+      const { isPublishingGistAsRevision } = this.props.appState;
 
       const maybeSignedIn = !!gitHubToken
         ? this.renderSignedIn()
         : this.renderNotSignedIn();
 
+      const publishGistAsRevisionInstructions = `
+        Enable this option to always publish your fiddle as a revision of the
+        default fiddle gist values.`.trim();
+
       return (
         <div>
           <h4>GitHub</h4>
           {maybeSignedIn}
+          <Callout>
+            <FormGroup>
+              <p>{publishGistAsRevisionInstructions}</p>
+              <Checkbox
+                checked={isPublishingGistAsRevision}
+                label="Publish as revision."
+                onChange={this.handlePublishGistAsRevisionChange}
+                defaultChecked={true}
+              />
+            </FormGroup>
+          </Callout>
         </div>
       );
     }

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -100,7 +100,6 @@ export const GitHubSettings = observer(
                 checked={isPublishingGistAsRevision}
                 label="Publish as revision."
                 onChange={this.handlePublishGistAsRevisionChange}
-                defaultChecked={true}
               />
             </FormGroup>
           </Callout>

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -13,3 +13,5 @@ export const CONFIG_PATH = path.join(
 
 export const ELECTRON_ORG = 'electron';
 export const ELECTRON_REPO = 'electron';
+
+export const FIDDLE_GIST_DESCRIPTION_PLACEHOLDER = 'Electron Fiddle Gist';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -91,6 +91,9 @@ export class AppState {
   );
   public isClearingConsoleOnRun = !!this.retrieve('isClearingConsoleOnRun');
   public isUsingSystemTheme = !!(this.retrieve('isUsingSystemTheme') ?? true);
+  public isPublishingGistAsRevision = !!this.retrieve(
+    'isPublishingGistAsRevision',
+  );
   public executionFlags: Array<string> =
     (this.retrieve('executionFlags') as Array<string>) === null
       ? []
@@ -219,6 +222,7 @@ export class AppState {
       isInstallingModules: observable,
       isKeepingUserDataDirs: observable,
       isOnline: observable,
+      isPublishingGistAsRevision: observable,
       isQuitting: observable,
       isRunning: observable,
       isSettingsShowing: observable,
@@ -330,6 +334,9 @@ export class AppState {
       this.save('isClearingConsoleOnRun', this.isClearingConsoleOnRun),
     );
     autorun(() => this.save('isUsingSystemTheme', this.isUsingSystemTheme));
+    autorun(() =>
+      this.save('isPublishingGistAsRevision', this.isPublishingGistAsRevision),
+    );
     autorun(() => this.save('gitHubAvatarUrl', this.gitHubAvatarUrl));
     autorun(() => this.save('gitHubLogin', this.gitHubLogin));
     autorun(() => this.save('gitHubName', this.gitHubName));

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -91,8 +91,8 @@ export class AppState {
   );
   public isClearingConsoleOnRun = !!this.retrieve('isClearingConsoleOnRun');
   public isUsingSystemTheme = !!(this.retrieve('isUsingSystemTheme') ?? true);
-  public isPublishingGistAsRevision = !!this.retrieve(
-    'isPublishingGistAsRevision',
+  public isPublishingGistAsRevision = !!(
+    this.retrieve('isPublishingGistAsRevision') ?? true
   );
   public executionFlags: Array<string> =
     (this.retrieve('executionFlags') as Array<string>) === null

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -38,6 +38,7 @@ export class StateMock {
   public isEnablingElectronLogging = false;
   public isGenericDialogShowing = false;
   public isInstallingModules = false;
+  public isPublishingGistAsRevision = true;
   public isOnline = true;
   public isQuitting = false;
   public isRunning = false;
@@ -130,6 +131,7 @@ export class StateMock {
       isGenericDialogShowing: observable,
       isInstallingModules: observable,
       isOnline: observable,
+      isPublishingGistAsRevision: observable,
       isQuitting: observable,
       isRunning: observable,
       isSettingsShowing: observable,

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -47,7 +47,6 @@ exports[`Action button component renders 1`] = `
         modifiers={Object {}}
         openOnTargetFocus={true}
         position="bottom"
-        shouldReturnFocusOnClose={false}
         targetTagName="span"
         transitionDuration={300}
         usePortal={true}

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -47,6 +47,7 @@ exports[`Action button component renders 1`] = `
         modifiers={Object {}}
         openOnTargetFocus={true}
         position="bottom"
+        shouldReturnFocusOnClose={false}
         targetTagName="span"
         transitionDuration={300}
         usePortal={true}

--- a/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
@@ -23,7 +23,6 @@ exports[`GitHubSettings component renders when not signed in 1`] = `
       </p>
       <Blueprint3.Checkbox
         checked={true}
-        defaultChecked={true}
         label="Publish as revision."
         onChange={[Function]}
       />
@@ -60,7 +59,6 @@ exports[`GitHubSettings component renders when signed in 1`] = `
       </p>
       <Blueprint3.Checkbox
         checked={true}
-        defaultChecked={true}
         label="Publish as revision."
         onChange={[Function]}
       />

--- a/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`GitHubSettings component renders when not signed in 1`] = `
     <Blueprint3.FormGroup>
       <p>
         Enable this option to always publish your fiddle as a revision of the
-        default fiddle gist values.
+    default fiddle gist values.
       </p>
       <Blueprint3.Checkbox
         checked={true}
@@ -56,7 +56,7 @@ exports[`GitHubSettings component renders when signed in 1`] = `
     <Blueprint3.FormGroup>
       <p>
         Enable this option to always publish your fiddle as a revision of the
-        default fiddle gist values.
+    default fiddle gist values.
       </p>
       <Blueprint3.Checkbox
         checked={true}

--- a/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
@@ -15,6 +15,20 @@ exports[`GitHubSettings component renders when not signed in 1`] = `
       text="Sign in"
     />
   </Blueprint3.Callout>
+  <Blueprint3.Callout>
+    <Blueprint3.FormGroup>
+      <p>
+        Enable this option to always publish your fiddle as a revision of the
+        default fiddle gist values.
+      </p>
+      <Blueprint3.Checkbox
+        checked={true}
+        defaultChecked={true}
+        label="Publish as revision."
+        onChange={[Function]}
+      />
+    </Blueprint3.FormGroup>
+  </Blueprint3.Callout>
 </div>
 `;
 
@@ -37,6 +51,20 @@ exports[`GitHubSettings component renders when signed in 1`] = `
       onClick={[MockFunction]}
       text="Sign out"
     />
+  </Blueprint3.Callout>
+  <Blueprint3.Callout>
+    <Blueprint3.FormGroup>
+      <p>
+        Enable this option to always publish your fiddle as a revision of the
+        default fiddle gist values.
+      </p>
+      <Blueprint3.Checkbox
+        checked={true}
+        defaultChecked={true}
+        label="Publish as revision."
+        onChange={[Function]}
+      />
+    </Blueprint3.FormGroup>
   </Blueprint3.Callout>
 </div>
 `;

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -124,6 +124,7 @@ describe('Action button component', () => {
     beforeEach(() => {
       // create a button that's primed to publish a new gist
       ({ instance } = createActionButton());
+      state.isPublishingGistAsRevision = false;
     });
 
     it('publishes a gist', async () => {

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -185,7 +185,7 @@ describe('Action button component', () => {
         const spy = jest.spyOn(instance, 'handleUpdate');
 
         await instance.performGistAction();
-        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(true);
       });
     });
 

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -176,6 +176,17 @@ describe('Action button component', () => {
         const expected = { ...expectedGistOpts, files };
         expect(mocktokit.gists.create).toHaveBeenCalledWith(expected);
       });
+
+      it('calls update() if isPublishingGistAsRevision is true', async () => {
+        state.isPublishingGistAsRevision = true;
+        state.showInputDialog = jest.fn().mockResolvedValueOnce(description);
+
+        const { instance } = createActionButton();
+        const spy = jest.spyOn(instance, 'handleUpdate');
+
+        await instance.performGistAction();
+        expect(spy).toHaveBeenCalled();
+      });
     });
 
     it('handles an error in Gist publishing', async () => {

--- a/tests/renderer/components/settings-general-github-spec.tsx
+++ b/tests/renderer/components/settings-general-github-spec.tsx
@@ -31,4 +31,23 @@ describe('GitHubSettings component', () => {
     wrapper.childAt(1).childAt(1).simulate('click');
     expect(store.isTokenDialogShowing).toBe(true);
   });
+
+  describe('Gist publish as revision component', () => {
+    it('state changes', async () => {
+      const wrapper = shallow(<GitHubSettings appState={store as any} />);
+      const instance = wrapper.instance() as any;
+
+      await instance.handlePublishGistAsRevisionChange({
+        currentTarget: { checked: false },
+      });
+
+      expect(store.isPublishingGistAsRevision).toBe(false);
+
+      await instance.handlePublishGistAsRevisionChange({
+        currentTarget: { checked: true },
+      });
+
+      expect(store.isPublishingGistAsRevision).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/electron/fiddle/issues/1176

This PR adds a checkbox to the Github settings to allow users to select whether they want to publish their gist as a revision of the default Fiddle startup editor values. This is useful when users submit issues, with Fiddle gists as repro examples: this change will allow maintainers to quickly spot diffs easier.


✅  Added option in settings to include checkbox
✅    Added tests to expand coverage (wip)
✅  Validated on Mac, (needs to be tested on Windows and Linux)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/33054982/191142738-4d42e530-008e-406f-9b91-3d792663aef0.gif)


