### PR TITLE
refactor: don't use shell.openExternal in renderer

### DIFF
--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Button, Callout, Dialog, InputGroup, Intent } from '@blueprintjs/core';
-import { shell } from 'electron';
 import { observer } from 'mobx-react';
 
 import { getOctokit } from '../../utils/octokit';
@@ -106,7 +105,7 @@ export const TokenDialog = observer(
      * @memberof TokenDialog
      */
     public openGenerateTokenExternal() {
-      shell.openExternal(GENERATE_TOKEN_URL);
+      window.open(GENERATE_TOKEN_URL);
     }
 
     /**

--- a/src/renderer/components/settings-credits.tsx
+++ b/src/renderer/components/settings-credits.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Callout, Card } from '@blueprintjs/core';
-import { shell } from 'electron';
 
 import { Contributor } from 'src/interfaces';
 
@@ -50,7 +49,7 @@ export class CreditsSettings extends React.Component<
       const style: React.CSSProperties = {
         backgroundImage: `url(${avatar})`,
       };
-      const onClick = () => shell.openExternal(url);
+      const onClick = () => window.open(url);
 
       return (
         <Card

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import * as electron from 'electron';
 import { shallow } from 'enzyme';
 
 import { TokenDialog } from '../../../src/renderer/components/dialog-token';
@@ -137,7 +136,7 @@ describe('TokenDialog component', () => {
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
     instance.openGenerateTokenExternal();
 
-    expect(electron.shell.openExternal).toHaveBeenCalled();
+    expect(window.open as jest.Mock).toHaveBeenCalled();
   });
 
   describe('onSubmitToken()', () => {

--- a/tests/renderer/components/settings-credits-spec.tsx
+++ b/tests/renderer/components/settings-credits-spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import * as electron from 'electron';
 import { shallow } from 'enzyme';
 
 import { CreditsSettings } from '../../../src/renderer/components/settings-credits';
@@ -62,6 +61,6 @@ describe('CreditsSettings component', () => {
     wrapper.setState({ contributors: mockContributors });
 
     wrapper.find('.contributor').simulate('click');
-    expect(electron.shell.openExternal).toHaveBeenCalled();
+    expect(window.open as jest.Mock).toHaveBeenCalled();
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -49,6 +49,7 @@ window.ElectronFiddle = new ElectronFiddleMock();
 window.localStorage.setItem = jest.fn();
 window.localStorage.getItem = jest.fn();
 window.localStorage.removeItem = jest.fn();
+window.open = jest.fn();
 window.navigator.clipboard.readText = jest.fn();
 window.navigator.clipboard.writeText = jest.fn();
 
@@ -61,4 +62,5 @@ beforeEach(() => {
   window.localStorage.setItem.mockReset();
   window.localStorage.getItem.mockReset();
   window.localStorage.removeItem.mockReset();
+  window.open.mockReset();
 });


### PR DESCRIPTION
All `window.open` calls are already denied and opened by `shell.openExternal` by default via `setWindowOpenHandler`, so `shell.openExternal` doesn't need to be used in the renderer.

https://github.com/electron/fiddle/blob/ff0de26376f9f0e17e8e0873ac89282b72933e06/src/main/windows.ts#L89-L92