### PR TITLE
fix(show-me): use IPC for clipboard example

### DIFF
--- a/static/show-me/clipboard/index.html
+++ b/static/show-me/clipboard/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Clipboard</title>
   </head>
   <body>
@@ -9,5 +11,6 @@
     <button id="paste">Paste into TextArea</button>
     <br />
     <textarea></textarea>
+    <script src="./renderer.js"></script>
   </body>
 </html>

--- a/static/show-me/clipboard/main.js
+++ b/static/show-me/clipboard/main.js
@@ -3,8 +3,16 @@
 // For more info, see:
 // https://electronjs.org/docs/api/clipboard
 
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, ipcMain, clipboard } = require('electron')
 const path = require('path')
+
+ipcMain.handle('clipboard:readText', () => {
+  return clipboard.readText()
+})
+
+ipcMain.handle('clipboard:writeText', (event, text) => {
+  clipboard.writeText(text)
+})
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({

--- a/static/show-me/clipboard/preload.js
+++ b/static/show-me/clipboard/preload.js
@@ -1,15 +1,6 @@
-const { clipboard } = require('electron')
+const { contextBridge, ipcRenderer } = require('electron')
 
-// All of the Node.js APIs are available in the preload process.
-// It has the same sandbox as a Chrome extension.
-window.addEventListener('DOMContentLoaded', () => {
-  const copyButton = document.querySelector('#copy')
-  const pasteButton = document.querySelector('#paste')
-  const textarea = document.querySelector('textarea')
-  copyButton.onclick = () => {
-    clipboard.writeText('Hello from Electron!')
-  }
-  pasteButton.onclick = () => {
-    textarea.value = clipboard.readText()
-  }
+contextBridge.exposeInMainWorld('clipboard', {
+  readText: () => ipcRenderer.invoke('clipboard:readText'),
+  writeText: (text) => ipcRenderer.invoke('clipboard:writeText', text)
 })

--- a/static/show-me/clipboard/renderer.js
+++ b/static/show-me/clipboard/renderer.js
@@ -1,0 +1,11 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const copyButton = document.querySelector('#copy')
+  const pasteButton = document.querySelector('#paste')
+  const textarea = document.querySelector('textarea')
+  copyButton.onclick = () => {
+    clipboard.writeText('Hello from Electron!')
+  }
+  pasteButton.onclick = async () => {
+    textarea.value = await clipboard.readText()
+  }
+})

--- a/static/show-me/clipboard/renderer.js
+++ b/static/show-me/clipboard/renderer.js
@@ -3,9 +3,9 @@ window.addEventListener('DOMContentLoaded', () => {
   const pasteButton = document.querySelector('#paste')
   const textarea = document.querySelector('textarea')
   copyButton.onclick = () => {
-    clipboard.writeText('Hello from Electron!')
+    window.clipboard.writeText('Hello from Electron!')
   }
   pasteButton.onclick = async () => {
-    textarea.value = await clipboard.readText()
+    textarea.value = await window.clipboard.readText()
   }
 })


### PR DESCRIPTION
Fixes #1239.

Electron v20.0.0 enabled renderer sandboxing by default and as a result clipboard can't be used in preload.js anymore.