### PR TITLE
refactor: add type awareness to getItemIcon()

### DIFF
--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -86,7 +86,7 @@ export function getItemLabel({ source, state, name }: RunnableVersion): string {
  * version.
  *
  * @param {RunnableVersion} { state }
- * @returns
+ * @returns {IconName}
  */
 export function getItemIcon({ state }: RunnableVersion): IconName {
   const installStateIcons: Record<InstallState, IconName> = {

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   ButtonGroupProps,
   ContextMenu,
+  IconName,
   Intent,
   Menu,
   MenuItem,
@@ -66,24 +67,18 @@ const itemListRenderer: ItemListRenderer<RunnableVersion> = ({
  * @returns {string}
  */
 export function getItemLabel({ source, state, name }: RunnableVersion): string {
-  let label = '';
-
   if (source === VersionSource.local) {
-    label = name || 'Local';
-  } else {
-    if (state === InstallState.missing) {
-      label = `Not downloaded`;
-    } else if (
-      state === InstallState.installed ||
-      state === InstallState.downloaded
-    ) {
-      label = `Downloaded`;
-    } else if (state === InstallState.downloading) {
-      label = `Downloading`;
-    }
+    return name || 'Local';
   }
 
-  return label;
+  const installStateLabels: Record<InstallState, string> = {
+    missing: 'Not downloaded',
+    downloading: 'Downloading',
+    downloaded: 'Downloaded',
+    installing: 'Downloaded',
+    installed: 'Downloaded',
+  } as const;
+  return installStateLabels[state] || '';
 }
 
 /**
@@ -93,18 +88,16 @@ export function getItemLabel({ source, state, name }: RunnableVersion): string {
  * @param {RunnableVersion} { state }
  * @returns
  */
-export function getItemIcon({ state }: RunnableVersion) {
-  switch (state) {
-    case InstallState.missing:
-      return 'cloud';
-    case InstallState.installing:
-      return 'compressed';
-    case InstallState.installed:
-    case InstallState.downloaded:
-      return 'saved';
-    case InstallState.downloading:
-      return 'cloud-download';
-  }
+export function getItemIcon({ state }: RunnableVersion): IconName {
+  const installStateIcons: Record<InstallState, IconName> = {
+    missing: 'cloud',
+    downloading: 'cloud-download',
+    downloaded: 'compressed',
+    installing: 'compressed',
+    installed: 'saved',
+  } as const;
+
+  return installStateIcons[state] || '';
 }
 
 /**


### PR DESCRIPTION
Nothing major; this is a side-refactor I wrote while looking at something else in Fiddle.

- Add type awareness (IconName) to `getItemIcon()`
- Simplify the logic of `getItemLabel()` and `getItemIcon()` by making a const Record of the InstallState enum types.