### PR TITLE
fix: tab focus for settings page

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -63,3 +63,7 @@ body {
   text-align: center;
   font-size: 12px;
 }
+
+.tabbing-hidden {
+  visibility: hidden;
+}

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { reaction } from 'mobx';
+
 import { AppState } from '../state';
 import { Commands } from './commands';
 import { WelcomeTour } from './tour-welcome';
@@ -8,17 +10,34 @@ interface HeaderProps {
   appState: AppState;
 }
 
+interface HeaderState {
+  focusable: boolean;
+}
+
 /**
  * Everything above the editors, so buttons and the address bar.
  *
  * @class Header
  * @extends {React.Component<HeaderProps>}
  */
-export class Header extends React.Component<HeaderProps> {
+export class Header extends React.Component<HeaderProps, HeaderState> {
+  constructor(props: HeaderProps) {
+    super(props);
+    this.state = {
+      focusable: true,
+    };
+    reaction(
+      () => this.props.appState.isSettingsShowing,
+      (isSettingsShowing) => this.setState({ focusable: !isSettingsShowing }),
+    );
+  }
   public render() {
     return (
       <>
-        <header id="header">
+        <header
+          id="header"
+          className={!this.state.focusable ? 'tabbing-hidden' : undefined}
+        >
           <Commands key="commands" appState={this.props.appState} />
         </header>
         <WelcomeTour appState={this.props.appState} />

--- a/src/renderer/components/output-editors-wrapper.tsx
+++ b/src/renderer/components/output-editors-wrapper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { reaction } from 'mobx';
 import { Mosaic, MosaicNode, MosaicParent } from 'react-mosaic-component';
 
 import { AppState } from '../state';
@@ -13,6 +14,7 @@ interface WrapperProps {
 
 interface WrapperState {
   mosaic: MosaicNode<WrapperEditorId>;
+  focusable: boolean;
 }
 
 export type WrapperEditorId = 'output' | 'editors' | 'sidebar';
@@ -41,7 +43,12 @@ export class OutputEditorsWrapper extends React.Component<
         },
         splitPercentage: 25,
       },
+      focusable: true,
     };
+    reaction(
+      () => this.props.appState.isSettingsShowing,
+      (isSettingsShowing) => this.setState({ focusable: !isSettingsShowing }),
+    );
   }
 
   public render() {
@@ -51,6 +58,7 @@ export class OutputEditorsWrapper extends React.Component<
         resize={{ minimumPaneSizePercentage: 15 }}
         value={this.state.mosaic}
         onChange={this.onChange}
+        className={!this.state.focusable ? 'tabbing-hidden' : undefined}
       />
     );
   }


### PR DESCRIPTION
Hello there,

Thought I'd try look into the issue (#1083) with tab focus misbehaving when the settings page is open.

I can confirm those tooltips come about because tabbing through the settings page eventually runs out of elements and goes on to tab through elements that are part of either the header or editor area.

The least invasive solution I could think of is to ensure the header and editor area elements are made invisible. `display: none` is a bit more destructive than `visibility: hidden`, because the former may interfere with components not rendering at all and potentially losing their state.

Now, I'm not awfully familiar with MobX, but I tried my best to work in some changes that do what I described above.

Happy to take feedback and revise (or add a test, which I couldn't work out how to do for this) as necessary. 🙂

---

As an aside, I was curious why tabbing inside those overlay dialogs worked better, so I also looked there at what's going on. It seems to be that the underlying Blueprint dialog implementations have some special code which ensure tabbing only cycles through within the overlay.