### PR TITLE
refactor: move getTemplateValues to main process

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,5 +1,6 @@
 import * as MonacoType from 'monaco-editor';
 
+import { EditorValues } from './interfaces';
 import { App } from './renderer/app';
 
 declare global {
@@ -8,6 +9,7 @@ declare global {
       app: App;
       appPaths: Record<string, string>;
       arch: string;
+      getTemplateValues: (name: string) => Promise<EditorValues>;
       monaco: typeof MonacoType;
       platform: string;
     };

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -38,6 +38,7 @@ export enum IpcEvents {
   RELOAD_WINDOW = 'RELOAD_WINDOW',
   SET_NATIVE_THEME = 'SET_NATIVE_THEME',
   SHOW_WINDOW = 'SHOW_WINDOW',
+  GET_TEMPLATE_VALUES = 'GET_TEMPLATE_VALUES',
 }
 
 export const ipcMainEvents = [
@@ -54,6 +55,7 @@ export const ipcMainEvents = [
   IpcEvents.RELOAD_WINDOW,
   IpcEvents.SET_NATIVE_THEME,
   IpcEvents.SHOW_WINDOW,
+  IpcEvents.GET_TEMPLATE_VALUES,
 ];
 
 export const WEBCONTENTS_READY_FOR_IPC_SIGNAL =

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,6 +15,7 @@ import { onFirstRunMaybe } from './first-run';
 import { ipcMainManager } from './ipc';
 import { listenForProtocolHandler, setupProtocolHandler } from './protocol';
 import { shouldQuit } from './squirrel';
+import { setupTemplates } from './templates';
 import { setupUpdates } from './update';
 import { getOrCreateMainWindow } from './windows';
 
@@ -44,6 +45,7 @@ export async function onReady() {
   setupDevTools();
   setupTitleBarClickMac();
   setupNativeTheme();
+  setupTemplates();
 
   processCommandLine(argv);
 }

--- a/src/main/templates.ts
+++ b/src/main/templates.ts
@@ -1,7 +1,12 @@
 import * as path from 'path';
 
+// eslint-disable-next-line import/no-unresolved
+import { IpcMainEvent } from 'electron/main';
+
 import { EditorValues } from '../interfaces';
+import { IpcEvents } from '../ipc-events';
 import { readFiddle } from '../utils/read-fiddle';
+import { ipcMainManager } from './ipc';
 
 const STATIC_DIR =
   process.env.NODE_ENV === 'production'
@@ -18,4 +23,11 @@ export function getTemplateValues(name: string): Promise<EditorValues> {
   const templatePath = path.join(STATIC_DIR, 'show-me', name.toLowerCase());
 
   return readFiddle(templatePath);
+}
+
+export function setupTemplates() {
+  ipcMainManager.handle(
+    IpcEvents.GET_TEMPLATE_VALUES,
+    (_: IpcMainEvent, name: string) => getTemplateValues(name),
+  );
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -12,6 +12,9 @@ export async function setupFiddleGlobal() {
     app: null as any, // will be set in main.tsx
     appPaths: await ipcRenderer.invoke(IpcEvents.GET_APP_PATHS),
     arch: process.arch,
+    getTemplateValues: (name: string) => {
+      return ipcRenderer.invoke(IpcEvents.GET_TEMPLATE_VALUES, name);
+    },
     monaco: null as any, // will be set in main.tsx
     platform: process.platform,
   };

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -10,7 +10,6 @@ import { isKnownFile } from '../utils/editor-utils';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
 import { readFiddle } from '../utils/read-fiddle';
 import { AppState } from './state';
-import { getTemplateValues } from './templates';
 import { dotfilesTransform } from './transforms/dotfiles';
 import { forgeTransform } from './transforms/forge';
 
@@ -48,7 +47,9 @@ export class FileManager {
    * @memberof FileManager
    */
   public async openTemplate(templateName: string) {
-    const editorValues = await getTemplateValues(templateName);
+    const editorValues = await window.ElectronFiddle.getTemplateValues(
+      templateName,
+    );
     await window.ElectronFiddle.app.replaceFiddle(editorValues, {
       templateName,
     });

--- a/tests/main/templates-spec.ts
+++ b/tests/main/templates-spec.ts
@@ -1,5 +1,5 @@
 import { MAIN_JS } from '../../src/interfaces';
-import { getTemplateValues } from '../../src/renderer/templates';
+import { getTemplateValues } from '../../src/main/templates';
 import { getEmptyContent } from '../../src/utils/editor-utils';
 
 jest.unmock('fs-extra');

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -7,6 +7,7 @@ export class ElectronFiddleMock {
     home: `~`,
   };
   public arch = process.arch;
+  public getTemplateValues = jest.fn();
   public monaco = new MonacoMock();
   public platform = process.platform;
 }

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -29,6 +29,9 @@ describe('FileManager', () => {
   beforeEach(() => {
     ipcRenderer.send = jest.fn();
     (readFiddle as jest.Mock).mockReturnValue(Promise.resolve(editorValues));
+    (window.ElectronFiddle.getTemplateValues as jest.Mock).mockResolvedValue(
+      editorValues,
+    );
 
     // create a real FileManager and insert it into our mocks
     app = (window.ElectronFiddle.app as unknown) as AppMock;


### PR DESCRIPTION
This is a small transitional PR to make future refactors have smaller diffs.

Can be tested with the "Show Me" menu.