### PR TITLE
chore: improve Sentry integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           root: .
           paths:
             - out
+            - .webpack
   win-build:
     parameters:
       arch:
@@ -105,6 +106,7 @@ jobs:
           root: .
           paths:
             - out
+            - .webpack
   linux-build:
     parameters:
       arch:
@@ -123,6 +125,7 @@ jobs:
           root: .
           paths:
             - out
+            - .webpack
   publish-to-github:
     docker:
       - image: cimg/base:stable
@@ -134,6 +137,23 @@ jobs:
           at: .
       - load-gh-token
       - run: yarn run publish --from-dry-run
+  notify-sentry-deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - install
+      - attach_workspace:
+          at: .
+      - run:
+          name: Create release and notify Sentry of deploy
+          command: |
+            curl -sL https://sentry.io/get-cli/ | bash
+            export SENTRY_RELEASE=Electron-Fiddle@${CIRCLE_TAG:1}
+            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+            sentry-cli releases set-commits $SENTRY_RELEASE --auto
+            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps ./.webpack
+            sentry-cli releases finalize $SENTRY_RELEASE
+            sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
 
 workflows:
   build-and-test:
@@ -202,6 +222,15 @@ workflows:
           filters:
             tags:
               only: 
+                - /^v.*/
+            branches:
+              ignore: /.*/
+      - notify-sentry-deploy:
+          requires:
+            - publish-to-github
+          filters:
+            tags:
+              only:
                 - /^v.*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
* Adds a CircleCI job to create releases
  * Will upload source maps
  * Will associate releases with the correct commit

Needs @electron/wg-infra to add a "Sentry Internal Integration" and add the token to the CircleCI environment as `SENTRY_AUTH_TOKEN`.

Refs https://docs.sentry.io/product/releases/setup/release-automation/circleci/