### PR TITLE
chore: update to Electron 24.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "cross-fetch": "^3.1.0",
     "css-loader": "^6.7.1",
-    "electron": "22.0.1",
+    "electron": "24.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "enzyme-to-json": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,10 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz"
   integrity sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==
 
-"@types/node@^16.11.26":
-  version "16.11.56"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz"
-  integrity sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==
+"@types/node@^18.11.18":
+  version "18.15.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
+  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4359,13 +4359,13 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@22.0.1:
-  version "22.0.1"
-  resolved "https://registry.npmjs.org/electron/-/electron-22.0.1.tgz"
-  integrity sha512-05X/UmQOtUYwFmytY4/rc+4Iz+LYzHhftRZDkx1GQzyX/BxopStddG8LMcx3SESNk25F2J93oHv1Lzs6QWeCjA==
+electron@24.1.1:
+  version "24.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.1.1.tgz#05fa6269b1ee303fed7a05de9eb4be56c46660b8"
+  integrity sha512-ymjUMe6Pvh9ytpM4lOvr+Qxd6NG5AELRtR6tw54bK3FXfKtTTKKAtZw/NbwHwkRAlWu8FNAGOuvCoap6/bm9LQ==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^16.11.26"
+    "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
 emittery@^0.8.1:


### PR DESCRIPTION
Tested on macOS 13.1.

Notable breaking changes in the jump from v22 to v24:
* [Behavior Changed: Draggable Regions on macOS](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#behavior-changed-draggable-regions-on-macos)
  * I tested the drag behavior and it seems fine still in Fiddle, but something to watch out for
* [Removed: Windows 7 / 8 / 8.1 support](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-windows-7--8--81-support)
  * So we'll be dropping support for those in the next Fiddle release