### PR TITLE
fix(show-me/desktopcapturer): allow example to work for v17 and above

### DIFF
--- a/static/show-me/desktopcapturer/main.js
+++ b/static/show-me/desktopcapturer/main.js
@@ -4,7 +4,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/desktop-capturer
 
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, desktopCapturer } = require('electron')
 const path = require('path')
 
 app.whenReady().then(() => {
@@ -19,4 +19,14 @@ app.whenReady().then(() => {
   })
 
   mainWindow.loadFile('index.html')
+  if (parseInt(process.versions.electron) >= 17) {
+    desktopCapturer.getSources({ types: ['window', 'screen'] }).then(async sources => {
+      for (const source of sources) {
+        if (source.id.startsWith('screen')) {
+          mainWindow.webContents.send('SET_SOURCE', source.id)
+          return
+        }
+      }
+    })
+  }
 })


### PR DESCRIPTION
Fixes: #1121

- The current 'Show Me' > DesktopCapturer example does not work with Electron version 17 and above due to https://www.electronjs.org/blog/electron-17-0#highlighted-features
> `desktopCapturer.getSources` is now only available in the main process. [#30720](https://github.com/electron/electron/pull/30720)

- Adding code to support v17 and above while also keeping legacy code and running the appropriate code path by detecting the Electron version


**Demo of v21 and v17 using new code**
<img width="917" alt="image" src="https://user-images.githubusercontent.com/892961/194760133-89622bff-1791-4429-a7dd-6a4ac92327a4.png">

<img width="902" alt="image" src="https://user-images.githubusercontent.com/892961/194760118-3496de64-13ef-4222-8832-8980aa2e09fe.png">

**Demo of v16 using legacy code**
<img width="936" alt="image" src="https://user-images.githubusercontent.com/892961/194760123-aa7d3935-30de-466d-a129-39817b079329.png">
