### PR TITLE
fix: keep versions in-sync with fiddle-core

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -52,6 +52,12 @@ import {
   saveLocalVersions,
 } from './versions';
 
+class UpdateableBaseVersions extends BaseVersions {
+  public updateVersions(val: unknown): void {
+    this.setVersions(val);
+  }
+}
+
 /**
  * The application's state. Exported as a singleton below.
  *
@@ -167,7 +173,7 @@ export class AppState {
   public appData: string;
 
   // Populating versions in fiddle-core
-  public baseVersions: BaseVersions = new BaseVersions(getElectronVersions());
+  public baseVersions = new UpdateableBaseVersions(getElectronVersions());
 
   // For managing downloads and versions for electron
   public installer: Installer = new Installer({
@@ -436,11 +442,13 @@ export class AppState {
     this.isUpdatingElectronVersions = true;
 
     try {
+      const fullVersions = await fetchVersions();
       this.addNewVersions(
-        (await fetchVersions())
+        fullVersions
           .filter((ver) => !(ver.version in this.versions))
           .map((ver) => makeRunnable(ver)),
       );
+      this.baseVersions.updateVersions(fullVersions);
     } catch (error) {
       console.warn(`State: Could not update Electron versions`, error);
     }


### PR DESCRIPTION
Update versions known to `fiddle-core` when updating versions in the UI.

This is a bit of a hack until #1203 is complete.

Fixes #1241.