### PR TITLE
fix: don't unset Electron typings when setting Node typings

### DIFF
--- a/src/renderer/electron-types.ts
+++ b/src/renderer/electron-types.ts
@@ -80,7 +80,6 @@ export class ElectronTypes {
   }
 
   private async setTypesFromDir(dir: string, version: string) {
-    this.dispose();
     try {
       const files = await readdir(dir);
       for (const file of files) {
@@ -99,7 +98,6 @@ export class ElectronTypes {
   }
 
   private setTypesFromFile(file: string, version: string) {
-    this.dispose();
     try {
       console.log(`Updating Monaco with "${ELECTRON_DTS}@${version}"`);
       const lib = this.monaco.languages.typescript.javascriptDefaults.addExtraLib(


### PR DESCRIPTION
This was throwing away the Electron typings when adding the Node ones. The previous typings are already disposed (via `clear()`) in `setVersion`, so these calls to `dispose` were redundant anyway.

Tests may flake until #1220 is merged.