### PR TITLE
ci: remove usage of 1arp/create-a-file-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,11 +29,11 @@ jobs:
       - name: Install
         run: yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000
       - name: Create fake contributors
-        uses: 1arp/create-a-file-action@0.2
+        uses: timheuer/base64-to-file@v1
         with:
-          path: 'static'
-          file: 'contributors.json'
-          content: "[]"
+          fileDir: 'static'
+          fileName: 'contributors.json'
+          encodedString: "W10="
       - name: lint
         run: yarn lint
       - name: test


### PR DESCRIPTION
Not being maintained at the moment.

Reuses the existing `timheuer/base64-to-file` action so we have fewer external actions.