### PR TITLE
fix: don't continue Gist publish if authing token fails

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -96,9 +96,7 @@ export const GistActionButton = observer(
       }
 
       // Wait for the dialog to be closed again
-      await when(
-        () => !!appState.gitHubToken || !appState.isTokenDialogShowing,
-      );
+      await when(() => !appState.isTokenDialogShowing);
 
       if (appState.gitHubToken) {
         return this.performGistAction();

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -108,6 +108,25 @@ describe('Action button component', () => {
     expect(state.toggleAuthDialog).toHaveBeenCalled();
   });
 
+  it('toggles the publish method on click only after authing if not authed', async () => {
+    state.toggleAuthDialog = jest.fn();
+    const { instance } = createActionButton();
+    instance.performGistAction = jest.fn();
+
+    // If not authed, don't continue to performGistAction
+    await instance.handleClick();
+    expect(state.toggleAuthDialog).toHaveBeenCalled();
+    expect(instance.performGistAction).not.toHaveBeenCalled();
+
+    // If authed, continue to performGistAction
+    state.toggleAuthDialog.mockImplementationOnce(
+      () => (state.gitHubToken = 'github-token'),
+    );
+    await instance.handleClick();
+    expect(state.toggleAuthDialog).toHaveBeenCalled();
+    expect(instance.performGistAction).toHaveBeenCalled();
+  });
+
   it('toggles the publish method on click if authed', async () => {
     state.gitHubToken = 'github-token';
 


### PR DESCRIPTION
Fixes the Gist publish process continuing even if the token fails to authenticate, causing this situation:

<img width="1512" alt="Screen Shot 2022-12-07 at 6 05 16 PM" src="https://user-images.githubusercontent.com/5820654/206338693-86505ea5-0155-432e-a42f-eda65ce7d71d.png">
