### PR TITLE
fix: don't check package.json version for Electron examples

### DIFF
--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -48,14 +48,14 @@ const handlePotentialProtocolLaunch = (url: string) => {
         return;
       }
       break;
-    // electron-fiddle://electron/{ref}/{path}
+    // electron-fiddle://electron/{tag}/{path}
     case 'electron':
       if (pathParts.length > 1) {
-        // First part of the commit HASH / ref / branch
+        // First part is the tag name (e.g. v22.0.0)
         // Rest is the path to the example
         ipcMainManager.send(IpcEvents.LOAD_ELECTRON_EXAMPLE_REQUEST, [
           {
-            ref: pathParts[0],
+            tag: pathParts[0],
             path: pathParts.slice(1).join('/'),
           },
         ]);

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -134,18 +134,18 @@ describe('protocol', () => {
     });
 
     it('handles an electron path url', () => {
-      // electron-fiddle://electron/{ref}/{path}
+      // electron-fiddle://electron/{tag}/{path}
       listenForProtocolHandler();
 
       const handler = (app.on as any).mock.calls[0][1];
 
-      handler({}, 'electron-fiddle://electron/4.0.0/test/path');
+      handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 
       expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
         IpcEvents.LOAD_ELECTRON_EXAMPLE_REQUEST,
         [
           {
-            ref: '4.0.0',
+            tag: 'v4.0.0',
             path: 'test/path',
           },
         ],
@@ -156,7 +156,7 @@ describe('protocol', () => {
       listenForProtocolHandler();
 
       const handler = (app.on as any).mock.calls[0][1];
-      handler({}, 'electron-fiddle://electron/4.0.0');
+      handler({}, 'electron-fiddle://electron/v4.0.0');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
     });
@@ -185,7 +185,7 @@ describe('protocol', () => {
       const mainWindow = getOrCreateMainWindow();
       const handler = (app.on as any).mock.calls[0][1];
 
-      handler({}, 'electron-fiddle://electron/4.0.0/test/path');
+      handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 
       expect(mainWindow.focus).toHaveBeenCalled();
     });

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -230,9 +230,6 @@ describe('RemoteLoader', () => {
 
     beforeEach(() => {
       instance.setElectronVersion = jest.fn().mockReturnValueOnce(true);
-      instance.getPackageVersionFromRef = jest
-        .fn()
-        .mockReturnValueOnce('4.0.0');
       fetchMock = new FetchMock();
       for (const { name, download_url } of mockRepos) {
         fetchMock.add(download_url, name);
@@ -242,7 +239,7 @@ describe('RemoteLoader', () => {
     it('loads an Electron example', async () => {
       (getOctokit as jest.Mock).mockReturnValue({ repos: mockGetRepos });
 
-      await instance.fetchExampleAndLoad('4.0.0', 'test/path');
+      await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
 
       const expectedValues = {};
       for (const filename of Object.keys(mockGistFiles)) {
@@ -253,6 +250,7 @@ describe('RemoteLoader', () => {
         expectedValues,
         expect.anything(),
       );
+      expect(instance.setElectronVersion).toBeCalledWith('4.0.0');
     });
 
     it('handles an error', async () => {
@@ -264,7 +262,7 @@ describe('RemoteLoader', () => {
         },
       });
 
-      const result = await instance.fetchExampleAndLoad('4.0.0', 'test/path');
+      const result = await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
       expect(result).toBe(false);
     });
 
@@ -278,7 +276,7 @@ describe('RemoteLoader', () => {
         },
       });
 
-      const result = await instance.fetchExampleAndLoad('4.0.0', 'test/path');
+      const result = await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
       expect(result).toBe(false);
       expect(store.showErrorDialog).toHaveBeenCalledWith(
         expect.stringMatching(/not a valid/i),
@@ -319,23 +317,6 @@ describe('RemoteLoader', () => {
     });
   });
 
-  describe('getPackageVersionFromRef()', () => {
-    it('gets Electron version from package.json', async () => {
-      const versionString = JSON.stringify({ version: '4.0.0' });
-      const content = Buffer.from(versionString).toString('base64');
-      const mockGetPackageJson = {
-        getContents: async () => ({
-          data: { content },
-        }),
-      };
-
-      (getOctokit as jest.Mock).mockReturnValue({ repos: mockGetPackageJson });
-
-      const result = await instance.getPackageVersionFromRef('4.0.0');
-      expect(result).toBe('4.0.0');
-    });
-  });
-
   describe('verifyReleaseChannelEnabled', () => {
     it('asks the user if they want to enable a release channel', async () => {
       store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
@@ -354,15 +335,15 @@ describe('RemoteLoader', () => {
       instance.fetchExampleAndLoad = jest.fn();
       await instance.loadFiddleFromElectronExample(
         {},
-        { path: 'test/path', ref: '4.0.0' },
+        { path: 'test/path', tag: 'v4.0.0' },
       );
 
       expect(store.showConfirmDialog).toHaveBeenCalledWith({
-        label: expect.stringMatching(/for version 4.0.0/i),
+        label: expect.stringMatching(/for version v4.0.0/i),
         ok: 'Load',
       });
       expect(instance.fetchExampleAndLoad).toHaveBeenCalledWith(
-        '4.0.0',
+        'v4.0.0',
         'test/path',
       );
     });
@@ -373,7 +354,7 @@ describe('RemoteLoader', () => {
       instance.fetchExampleAndLoad = jest.fn();
       await instance.loadFiddleFromElectronExample(
         {},
-        { path: 'test/path', ref: '4.0.0' },
+        { path: 'test/path', tag: 'v4.0.0' },
       );
 
       expect(store.showConfirmDialog).toHaveBeenCalled();


### PR DESCRIPTION
Fixes #1217.

This change means Fiddle will no longer be able to handle URLs like `electron-fiddle://electron/22-x-y/docs/fiddles/features/macos-dark-mode`, but AFAIK there is no use case for those kinds of URLs. If we want to support those going forward there's no clear path after the change in `electron/electron`, other than hardcoded rules around the branch name. So I think it's best to just drop support for those kinds of URLs now and only support tags.