### PR TITLE
test: refactor usage of Promise.resolve/Promise.reject

### DIFF
--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -33,9 +33,7 @@ describe('App component', () => {
     const { app: appMock } = ElectronFiddle;
     const { electronTypes, fileManager, remoteLoader, runner, state } = appMock;
     app = new App();
-    jest
-      .spyOn(app.state, 'downloadVersion')
-      .mockImplementation(() => Promise.resolve());
+    jest.spyOn(app.state, 'downloadVersion').mockResolvedValue(undefined);
     Object.assign(app, {
       electronTypes,
       fileManager,
@@ -93,7 +91,7 @@ describe('App component', () => {
 
     it('understands files', async () => {
       const { openFiddle } = app.fileManager;
-      (openFiddle as jest.Mock).mockImplementationOnce(() => Promise.resolve());
+      (openFiddle as jest.Mock).mockResolvedValueOnce(undefined);
 
       const filePath = '/fake/path';
       await app.openFiddle({ filePath });

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -135,7 +135,7 @@ describe('Editors component', () => {
       // setup
       const getTemplateSpy = jest
         .spyOn(content, 'getTemplate')
-        .mockImplementation(() => Promise.resolve(fakeValues));
+        .mockResolvedValue(fakeValues);
       const replaceFiddleSpy = jest
         .spyOn(app, 'replaceFiddle')
         .mockImplementation(() => resolve());
@@ -194,7 +194,7 @@ describe('Editors component', () => {
       // setup
       const getTestTemplateSpy = jest
         .spyOn(content, 'getTestTemplate')
-        .mockImplementation(() => Promise.resolve(fakeValues));
+        .mockResolvedValue(fakeValues);
       let replaceResolve: any;
       const replacePromise = new Promise((r) => {
         replaceResolve = r;

--- a/tests/renderer/content-spec.ts
+++ b/tests/renderer/content-spec.ts
@@ -32,7 +32,7 @@ let lastResponse = new Response(null, {
 
 // instead of downloading fixtures,
 // pull the files from tests/fixtures/templates/
-const fetchFromFilesystem = (url: string) => {
+const fetchFromFilesystem = async (url: string) => {
   let arrayBuffer = null;
   let status = 404;
   let statusText = 'Not Found';
@@ -52,7 +52,7 @@ const fetchFromFilesystem = (url: string) => {
     console.log(err);
   }
   lastResponse = new Response(arrayBuffer, { status, statusText });
-  return Promise.resolve(lastResponse);
+  return lastResponse;
 };
 
 describe('content', () => {

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -77,8 +77,8 @@ describe('ElectronTypes', () => {
 
   function makeFetchSpy(text: string) {
     return jest.spyOn(global, 'fetch').mockResolvedValue({
-      text: () => Promise.resolve(text),
-      json: () => Promise.resolve({ files: nodeTypesData }),
+      text: async () => text,
+      json: async () => ({ files: nodeTypesData }),
     } as any);
   }
 

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -28,7 +28,7 @@ describe('FileManager', () => {
 
   beforeEach(() => {
     ipcRenderer.send = jest.fn();
-    (readFiddle as jest.Mock).mockReturnValue(Promise.resolve(editorValues));
+    (readFiddle as jest.Mock).mockResolvedValue(editorValues);
 
     // create a real FileManager and insert it into our mocks
     app = (window.ElectronFiddle.app as unknown) as AppMock;
@@ -262,7 +262,7 @@ describe('FileManager', () => {
 
     it('handles an error', async () => {
       (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
-      (fs.remove as jest.Mock).mockReturnValueOnce(Promise.reject('bwapbwap'));
+      (fs.remove as jest.Mock).mockRejectedValueOnce('bwapbwap');
 
       const result = await fm.cleanup('/fake/dir');
 

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -19,9 +19,7 @@ describe('npm', () => {
       it('returns true if npm installed', async () => {
         overrideRendererPlatform('darwin');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-npm'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm');
 
@@ -32,9 +30,7 @@ describe('npm', () => {
       it('returns true if npm installed', async () => {
         overrideRendererPlatform('win32');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-npm'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm', true);
 
@@ -45,9 +41,7 @@ describe('npm', () => {
       it('returns false if npm not installed', async () => {
         overrideRendererPlatform('darwin');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.reject('/usr/bin/fake-npm'),
-        );
+        (exec as jest.Mock).mockRejectedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm', true);
 
@@ -56,9 +50,7 @@ describe('npm', () => {
       });
 
       it('uses the cache', async () => {
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-npm'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const one = await getIsPackageManagerInstalled('npm', true);
         expect(one).toBe(true);
@@ -80,9 +72,7 @@ describe('npm', () => {
       it('returns true if yarn installed', async () => {
         overrideRendererPlatform('darwin');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-yarn'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn');
 
@@ -93,9 +83,7 @@ describe('npm', () => {
       it('returns true if yarn installed', async () => {
         overrideRendererPlatform('win32');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-yarn'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn', true);
 
@@ -106,9 +94,7 @@ describe('npm', () => {
       it('returns false if yarn not installed', async () => {
         overrideRendererPlatform('darwin');
 
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.reject('/usr/bin/fake-yarn'),
-        );
+        (exec as jest.Mock).mockRejectedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn', true);
 
@@ -117,9 +103,7 @@ describe('npm', () => {
       });
 
       it('uses the cache', async () => {
-        (exec as jest.Mock).mockReturnValueOnce(
-          Promise.resolve('/usr/bin/fake-yarn'),
-        );
+        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const one = await getIsPackageManagerInstalled('yarn', true);
         expect(one).toBe(true);

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -67,10 +67,10 @@ describe('AppState', () => {
     appState = new AppState(mockVersionsArray);
     removeSpy = jest
       .spyOn(appState.installer, 'remove')
-      .mockImplementation(() => Promise.resolve());
+      .mockResolvedValue(undefined);
     installSpy = jest
       .spyOn(appState.installer, 'install')
-      .mockImplementation(() => Promise.resolve(''));
+      .mockResolvedValue('');
   });
 
   it('exists', () => {

--- a/tests/renderer/themes-spec.tsx
+++ b/tests/renderer/themes-spec.tsx
@@ -58,9 +58,7 @@ describe('themes', () => {
 
     it('handles a readdir error', async () => {
       (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
-      (fs.readdir as jest.Mock).mockImplementationOnce(() =>
-        Promise.reject('Bwap'),
-      );
+      (fs.readdir as jest.Mock).mockRejectedValueOnce('Bwap');
 
       const themes = await getAvailableThemes();
       expect(themes).toHaveLength(2);
@@ -69,9 +67,7 @@ describe('themes', () => {
     it('handles a readJSON error', async () => {
       (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
       (fs.readdir as jest.Mock).mockImplementationOnce(() => ['hi']);
-      (fs.readJSON as jest.Mock).mockImplementationOnce(() =>
-        Promise.reject('Bwap'),
-      );
+      (fs.readJSON as jest.Mock).mockRejectedValueOnce('Bwap');
 
       const themes = await getAvailableThemes();
       expect(themes).toHaveLength(2);
@@ -100,9 +96,7 @@ describe('themes', () => {
     });
 
     it('handles a read error', async () => {
-      (fs.readJSON as jest.Mock).mockImplementationOnce(() =>
-        Promise.reject('Bwap'),
-      );
+      (fs.readJSON as jest.Mock).mockRejectedValueOnce('Bwap');
 
       const theme = await getTheme('test');
       expect(theme.name).toBe('Fiddle (Dark)');

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -62,11 +62,9 @@ export function flushPromises() {
 }
 
 export function mockFetchOnce(text: string) {
-  (window.fetch as jest.Mock).mockImplementationOnce(() => {
-    return Promise.resolve({
-      text: jest.fn().mockResolvedValue(text),
-      json: jest.fn().mockResolvedValue(JSON.parse(text)),
-    });
+  (window.fetch as jest.Mock).mockResolvedValueOnce({
+    text: jest.fn().mockResolvedValue(text),
+    json: jest.fn().mockImplementation(async () => JSON.parse(text)),
   });
 }
 
@@ -76,7 +74,7 @@ export class FetchMock {
     this.urls.set(url, content);
   }
   constructor() {
-    window.fetch = jest.fn().mockImplementation((url: string) => {
+    window.fetch = jest.fn().mockImplementation(async (url: string) => {
       const content = this.urls.get(url);
       if (!content) {
         console.trace('Unhandled mock URL:', url);
@@ -84,13 +82,11 @@ export class FetchMock {
           ok: false,
         };
       }
-      return Promise.resolve({
-        text: jest.fn().mockImplementation(() => Promise.resolve(content)),
-        json: jest
-          .fn()
-          .mockImplementation(() => Promise.resolve(JSON.parse(content))),
+      return {
+        text: jest.fn().mockResolvedValue(content),
+        json: jest.fn().mockImplementation(async () => JSON.parse(content)),
         ok: true,
-      });
+      };
     });
   }
 }

--- a/tests/utils/read-fiddle-spec.ts
+++ b/tests/utils/read-fiddle-spec.ts
@@ -15,9 +15,7 @@ describe('read-fiddle', () => {
   const folder = '/some/place';
 
   beforeEach(() => {
-    (fs.readFile as jest.Mock).mockImplementation((filename) =>
-      Promise.resolve(filename),
-    );
+    (fs.readFile as jest.Mock).mockImplementation(async (filename) => filename);
     console.warn = jest.fn();
   });
 
@@ -27,8 +25,8 @@ describe('read-fiddle', () => {
 
   function setupFSMocks(editorValues: EditorValues) {
     (fs.readdir as jest.Mock).mockResolvedValue(Object.keys(editorValues));
-    (fs.readFile as jest.Mock).mockImplementation((filename) =>
-      Promise.resolve(editorValues[path.basename(filename)]),
+    (fs.readFile as jest.Mock).mockImplementation(
+      async (filename) => editorValues[path.basename(filename)],
     );
   }
 


### PR DESCRIPTION
Most every usage of `Promise.resolve`/`Promise.reject` can be refactored away using Jest's handy helpers, and this simplifies the test code.