### PR TITLE
fix: resets isQuitting flag to false when user cancels dialog

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -297,6 +297,8 @@ export class App {
               }
               window.onbeforeunload = null;
               window.close();
+            } else {
+              state.isQuitting = false;
             }
           });
           ipcRenderer.send(IpcEvents.SHOW_WINDOW);

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -481,6 +481,7 @@ describe('App component', () => {
       );
       expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
       expect(window.close).not.toHaveBeenCalled();
+      expect(!app.state.isQuitting);
     });
   });
 });


### PR DESCRIPTION
Fixes [#1287](https://github.com/electron/fiddle/issues/1287)

This addresses the issue raised [here](https://github.com/electron/fiddle/issues/1287), where closing the last window quits the app after a quit is cancelled. I just added logic that resets the state's isQuitting flag to false when confirmExitUnsaved returns false. Before this, the isQuitting flag remained true whenever a quit with unsaved data was prompted, regardless of whether it was cancelled or not -- this meant that closing the window afterwards would quit the app. 

I added a line to the end of the 'does nothing if user cancels the dialog' test that checks if the flag is reset.
