### PR TITLE
chore: release v0.32.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-fiddle",
   "productName": "Electron Fiddle",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
   "main": "./.webpack/main",


### PR DESCRIPTION
This PR bumps Fiddle to v0.32.2. 

This is the first release done on CircleCI, rather than GH Actions.