### PR TITLE
test: await electronTypes.setVersion() in afterEach

### DIFF
--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -70,8 +70,8 @@ describe('ElectronTypes', () => {
     nodeTypesData = require('../fixtures/node-types.json');
   });
 
-  afterEach(() => {
-    electronTypes.setVersion();
+  afterEach(async () => {
+    await electronTypes.setVersion();
     tmpdir.removeCallback();
   });
 


### PR DESCRIPTION
There's a CI flake in this test somewhere, I'm taking a stab at this being it.

Unfortunately some of the code under test can silently fail (will just `console.debug` a message) so if there are failures happening as a result of this await not happening, you wouldn't see it unless an `expect` fails.