### PR TITLE
fix: Allow scrolling in Editors Listing

### DIFF
--- a/src/less/components/sidebar.less
+++ b/src/less/components/sidebar.less
@@ -50,3 +50,24 @@
     color: @white;
   }
 }
+
+.fiddle-scrollbar {
+  overflow: auto;
+}
+
+.fiddle-scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.fiddle-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: rgba(172, 172, 172, 0.6);
+
+  .bp3-dark & {
+    background-color: rgba(172, 172, 172, 0.4);
+  }
+}
+
+.fiddle-scrollbar::-webkit-scrollbar-track {
+  background-color: transparent;
+}

--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -160,7 +160,7 @@ export const SidebarFileTree = observer(
       ];
 
       return (
-        <div style={{ overflow: 'auto' }}>
+        <div className="fiddle-scrollbar">
           <Tree contents={editorsTree} />
         </div>
       );

--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -160,7 +160,7 @@ export const SidebarFileTree = observer(
       ];
 
       return (
-        <div style={{ overflow: 'hidden' }}>
+        <div style={{ overflow: 'auto' }}>
           <Tree contents={editorsTree} />
         </div>
       );

--- a/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
 <div
   style={
     Object {
-      "overflow": "hidden",
+      "overflow": "auto",
     }
   }
 >
@@ -348,7 +348,7 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
 <div
   style={
     Object {
-      "overflow": "hidden",
+      "overflow": "auto",
     }
   }
 >
@@ -674,7 +674,7 @@ exports[`SidebarFileTree component renders 1`] = `
 <div
   style={
     Object {
-      "overflow": "hidden",
+      "overflow": "auto",
     }
   }
 >

--- a/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
@@ -2,11 +2,7 @@
 
 exports[`SidebarFileTree component can bring up the Add File input 1`] = `
 <div
-  style={
-    Object {
-      "overflow": "auto",
-    }
-  }
+  className="fiddle-scrollbar"
 >
   <Blueprint3.Tree
     contents={
@@ -346,11 +342,7 @@ exports[`SidebarFileTree component can bring up the Add File input 1`] = `
 
 exports[`SidebarFileTree component reflects the visibility state of all icons 1`] = `
 <div
-  style={
-    Object {
-      "overflow": "auto",
-    }
-  }
+  className="fiddle-scrollbar"
 >
   <Blueprint3.Tree
     contents={
@@ -672,11 +664,7 @@ exports[`SidebarFileTree component reflects the visibility state of all icons 1`
 
 exports[`SidebarFileTree component renders 1`] = `
 <div
-  style={
-    Object {
-      "overflow": "auto",
-    }
-  }
+  className="fiddle-scrollbar"
 >
   <Blueprint3.Tree
     contents={


### PR DESCRIPTION
Fixes: https://github.com/electron/fiddle/issues/1187

Add ability to scroll "Editors" listing by just changing `hidden` to `auto` for simplicity (see details of other approach below which feels a bit much in terms of code changes but if the user experience s more desirable and there are betters ways to improve it, I'll be happy to contiinue investigating with any guidance)

**Preview of change**
<img width="369" alt="image" src="https://user-images.githubusercontent.com/892961/195087212-783dc9d2-2d57-4230-9be5-3bf767ac9dc6.png">

* * *

**Preview of other approach**
<img width="377" alt="image" src="https://user-images.githubusercontent.com/892961/195604998-e358ca4b-6696-4e53-ad8b-6135912a11fe.png">

- I feel the above better in terms of user experience with the top section being static and only scroll the list of files
- It involves CSS overrides including using `!important` as it is overring Blueprint's Collapse component behaviour https://github.com/palantir/blueprint/blob/a7479b73312afba568a41773060c5302ef4f13b5/packages/core/src/components/collapse/collapse.tsx#L184-L186
- I have a branch with those changes here https://github.com/thewheat/fiddle/pull/new/fix-editors-scroll-css but felt it was doing too much overriding for my liking (am also a bit rusty with CSS in general so maybe there is a better way to do it)

