### PR TITLE
fix: race condition when getting Node types

### DIFF
--- a/src/renderer/electron-types.ts
+++ b/src/renderer/electron-types.ts
@@ -179,19 +179,23 @@ export class ElectronTypes {
       );
     }
 
-    const { files: fileJson } = await response.json();
-    fileJson
-      .flatMap((item: { files?: { path: string }[]; path: string }) => {
-        return item.files ? item.files.map((f: any) => f.path) : item.path;
-      })
-      .filter((path: string) => path.endsWith('.d.ts'))
-      .map(async (path: string) => {
-        const res = await fetch(
-          `https://unpkg.com/@types/node@${downloadVersion}${path}`,
-        );
-        const text = await res.text();
-        await fs.outputFileSync(`${dir}${path}`, text);
-      });
+    const { files: fileJson } = (await response.json()) as {
+      files: { path: string }[];
+    };
+    await Promise.all(
+      fileJson
+        .flatMap((item: { files?: { path: string }[]; path: string }) => {
+          return item.files ? item.files.map((f: any) => f.path) : item.path;
+        })
+        .filter((path: string) => path.endsWith('.d.ts'))
+        .map(async (path: string) => {
+          const res = await fetch(
+            `https://unpkg.com/@types/node@${downloadVersion}${path}`,
+          );
+          const text = await res.text();
+          fs.outputFileSync(`${dir}${path}`, text);
+        }),
+    );
 
     return downloadVersion;
   }

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -174,7 +174,7 @@ describe('ElectronTypes', () => {
         expect(fetchSpy).toHaveBeenCalledWith(expect.stringMatching(file.path));
       }
 
-      expect(addExtraLib).toHaveBeenCalledTimes(1);
+      expect(addExtraLib).toHaveBeenCalledTimes(52);
       expect(addExtraLib).toHaveBeenCalledWith(types);
     });
 


### PR DESCRIPTION
Found the race condition that's been haunting the tests.