### PR TITLE
refactor: use navigator.clipboard in renderer

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -10,7 +10,6 @@ import {
   Position,
   Toaster,
 } from '@blueprintjs/core';
-import { clipboard } from 'electron';
 import { when } from 'mobx';
 import { observer } from 'mobx-react';
 
@@ -150,7 +149,7 @@ export const GistActionButton = observer(
           action: {
             text: 'Copy link',
             icon: 'clipboard',
-            onClick: () => clipboard.writeText(gist.data.html_url),
+            onClick: () => navigator.clipboard.writeText(gist.data.html_url),
           },
         });
 
@@ -233,7 +232,7 @@ export const GistActionButton = observer(
             action: {
               text: 'Copy link',
               icon: 'clipboard',
-              onClick: () => clipboard.writeText(gist.data.html_url),
+              onClick: () => navigator.clipboard.writeText(gist.data.html_url),
             },
           });
         }

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Button, Callout, Dialog, InputGroup, Intent } from '@blueprintjs/core';
-import { clipboard, shell } from 'electron';
+import { shell } from 'electron';
 import { observer } from 'mobx-react';
 
 import { getOctokit } from '../../utils/octokit';
@@ -116,8 +116,8 @@ export const TokenDialog = observer(
      * @returns
      * @memberof TokenDialog
      */
-    public onTokenInputFocused() {
-      const text = (clipboard.readText() || '').trim();
+    public async onTokenInputFocused() {
+      const text = ((await navigator.clipboard.readText()) || '').trim();
 
       if (text.length !== 40) return;
       if (!/^[a-z0-9]+$/.test(text)) return;

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -16,7 +16,6 @@ import {
   Select,
 } from '@blueprintjs/select';
 import { InstallState } from '@electron/fiddle-core';
-import { clipboard } from 'electron';
 import { observer } from 'mobx-react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import semver from 'semver';
@@ -170,7 +169,7 @@ export const renderVersionContextMenu = (
       <MenuItem
         text="Copy Version Number"
         onClick={() => {
-          clipboard.writeText(version);
+          navigator.clipboard.writeText(version);
         }}
       />
     </Menu>,

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -40,49 +40,55 @@ describe('TokenDialog component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('tries to read the clipboard on focus and enters it if valid', () => {
+  it('tries to read the clipboard on focus and enters it if valid', async () => {
     const wrapper = shallow(<TokenDialog appState={store as any} />);
     const instance: any = wrapper.instance() as any;
 
-    (electron as any).clipboard.readText.mockReturnValueOnce(mockValidToken);
-    instance.onTokenInputFocused();
+    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
+      mockValidToken,
+    );
+    await instance.onTokenInputFocused();
 
-    expect((electron as any).clipboard.readText).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe(mockValidToken);
   });
 
-  it('tries to read the clipboard on focus and does not enter it if too short', () => {
+  it('tries to read the clipboard on focus and does not enter it if too short', async () => {
     const wrapper = shallow(<TokenDialog appState={store as any} />);
     const instance: any = wrapper.instance() as any;
 
-    (electron as any).clipboard.readText.mockReturnValueOnce(mockInvalidToken);
-    instance.onTokenInputFocused();
+    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
+      mockInvalidToken,
+    );
+    await instance.onTokenInputFocused();
 
-    expect((electron as any).clipboard.readText).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 
-  it('tries to read the clipboard on focus and does not enter it if invalid', () => {
+  it('tries to read the clipboard on focus and does not enter it if invalid', async () => {
     const wrapper = shallow(<TokenDialog appState={store as any} />);
     const instance: any = wrapper.instance() as any;
 
-    (electron as any).clipboard.readText.mockReturnValueOnce(
+    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
       'String with the right length not a token',
     );
-    instance.onTokenInputFocused();
+    await instance.onTokenInputFocused();
 
-    expect((electron as any).clipboard.readText).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 
-  it('tries to read the clipboard on focus and does not enter it if invalid', () => {
+  it('tries to read the clipboard on focus and does not enter it if invalid', async () => {
     const wrapper = shallow(<TokenDialog appState={store as any} />);
     const instance: any = wrapper.instance() as any;
 
-    (electron as any).clipboard.readText.mockReturnValueOnce(undefined);
-    instance.onTokenInputFocused();
+    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
+      'invalid',
+    );
+    await instance.onTokenInputFocused();
 
-    expect((electron as any).clipboard.readText).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -37,6 +37,9 @@ global.fetch = window.fetch = jest.fn();
 delete window.localStorage;
 window.localStorage = {};
 
+window.navigator = window.navigator ?? {};
+window.navigator.clipboard = {};
+
 /**
  * Mock these properties twice so that they're available
  * both at the top-level of files and also within the
@@ -46,6 +49,8 @@ window.ElectronFiddle = new ElectronFiddleMock();
 window.localStorage.setItem = jest.fn();
 window.localStorage.getItem = jest.fn();
 window.localStorage.removeItem = jest.fn();
+window.navigator.clipboard.readText = jest.fn();
+window.navigator.clipboard.writeText = jest.fn();
 
 beforeEach(() => {
   process.env.JEST = true;


### PR DESCRIPTION
For the use cases in Fiddle, `navigator.clipboard` is a drop-in replacement, so switch to it and stop using the `electron` module in the renderer.