### PR TITLE
fix: focus Fiddle app for unsaved fiddle dialog (#1036)

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -39,7 +39,7 @@ export enum IpcEvents {
   TASK_DONE = 'TASK_DONE',
   OUTPUT_ENTRY = 'OUTPUT_ENTRY',
   RELOAD_WINDOW = 'RELOAD_WINDOW',
-  FOCUS_APP = 'FOCUS_APP',
+  SHOW_WINDOW = 'SHOW_WINDOW',
 }
 
 export const ipcMainEvents = [
@@ -56,7 +56,7 @@ export const ipcMainEvents = [
   IpcEvents.OUTPUT_ENTRY,
   IpcEvents.TASK_DONE,
   IpcEvents.RELOAD_WINDOW,
-  IpcEvents.FOCUS_APP,
+  IpcEvents.SHOW_WINDOW,
 ];
 
 export const ipcRendererEvents = [

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -39,6 +39,7 @@ export enum IpcEvents {
   TASK_DONE = 'TASK_DONE',
   OUTPUT_ENTRY = 'OUTPUT_ENTRY',
   RELOAD_WINDOW = 'RELOAD_WINDOW',
+  FOCUS_APP = 'FOCUS_APP',
 }
 
 export const ipcMainEvents = [
@@ -55,6 +56,7 @@ export const ipcMainEvents = [
   IpcEvents.OUTPUT_ENTRY,
   IpcEvents.TASK_DONE,
   IpcEvents.RELOAD_WINDOW,
+  IpcEvents.FOCUS_APP,
 ];
 
 export const ipcRendererEvents = [

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,7 +34,7 @@ export async function onReady() {
   const { setupMenu } = await import('./menu');
   const { setupFileListeners } = await import('./files');
 
-  setupFocusApp()
+  setupShowWindow();
   setupMenu();
   setupMenuHandler();
   setupProtocolHandler();
@@ -57,9 +57,12 @@ export function onBeforeQuit() {
   ipcMainManager.on(IpcEvents.CONFIRM_QUIT, app.quit);
 }
 
-export function setupFocusApp() {
-  ipcMainManager.on(IpcEvents.FOCUS_APP, () => {
-    app.focus({ steal: true })
+export function setupShowWindow() {
+  ipcMainManager.on(IpcEvents.SHOW_WINDOW, (event: IpcMainEvent) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) {
+      win.show();
+    }
   });
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,6 +34,7 @@ export async function onReady() {
   const { setupMenu } = await import('./menu');
   const { setupFileListeners } = await import('./files');
 
+  setupFocusApp()
   setupMenu();
   setupMenuHandler();
   setupProtocolHandler();
@@ -54,6 +55,12 @@ export async function onReady() {
 export function onBeforeQuit() {
   ipcMainManager.send(IpcEvents.BEFORE_QUIT);
   ipcMainManager.on(IpcEvents.CONFIRM_QUIT, app.quit);
+}
+
+export function setupFocusApp() {
+  ipcMainManager.on(IpcEvents.FOCUS_APP, () => {
+    app.focus({ steal: true })
+  });
 }
 
 export function setupMenuHandler() {

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -274,6 +274,9 @@ export class App {
       }
 
       window.onbeforeunload = async () => {
+        // On Mac OS, quitting can be triggered from the dock,
+        // focus the app before presenting the dialog
+        ipcRendererManager.send(IpcEvents.FOCUS_APP)
         if (await this.confirmExitUnsaved()) {
           // isQuitting checks if we're trying to quit the app
           // or just close the window

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -275,8 +275,8 @@ export class App {
 
       window.onbeforeunload = async () => {
         // On Mac OS, quitting can be triggered from the dock,
-        // focus the app before presenting the dialog
-        ipcRendererManager.send(IpcEvents.FOCUS_APP)
+        // show the window before presenting the dialog
+        ipcRendererManager.send(IpcEvents.SHOW_WINDOW);
         if (await this.confirmExitUnsaved()) {
           // isQuitting checks if we're trying to quit the app
           // or just close the window

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -14,6 +14,7 @@ import {
   onWindowsAllClosed,
   setupMenuHandler,
   setupTitleBarClickMac,
+  setupFocusApp,
 } from '../../src/main/main';
 import { shouldQuit } from '../../src/main/squirrel';
 import { setupUpdates } from '../../src/main/update';
@@ -126,6 +127,26 @@ describe('main', () => {
         IpcEvents.BLOCK_ACCELERATORS,
         expect.anything(),
       );
+    });
+  });
+
+  describe('setupFocusApp()', () => {
+   beforeEach(() => {
+        // Since ipcMainManager is mocked, we can't just .emit to trigger
+        // the event. Instead, call the callback as soon as the listener
+        // is instantiated.
+        (ipcMainManager.on as jest.Mock).mockImplementationOnce(
+          (channel, callback) => {
+            if (channel === IpcEvents.FOCUS_APP) {
+              callback({});
+            }
+          },
+        );
+    });
+
+    it('focuses the app on FOCUS_APP', () => {
+      setupFocusApp();
+      expect(app.focus).toHaveBeenCalledWith({ steal: true })
     });
   });
 

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -13,8 +13,8 @@ import {
   onReady,
   onWindowsAllClosed,
   setupMenuHandler,
+  setupShowWindow,
   setupTitleBarClickMac,
-  setupFocusApp,
 } from '../../src/main/main';
 import { shouldQuit } from '../../src/main/squirrel';
 import { setupUpdates } from '../../src/main/update';
@@ -130,23 +130,25 @@ describe('main', () => {
     });
   });
 
-  describe('setupFocusApp()', () => {
-   beforeEach(() => {
-        // Since ipcMainManager is mocked, we can't just .emit to trigger
-        // the event. Instead, call the callback as soon as the listener
-        // is instantiated.
-        (ipcMainManager.on as jest.Mock).mockImplementationOnce(
-          (channel, callback) => {
-            if (channel === IpcEvents.FOCUS_APP) {
-              callback({});
-            }
-          },
-        );
+  describe('setupShowWindow()', () => {
+    beforeEach(() => {
+      // Since ipcMainManager is mocked, we can't just .emit to trigger
+      // the event. Instead, call the callback as soon as the listener
+      // is instantiated.
+      (ipcMainManager.on as jest.Mock).mockImplementationOnce(
+        (channel, callback) => {
+          if (channel === IpcEvents.SHOW_WINDOW) {
+            callback({});
+          }
+        },
+      );
     });
 
-    it('focuses the app on FOCUS_APP', () => {
-      setupFocusApp();
-      expect(app.focus).toHaveBeenCalledWith({ steal: true })
+    it('shows the window', () => {
+      const mockWindow = new BrowserWindowMock();
+      (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(mockWindow);
+      setupShowWindow();
+      expect(mockWindow.show).toHaveBeenCalled();
     });
   });
 

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -390,6 +390,9 @@ describe('App component', () => {
       expect(window.onbeforeunload).toBeTruthy();
       const result = await window.onbeforeunload!(undefined as any);
       expect(result).toBe(false);
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.FOCUS_APP,
+      );
       expect(window.close).toHaveBeenCalled();
     });
 
@@ -404,6 +407,9 @@ describe('App component', () => {
 
       expect(result).toBe(false);
       expect(window.close).toHaveBeenCalledTimes(1);
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.FOCUS_APP,
+      );
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
         IpcEvents.CONFIRM_QUIT,
       );
@@ -420,7 +426,21 @@ describe('App component', () => {
 
       expect(result).toBe(false);
       expect(window.close).not.toHaveBeenCalled();
-      expect(ipcRendererManager.send).not.toHaveBeenCalled();
+      expect(ipcRendererManager.send).toHaveBeenCalledTimes(1);
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.FOCUS_APP,
+      );
+    });
+
+    it('sends FOCUS_APP event when there are unsaved changes', async () => {
+      app.state.editorMosaic.isEdited = true;
+      expect(window.onbeforeunload).toBeTruthy();
+      const result = await window.onbeforeunload!(undefined as any);
+
+      expect(result).toBe(false);
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.FOCUS_APP,
+      );
     });
   });
 });

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -391,7 +391,7 @@ describe('App component', () => {
       const result = await window.onbeforeunload!(undefined as any);
       expect(result).toBe(false);
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
-        IpcEvents.FOCUS_APP,
+        IpcEvents.SHOW_WINDOW,
       );
       expect(window.close).toHaveBeenCalled();
     });
@@ -408,7 +408,7 @@ describe('App component', () => {
       expect(result).toBe(false);
       expect(window.close).toHaveBeenCalledTimes(1);
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
-        IpcEvents.FOCUS_APP,
+        IpcEvents.SHOW_WINDOW,
       );
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
         IpcEvents.CONFIRM_QUIT,
@@ -428,18 +428,18 @@ describe('App component', () => {
       expect(window.close).not.toHaveBeenCalled();
       expect(ipcRendererManager.send).toHaveBeenCalledTimes(1);
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
-        IpcEvents.FOCUS_APP,
+        IpcEvents.SHOW_WINDOW,
       );
     });
 
-    it('sends FOCUS_APP event when there are unsaved changes', async () => {
+    it('sends SHOW_WINDOW event if there are unsaved changes', async () => {
       app.state.editorMosaic.isEdited = true;
       expect(window.onbeforeunload).toBeTruthy();
       const result = await window.onbeforeunload!(undefined as any);
 
       expect(result).toBe(false);
       expect(ipcRendererManager.send).toHaveBeenCalledWith(
-        IpcEvents.FOCUS_APP,
+        IpcEvents.SHOW_WINDOW,
       );
     });
   });


### PR DESCRIPTION
Fixes #1036.

Focuses the Fiddle app before presenting unsaved fiddle dialogs. Previously, quitting the app from the Mac OS dock would appear to do nothing if the app is covered or hidden.

Changes summary:

- Use the `App` api focus method with steal option to take focus from the foreground app before showing the dialogs.
- Call this through a new IPC event type, `FOCUS_APP`. I added it because the dialog is conditionally presented from the renderer process. As far as I know, this code doesn't have access to BrowserWindow or App object.