### PR TITLE
fix: remote loader loading incompatible versions

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -4,9 +4,11 @@ import semver from 'semver';
 import {
   EditorValues,
   ElectronReleaseChannel,
+  GenericDialogType,
   PACKAGE_NAME,
   VersionSource,
 } from '../interfaces';
+import { disableDownload } from '../utils/disable-download';
 import { isKnownFile, isSupportedFile } from '../utils/editor-utils';
 import { getOctokit } from '../utils/octokit';
 import { ELECTRON_ORG, ELECTRON_REPO } from './constants';
@@ -147,9 +149,16 @@ export class RemoteLoader {
               throw new Error(
                 "This gist's package.json contains an invalid Electron version.",
               );
+            } else if (disableDownload(version)) {
+              await this.appState.showGenericDialog({
+                label: `This gist's Electron version (${version}) is not available on your current OS. Falling back to last used version.`,
+                ok: 'Close',
+                type: GenericDialogType.warning,
+                wantsInput: false,
+              });
+            } else {
+              this.setElectronVersion(version);
             }
-
-            this.setElectronVersion(version);
 
             // We want to include all dependencies except Electron.
             delete deps[dep];


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1281.

Fixes an issue where if a user tries to load a gist with a package.json using an Electron version too old for or incompatible with the current OS, it is loaded anyway.

After:
<details>
<img width="1512" alt="Screenshot 2023-03-13 at 1 38 42 PM" src="https://user-images.githubusercontent.com/2036040/224704321-a8e6e9cf-2484-4df7-be60-8c2d89ae2432.png">
</details>