### PR TITLE
fix: don't activate when downloading versions from settings

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -383,7 +383,7 @@ export const ElectronSettings = observer(
           buttonProps.onClick = () => {
             isLocal
               ? appState.removeVersion(ver)
-              : appState.downloadVersion(ver);
+              : appState.downloadVersion(ver, { noActivate: true });
           };
           break;
       }

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -383,7 +383,7 @@ export const ElectronSettings = observer(
           buttonProps.onClick = () => {
             isLocal
               ? appState.removeVersion(ver)
-              : appState.downloadVersion(ver, { noActivate: true });
+              : appState.downloadVersion(ver, { activate: true });
           };
           break;
       }

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -383,7 +383,7 @@ export const ElectronSettings = observer(
           buttonProps.onClick = () => {
             isLocal
               ? appState.removeVersion(ver)
-              : appState.downloadVersion(ver, { activate: true });
+              : appState.downloadVersion(ver, { activate: false });
           };
           break;
       }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -577,14 +577,17 @@ export class AppState {
   }
 
   /**
-   * Download a version of Electron.
+   * Download a version of Electron and set it as the current
+   * version in use unless otherwise specified.
    *
    * @param {RunnableVersion} ver
+   * @param {Object} opts
+   * @param {Boolean} [options.activate=100] - Whether to set ver as current
    * @returns {Promise<void>}
    */
   public async downloadVersion(
     ver: RunnableVersion,
-    opts?: { noActivate: boolean },
+    opts: { activate: boolean } = { activate: true },
   ) {
     const { source, state, version } = ver;
     const {
@@ -613,13 +616,14 @@ export class AppState {
       return;
     }
 
+    console.log(`State: Downloading Electron ${version}`);
+
     // Download the version without setting it as the current version.
-    if (opts?.noActivate) {
+    if (!opts.activate) {
       await this.installer.ensureDownloaded(version);
       return;
     }
 
-    console.log(`State: Downloading Electron ${version}`);
     await this.installer.install(version, {
       mirror: {
         electronMirror,

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -582,7 +582,7 @@ export class AppState {
    *
    * @param {RunnableVersion} ver
    * @param {Object} opts
-   * @param {Boolean} [options.activate=100] - Whether to set ver as current
+   * @param {Boolean} [options.activate=true] - Whether to set ver as current
    * @returns {Promise<void>}
    */
   public async downloadVersion(
@@ -618,13 +618,7 @@ export class AppState {
 
     console.log(`State: Downloading Electron ${version}`);
 
-    // Download the version without setting it as the current version.
-    if (!opts.activate) {
-      await this.installer.ensureDownloaded(version);
-      return;
-    }
-
-    await this.installer.install(version, {
+    const options = {
       mirror: {
         electronMirror,
         electronNightlyMirror,
@@ -638,7 +632,15 @@ export class AppState {
           }
         });
       },
-    });
+    };
+
+    // Download the version without setting it as the current version.
+    if (!opts.activate) {
+      await this.installer.ensureDownloaded(version, options);
+      return;
+    }
+
+    await this.installer.install(version, options);
   }
 
   /**

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -582,7 +582,10 @@ export class AppState {
    * @param {RunnableVersion} ver
    * @returns {Promise<void>}
    */
-  public async downloadVersion(ver: RunnableVersion) {
+  public async downloadVersion(
+    ver: RunnableVersion,
+    opts?: { noActivate: boolean },
+  ) {
     const { source, state, version } = ver;
     const {
       electronMirror,
@@ -607,6 +610,12 @@ export class AppState {
     if (isDownloaded) {
       // The electron zip needs to be unzipped as well
       await this.installer.install(version);
+      return;
+    }
+
+    // Download the version without setting it as the current version.
+    if (opts?.noActivate) {
+      await this.installer.ensureDownloaded(version);
       return;
     }
 

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -107,7 +107,7 @@ function getVersions(
  * Save an array of GitHubVersions to localStorage.
  *
  * @param {VersionKeys} key
- * @param {Array<Version} versions
+ * @param {Array<Version>} versions
  */
 function saveVersions(key: VersionKeys, versions: Array<Version>) {
   const stringified = JSON.stringify(versions);


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1238.

`fiddle-core` was installing versions and activating them regardless of origin - when a version is downloaded from settings it should not be activated. 