### PR TITLE
fix: fall back on invalid fiddle gist version

### DIFF
--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -4,7 +4,12 @@ import { ipcRenderer } from 'electron';
 import * as fs from 'fs-extra';
 import semver from 'semver';
 
-import { FileTransform, Files, PACKAGE_NAME } from '../interfaces';
+import {
+  FileTransform,
+  Files,
+  GenericDialogType,
+  PACKAGE_NAME,
+} from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { isKnownFile } from '../utils/editor-utils';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
@@ -93,14 +98,17 @@ export class FileManager {
           const version = deps[dep].substring(index);
 
           if (!semver.valid(version)) {
-            throw new Error(
-              "This Fiddle's package.json contains an invalid Electron version.",
-            );
+            await this.appState.showGenericDialog({
+              label: `The Electron version (${version}) in this Fiddle's package.json is invalid. Falling back to last used version.`,
+              ok: 'Close',
+              type: GenericDialogType.warning,
+              wantsInput: false,
+            });
+          } else {
+            remoteLoader.setElectronVersion(version);
           }
 
           // We want to include all dependencies except Electron.
-          remoteLoader.setElectronVersion(version);
-
           delete deps[dep];
         }
 

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -146,9 +146,12 @@ export class RemoteLoader {
               !semver.valid(version) ||
               !isReleasedMajor(semver.major(version))
             ) {
-              throw new Error(
-                "This gist's package.json contains an invalid Electron version.",
-              );
+              await this.appState.showGenericDialog({
+                label: `The Electron version (${version}) in this gist's package.json is invalid. Falling back to last used version.`,
+                ok: 'Close',
+                type: GenericDialogType.warning,
+                wantsInput: false,
+              });
             } else if (disableDownload(version)) {
               await this.appState.showGenericDialog({
                 label: `This gist's Electron version (${version}) is not available on your current OS. Falling back to last used version.`,

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -171,11 +171,14 @@ describe('RemoteLoader', () => {
 
       const result = await instance.fetchGistAndLoad(gistId);
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
       expect(store.modules.size).toEqual(0);
-      expect(store.showErrorDialog).toBeCalledWith(
-        "Loading the fiddle failed: This gist's package.json contains an invalid Electron version.",
-      );
+      expect(store.showGenericDialog).toBeCalledWith({
+        label: `The Electron version (99999.0.0) in this gist's package.json is invalid. Falling back to last used version.`,
+        ok: 'Close',
+        type: 'warning',
+        wantsInput: false,
+      });
     });
 
     it('handles extra gist fiddle dependencies', async () => {


### PR DESCRIPTION
In local development, some of us have our testing versions configured to invalid versions of Electron, like `9999.2.1-main` etc. Loading shouldn't totally fail if I try to load a gist made in this scenario - it should just throw up a dialog and fall back.