### PR TITLE
chore: normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 * text=auto
+
+# Source code should always use LF as line ending
+*.d.ts text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf


### PR DESCRIPTION
Theme of the week is line endings. After #1269, linting on Windows out of the box doesn't work due to ESLint not liking the CRLF line endings. This PR normalizes and enforces LF line endings.

Did an initial commit to show that linting is broken on Windows out of the box: https://github.com/electron/fiddle/actions/runs/4560442995/jobs/8045390014?pr=1293

And the clean lint run on Windows with these changes: https://github.com/electron/fiddle/actions/runs/4560499302/jobs/8045508959?pr=1293