### PR TITLE
fix: use nativeTheme module

### DIFF
--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -39,6 +39,7 @@ export enum IpcEvents {
   TASK_DONE = 'TASK_DONE',
   OUTPUT_ENTRY = 'OUTPUT_ENTRY',
   RELOAD_WINDOW = 'RELOAD_WINDOW',
+  SET_NATIVE_THEME = 'SET_NATIVE_THEME',
 }
 
 export const ipcMainEvents = [
@@ -55,6 +56,7 @@ export const ipcMainEvents = [
   IpcEvents.OUTPUT_ENTRY,
   IpcEvents.TASK_DONE,
   IpcEvents.RELOAD_WINDOW,
+  IpcEvents.SET_NATIVE_THEME,
 ];
 
 export const ipcRendererEvents = [

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1,3 +1,7 @@
+:root {
+  color-scheme: light dark;
+}
+
 body {
   padding: 0;
   margin: 0;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { initSentry } from '../sentry';
 initSentry();
-import { BrowserWindow, app, systemPreferences } from 'electron';
+import { BrowserWindow, app, nativeTheme, systemPreferences } from 'electron';
 // eslint-disable-next-line import/no-unresolved
 import { IpcMainEvent } from 'electron/main';
 
@@ -42,6 +42,7 @@ export async function onReady() {
   setupDialogs();
   setupDevTools();
   setupTitleBarClickMac();
+  setupNativeTheme();
 
   processCommandLine(argv);
 }
@@ -102,6 +103,23 @@ export function setupTitleBarClickMac() {
           win.unmaximize();
         }
       }
+    }
+  });
+}
+
+function isNativeThemeSource(
+  val: unknown,
+): val is typeof nativeTheme.themeSource {
+  return typeof val === 'string' && ['dark', 'light', 'system'].includes(val);
+}
+
+/**
+ * Handle theme changes.
+ */
+export function setupNativeTheme() {
+  ipcMainManager.on(IpcEvents.SET_NATIVE_THEME, async (_, source: string) => {
+    if (isNativeThemeSource(source)) {
+      nativeTheme.themeSource = source;
     }
   });
 }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -169,9 +169,15 @@ export class App {
     reaction(
       () => this.state.isUsingSystemTheme,
       () => {
-        if (this.state.isUsingSystemTheme && !!window.matchMedia) {
-          const { matches } = window.matchMedia('(prefers-color-scheme: dark)');
-          setSystemTheme(matches);
+        if (this.state.isUsingSystemTheme) {
+          ipcRendererManager.send(IpcEvents.SET_NATIVE_THEME, 'system');
+
+          if (!!window.matchMedia) {
+            const { matches } = window.matchMedia(
+              '(prefers-color-scheme: dark)',
+            );
+            setSystemTheme(matches);
+          }
         }
       },
     );
@@ -221,8 +227,14 @@ export class App {
 
     if (theme.isDark || theme.name.includes('dark')) {
       document.body.classList.add('bp3-dark');
+      if (!this.state.isUsingSystemTheme) {
+        ipcRendererManager.send(IpcEvents.SET_NATIVE_THEME, 'dark');
+      }
     } else {
       document.body.classList.remove('bp3-dark');
+      if (!this.state.isUsingSystemTheme) {
+        ipcRendererManager.send(IpcEvents.SET_NATIVE_THEME, 'light');
+      }
     }
   }
 

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -234,6 +234,24 @@ describe('App component', () => {
 
       expect(document.body.classList.value).toBe('bp3-dark');
     });
+
+    it('sets native theme', async () => {
+      app.state.isUsingSystemTheme = false;
+
+      ipcRendererManager.send = jest.fn();
+      await app.loadTheme('defaultLight');
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.SET_NATIVE_THEME,
+        'light',
+      );
+
+      ipcRendererManager.send = jest.fn();
+      await app.loadTheme('custom-dark');
+      expect(ipcRendererManager.send).toHaveBeenCalledWith(
+        IpcEvents.SET_NATIVE_THEME,
+        'dark',
+      );
+    });
   });
 
   describe('setupThemeListeners()', () => {
@@ -256,6 +274,10 @@ describe('App component', () => {
     });
 
     describe('isUsingSystemTheme reaction', () => {
+      beforeEach(() => {
+        ipcRendererManager.send = jest.fn();
+      });
+
       it('ignores system theme changes when not isUsingSystemTheme', () => {
         app.state.isUsingSystemTheme = true;
         app.setupThemeListeners();
@@ -281,6 +303,17 @@ describe('App component', () => {
         });
         app.state.isUsingSystemTheme = true;
         expect(app.state.setTheme).toHaveBeenCalledWith(defaultLight.file);
+      });
+
+      it('sets native theme to system', () => {
+        app.state.isUsingSystemTheme = false;
+        app.setupThemeListeners();
+        app.state.isUsingSystemTheme = true;
+
+        expect(ipcRendererManager.send).toHaveBeenCalledWith(
+          IpcEvents.SET_NATIVE_THEME,
+          'system',
+        );
       });
     });
 


### PR DESCRIPTION
Currently the main process never sets `nativeTheme.themeSource`, so setting Fiddle to use a dark or light theme, rather than syncing with the system, ends up being out of sync with itself. If your system is set to dark mode, and you set light mode in Fiddle, on Windows 10 the titlebar will stay dark, for example. On macOS things like the background color of context menus will follow the system theme rather than the set theme in Fiddle.

Pretty straight forward fix. Tested on macOS and Windows 10.