### PR TITLE
refactor: don't use `process.arch`/`process.platform` in renderer

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -7,7 +7,9 @@ declare global {
     ElectronFiddle: {
       app: App;
       appPaths: Record<string, string>;
+      arch: string;
       monaco: typeof MonacoType;
+      platform: string;
     };
   }
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -10,7 +10,9 @@ export async function setupFiddleGlobal() {
   window.ElectronFiddle = {
     app: null as any, // will be set in main.tsx
     appPaths: await ipcRendererManager.invoke(IpcEvents.GET_APP_PATHS),
+    arch: process.arch,
     monaco: null as any, // will be set in main.tsx
+    platform: process.platform,
   };
 }
 

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -43,7 +43,7 @@ export const Commands = observer(
       return (
         <div
           className={
-            process.platform === 'darwin' ? 'commands is-mac' : 'commands'
+            window.ElectronFiddle.platform === 'darwin' ? 'commands is-mac' : 'commands'
           }
           onDoubleClick={this.handleDoubleClick}
         >
@@ -73,7 +73,7 @@ export const Commands = observer(
               />
             </ControlGroup>
           </div>
-          {process.platform === 'darwin' ? (
+          {window.ElectronFiddle.platform === 'darwin' ? (
             <div className="title">{title}</div>
           ) : undefined}
           <div>

--- a/src/renderer/npm.ts
+++ b/src/renderer/npm.ts
@@ -24,7 +24,7 @@ export async function getIsPackageManagerInstalled(
     return isYarnInstalled;
 
   const command =
-    process.platform === 'win32'
+    window.ElectronFiddle.platform === 'win32'
       ? `where.exe ${packageManager}`
       : `which ${packageManager}`;
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -833,7 +833,7 @@ export class AppState {
     let strData = data.toString();
     const { isNotPre, bypassBuffer } = options;
 
-    if (process.platform === 'win32' && bypassBuffer === false) {
+    if (window.ElectronFiddle.platform === 'win32' && bypassBuffer === false) {
       this.outputBuffer += strData;
       strData = this.outputBuffer;
       const parts = strData.split(/\r?\n/);

--- a/src/utils/disable-download.ts
+++ b/src/utils/disable-download.ts
@@ -11,11 +11,11 @@ import semver from 'semver';
  */
 export function disableDownload(version: string) {
   return (
-    (process.platform === 'darwin' &&
-      process.arch === 'arm64' &&
+    (window.ElectronFiddle.platform === 'darwin' &&
+      window.ElectronFiddle.arch === 'arm64' &&
       semver.lt(version, '11.0.0')) ||
-    (process.platform === 'win32' &&
-      process.arch === 'arm64' &&
+    (window.ElectronFiddle.platform === 'win32' &&
+      window.ElectronFiddle.arch === 'arm64' &&
       !semver.satisfies(version, '>=6.0.8 || >=7.0.0'))
   );
 }

--- a/src/utils/electron-name.ts
+++ b/src/utils/electron-name.ts
@@ -4,7 +4,7 @@
  * @returns {string}
  */
 export function getElectronNameForPlatform(): string {
-  switch (process.platform) {
+  switch (window.ElectronFiddle.platform) {
     case 'win32': {
       return 'electron.exe';
     }

--- a/src/utils/position-for-rect.ts
+++ b/src/utils/position-for-rect.ts
@@ -24,7 +24,7 @@ export function positionForRect(
 ): PositionResult {
   const result: PositionResult = { left: 0, top: 0, type: 'top' };
   const middle = target.left + target.width / 2 - size.width / 2;
-  const darwinTop = process.platform === 'darwin' ? margin * 1.5 : 0;
+  const darwinTop = window.ElectronFiddle.platform === 'darwin' ? margin * 1.5 : 0;
   const topPlusMargin = target.top - darwinTop;
 
   // Okay, let's try top right

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -6,5 +6,7 @@ export class ElectronFiddleMock {
     userData: '/fake/path',
     home: `~`,
   };
+  public arch = process.arch;
   public monaco = new MonacoMock();
+  public platform = process.platform;
 }

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -8,7 +8,7 @@ import { Commands } from '../../../src/renderer/components/commands';
 import { BisectHandler } from '../../../src/renderer/components/commands-bisect';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform, resetRendererPlatform } from '../../utils';
 
 jest.mock('../../../src/renderer/components/commands-runner', () => ({
   Runner: 'runner',
@@ -30,22 +30,22 @@ describe('Commands component', () => {
   let store: StateMock;
 
   beforeEach(() => {
-    overridePlatform('linux');
+    overrideRendererPlatform('linux');
     ({ state: store } = (window as any).ElectronFiddle.app);
   });
 
   afterEach(() => {
-    resetPlatform();
+    resetRendererPlatform();
   });
 
   it('renders when system is darwin', () => {
-    overridePlatform('darwin');
+    overrideRendererPlatform('darwin');
     const wrapper = shallow(<Commands appState={store as any} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders when system not is darwin', () => {
-    overridePlatform('win32');
+    overrideRendererPlatform('win32');
     const wrapper = shallow(<Commands appState={store as any} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/renderer/components/dialog-add-theme-spec.tsx
+++ b/tests/renderer/components/dialog-add-theme-spec.tsx
@@ -12,24 +12,18 @@ import {
   defaultLight,
 } from '../../../src/renderer/themes-defaults';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 jest.mock('../../../src/renderer/ipc');
 
 describe('AddThemeDialog component', () => {
   let store: StateMock;
 
-  beforeAll(() => {
+  beforeEach(() => {
     // We render the buttons different depending on the
     // platform, so let' have a uniform platform for unit tests
-    overridePlatform('darwin');
-  });
+    overrideRendererPlatform('darwin');
 
-  afterAll(() => {
-    resetPlatform();
-  });
-
-  beforeEach(() => {
     ({ state: store } = (window as any).ElectronFiddle.app);
   });
 

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -6,7 +6,7 @@ import { IpcEvents } from '../../../src/ipc-events';
 import { AddVersionDialog } from '../../../src/renderer/components/dialog-add-version';
 import { ipcRendererManager } from '../../../src/renderer/ipc';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 jest.mock('../../../src/renderer/ipc');
 
@@ -15,17 +15,11 @@ describe('AddVersionDialog component', () => {
 
   const mockFile = '/test/file';
 
-  beforeAll(() => {
+  beforeEach(() => {
     // We render the buttons different depending on the
     // platform, so let' have a uniform platform for unit tests
-    overridePlatform('darwin');
-  });
+    overrideRendererPlatform('darwin');
 
-  afterAll(() => {
-    resetPlatform();
-  });
-
-  beforeEach(() => {
     ({ state: store } = (window as any).ElectronFiddle.app);
   });
 

--- a/tests/renderer/components/dialog-generic-spec.tsx
+++ b/tests/renderer/components/dialog-generic-spec.tsx
@@ -5,23 +5,17 @@ import { shallow } from 'enzyme';
 import { GenericDialogType } from '../../../src/interfaces';
 import { GenericDialog } from '../../../src/renderer/components/dialog-generic';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 describe('GenericDialog component', () => {
   let store: StateMock;
 
-  beforeAll(() => {
+  beforeEach(() => {
     // We render the buttons different depending on the
     // platform, so let' have a uniform platform for unit tests
-    overridePlatform('darwin');
-  });
+    overrideRendererPlatform('darwin');
 
-  beforeEach(() => {
     ({ state: store } = (window as any).ElectronFiddle.app);
-  });
-
-  afterAll(() => {
-    resetPlatform();
   });
 
   describe('renders', () => {

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import { TokenDialog } from '../../../src/renderer/components/dialog-token';
 import { getOctokit } from '../../../src/utils/octokit';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 jest.mock('../../../src/utils/octokit');
 
@@ -14,17 +14,11 @@ describe('TokenDialog component', () => {
   const mockInvalidToken = 'testtoken';
   let store: StateMock;
 
-  beforeAll(() => {
+  beforeEach(() => {
     // We render the buttons different depending on the
     // platform, so let' have a uniform platform for unit tests
-    overridePlatform('darwin');
-  });
+    overrideRendererPlatform('darwin');
 
-  afterAll(() => {
-    resetPlatform();
-  });
-
-  beforeEach(() => {
     ({ state: store } = (window as any).ElectronFiddle.app);
     /*
     store = {

--- a/tests/renderer/components/dialogs-spec.tsx
+++ b/tests/renderer/components/dialogs-spec.tsx
@@ -4,24 +4,18 @@ import { shallow } from 'enzyme';
 
 import { Dialogs } from '../../../src/renderer/components/dialogs';
 import { StateMock } from '../../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 describe('Dialogs component', () => {
   let store: StateMock;
 
-  beforeAll(() => {
+  beforeEach(() => {
     // We render the buttons different depending on the
     // platform, so let' have a uniform platform for unit tests
-    overridePlatform('darwin');
-  });
+    overrideRendererPlatform('darwin');
 
-  beforeEach(() => {
     ({ state: store } = (window as any).ElectronFiddle.app);
     store.isGenericDialogShowing = true;
-  });
-
-  afterAll(() => {
-    resetPlatform();
   });
 
   it('renders the token dialog', () => {

--- a/tests/renderer/components/tour-spec.tsx
+++ b/tests/renderer/components/tour-spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import { Tour } from '../../../src/renderer/components/tour';
-import { overridePlatform, resetPlatform } from '../../utils';
+import { overrideRendererPlatform } from '../../utils';
 
 describe('VersionChooser component', () => {
   const oldQuerySelector = document.querySelector;
@@ -22,15 +22,9 @@ describe('VersionChooser component', () => {
     },
   ]);
 
-  beforeAll(() => {
-    overridePlatform('darwin');
-  });
-
-  afterAll(() => {
-    resetPlatform();
-  });
-
   beforeEach(() => {
+    overrideRendererPlatform('darwin');
+
     document.querySelector = jest.fn(() => ({
       getBoundingClientRect: jest.fn(() => ({
         top: 20,

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -4,7 +4,7 @@ import {
   packageRun,
 } from '../../src/renderer/npm';
 import { exec } from '../../src/utils/exec';
-import { overridePlatform, resetPlatform } from '../utils';
+import { overrideRendererPlatform, resetRendererPlatform } from '../utils';
 jest.mock('../../src/utils/exec');
 
 describe('npm', () => {
@@ -14,10 +14,10 @@ describe('npm', () => {
         jest.resetModules();
       });
 
-      afterEach(() => resetPlatform());
+      afterEach(() => resetRendererPlatform());
 
       it('returns true if npm installed', async () => {
-        overridePlatform('darwin');
+        overrideRendererPlatform('darwin');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.resolve('/usr/bin/fake-npm'),
@@ -30,7 +30,7 @@ describe('npm', () => {
       });
 
       it('returns true if npm installed', async () => {
-        overridePlatform('win32');
+        overrideRendererPlatform('win32');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.resolve('/usr/bin/fake-npm'),
@@ -43,7 +43,7 @@ describe('npm', () => {
       });
 
       it('returns false if npm not installed', async () => {
-        overridePlatform('darwin');
+        overrideRendererPlatform('darwin');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.reject('/usr/bin/fake-npm'),
@@ -75,10 +75,10 @@ describe('npm', () => {
         jest.resetModules();
       });
 
-      afterEach(() => resetPlatform());
+      afterEach(() => resetRendererPlatform());
 
       it('returns true if yarn installed', async () => {
-        overridePlatform('darwin');
+        overrideRendererPlatform('darwin');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.resolve('/usr/bin/fake-yarn'),
@@ -91,7 +91,7 @@ describe('npm', () => {
       });
 
       it('returns true if yarn installed', async () => {
-        overridePlatform('win32');
+        overrideRendererPlatform('win32');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.resolve('/usr/bin/fake-yarn'),
@@ -104,7 +104,7 @@ describe('npm', () => {
       });
 
       it('returns false if yarn not installed', async () => {
-        overridePlatform('darwin');
+        overrideRendererPlatform('darwin');
 
         (exec as jest.Mock).mockReturnValueOnce(
           Promise.reject('/usr/bin/fake-yarn'),

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../src/renderer/versions';
 import { getName } from '../../src/utils/get-name';
 import { VersionsMock, createEditorValues } from '../mocks/mocks';
-import { overridePlatform, resetPlatform } from '../utils';
+import { overrideRendererPlatform, resetRendererPlatform } from '../utils';
 
 jest.mock('../../src/renderer/content', () => ({
   getTemplate: jest.fn(),
@@ -691,7 +691,7 @@ describe('AppState', () => {
     });
 
     it('handles a complex buffer on Win32', () => {
-      overridePlatform('win32');
+      overrideRendererPlatform('win32');
 
       appState.pushOutput(Buffer.from('Buffer\r\nStuff\nMore'), {
         bypassBuffer: false,
@@ -699,7 +699,7 @@ describe('AppState', () => {
       expect(appState.output[1].text).toBe('Buffer');
       expect(appState.output[2].text).toBe('Stuff');
 
-      resetPlatform();
+      resetRendererPlatform();
     });
   });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -16,18 +16,43 @@ export function resetPlatform() {
   });
 }
 
-const arch = process.arch;
+const rendererOverrides = {
+  arch: '',
+  platform: '',
+};
 
-export function overrideArch(value: string) {
-  Object.defineProperty(process, 'arch', {
+export function overrideRendererPlatform(value: NodeJS.Platform) {
+  if (!rendererOverrides.platform) {
+    rendererOverrides.platform = window.ElectronFiddle.platform;
+  }
+
+  Object.defineProperty(window.ElectronFiddle, 'platform', {
     value,
     writable: true,
   });
 }
 
-export function resetArch() {
-  Object.defineProperty(process, 'arch', {
-    value: arch,
+export function resetRendererPlatform() {
+  Object.defineProperty(window.ElectronFiddle, 'platform', {
+    value: rendererOverrides.platform,
+    writable: true,
+  });
+}
+
+export function overrideRendererArch(value: string) {
+  if (!rendererOverrides.arch) {
+    rendererOverrides.arch = window.ElectronFiddle.arch;
+  }
+
+  Object.defineProperty(window.ElectronFiddle, 'arch', {
+    value,
+    writable: true,
+  });
+}
+
+export function resetRendererArch() {
+  Object.defineProperty(window.ElectronFiddle, 'arch', {
+    value: rendererOverrides.arch,
     writable: true,
   });
 }

--- a/tests/utils/disable-download-spec.ts
+++ b/tests/utils/disable-download-spec.ts
@@ -1,20 +1,20 @@
 import { disableDownload } from '../../src/utils/disable-download';
 import {
-  overrideArch,
-  overridePlatform,
-  resetArch,
-  resetPlatform,
+  overrideRendererArch,
+  overrideRendererPlatform,
+  resetRendererArch,
+  resetRendererPlatform,
 } from '../utils';
 
 describe('disableDownload', () => {
   afterEach(() => {
-    resetPlatform();
-    resetArch();
+    resetRendererPlatform();
+    resetRendererArch();
   });
 
   it('always return false when the system is windows and the arch is not arm64', () => {
-    overridePlatform('win32');
-    overrideArch('x64');
+    overrideRendererPlatform('win32');
+    overrideRendererArch('x64');
 
     expect(disableDownload('6.0.0')).toBe(false);
     expect(disableDownload('6.0.8')).toBe(false);
@@ -23,8 +23,8 @@ describe('disableDownload', () => {
   });
 
   it('returns true if the system is windows and the arch is arm64', () => {
-    overridePlatform('win32');
-    overrideArch('arm64');
+    overrideRendererPlatform('win32');
+    overrideRendererArch('arm64');
 
     expect(disableDownload('6.0.0')).toBe(true);
     expect(disableDownload('6.0.8')).toBe(false);
@@ -33,7 +33,7 @@ describe('disableDownload', () => {
   });
 
   it('always return false when the system is linux', () => {
-    overridePlatform('linux');
+    overrideRendererPlatform('linux');
 
     expect(disableDownload('10.0.0')).toBe(false);
     expect(disableDownload('11.0.0')).toBe(false);
@@ -41,8 +41,8 @@ describe('disableDownload', () => {
   });
 
   it('always return false when the system is macOS and the arch is not arm64', () => {
-    overridePlatform('darwin');
-    overrideArch('x64');
+    overrideRendererPlatform('darwin');
+    overrideRendererArch('x64');
 
     expect(disableDownload('10.0.0')).toBe(false);
     expect(disableDownload('11.0.0')).toBe(false);
@@ -50,8 +50,8 @@ describe('disableDownload', () => {
   });
 
   it('returns true if the system is macOS and the arch is arm64', () => {
-    overridePlatform('darwin');
-    overrideArch('arm64');
+    overrideRendererPlatform('darwin');
+    overrideRendererArch('arm64');
 
     expect(disableDownload('10.0.0')).toBe(true);
     expect(disableDownload('11.0.0')).toBe(false);

--- a/tests/utils/electron-name-spec.ts
+++ b/tests/utils/electron-name-spec.ts
@@ -1,9 +1,9 @@
 import { getElectronNameForPlatform } from '../../src/utils/electron-name';
-import { overridePlatform, resetPlatform } from '../utils';
+import { overrideRendererPlatform, resetRendererPlatform } from '../utils';
 
 describe('electron-name', () => {
   afterAll(() => {
-    resetPlatform();
+    resetRendererPlatform();
   });
 
   it('returns the right name for each platform', () => {
@@ -14,7 +14,7 @@ describe('electron-name', () => {
     ];
 
     platforms.forEach(({ platform, expected }) => {
-      overridePlatform(platform);
+      overrideRendererPlatform(platform);
       expect(getElectronNameForPlatform()).toBe(expected);
     });
   });

--- a/tests/utils/position-for-rect-spec.ts
+++ b/tests/utils/position-for-rect-spec.ts
@@ -1,5 +1,5 @@
 import { positionForRect } from '../../src/utils/position-for-rect';
-import { overridePlatform } from '../utils';
+import { overrideRendererPlatform } from '../utils';
 
 describe('position-for-rect', () => {
   describe('positionForRect()', () => {
@@ -14,7 +14,7 @@ describe('position-for-rect', () => {
 
     describe('positionForRect() (Windows, Linux)', () => {
       beforeEach(() => {
-        overridePlatform('win32');
+        overrideRendererPlatform('win32');
       });
 
       it('returns a position on the top right if doable', () => {
@@ -38,7 +38,7 @@ describe('position-for-rect', () => {
 
     describe('positionForRect() (macOS)', () => {
       beforeEach(() => {
-        overridePlatform('darwin');
+        overrideRendererPlatform('darwin');
       });
 
       it('returns a position on the top right if doable', () => {


### PR DESCRIPTION
Another step towards cleaning up the code in the renderer, moves usages of `process.arch` and `process.platform` to `window.ElectronFiddle`.