### PR TITLE
feat: show version download progress in settings

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -11,6 +11,7 @@ import {
   HTMLTable,
   Icon,
   IconName,
+  Spinner,
   Tooltip,
 } from '@blueprintjs/core';
 import { InstallState } from '@electron/fiddle-core';
@@ -370,8 +371,7 @@ export const ElectronSettings = observer(
         case InstallState.installing:
         case InstallState.downloading:
           buttonProps.disabled = true;
-          buttonProps.icon = 'cloud-download';
-          buttonProps.loading = true;
+          buttonProps.icon = <Spinner size={16} value={ver.downloadProgress} />;
           buttonProps.text = 'Downloading';
           break;
 

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -253,8 +253,11 @@ exports[`ElectronSettings component renders 1`] = `
             <Blueprint3.Button
               disabled={true}
               fill={true}
-              icon="cloud-download"
-              loading={true}
+              icon={
+                <Blueprint3.Spinner
+                  size={16}
+                />
+              }
               small={true}
               text="Downloading"
             />
@@ -317,8 +320,11 @@ exports[`ElectronSettings component renders 1`] = `
             <Blueprint3.Button
               disabled={true}
               fill={true}
-              icon="cloud-download"
-              loading={true}
+              icon={
+                <Blueprint3.Spinner
+                  size={16}
+                />
+              }
               small={true}
               text="Downloading"
             />


### PR DESCRIPTION
`buttonProps.loading` was just showing an indefinite spinner, let's show progress like on `VersionSelect`.