### PR TITLE
test: simplify expect code

### DIFF
--- a/rtl-spec/commands-bisect.spec.tsx
+++ b/rtl-spec/commands-bisect.spec.tsx
@@ -64,9 +64,7 @@ describe('Bisect commands component', () => {
       });
       await user.click(goodButton);
       expect(store.Bisector).toBeTruthy();
-      expect(store.Bisector!.continue as jest.Mock).toBeCalledWith(
-        bisectorValue,
-      );
+      expect(store.Bisector!.continue).toBeCalledWith(bisectorValue);
     },
   );
 

--- a/tests/main/content-spec.ts
+++ b/tests/main/content-spec.ts
@@ -83,8 +83,8 @@ describe('content', () => {
 
     it('loads a test template', async () => {
       await getTestTemplate();
-      expect(fetch as jest.Mock).toHaveBeenCalledTimes(1);
-      expect(fetch as jest.Mock).toHaveBeenLastCalledWith(
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenLastCalledWith(
         'https://github.com/electron/electron-quick-start/archive/test-template.zip',
       );
     });

--- a/tests/main/context-menu-spec.ts
+++ b/tests/main/context-menu-spec.ts
@@ -50,17 +50,17 @@ describe('context-menu', () => {
 
       mockWindow.webContents.emit('context-menu', null, mockFlags);
 
-      const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
-
-      expect(template).toHaveLength(8);
-      expect(template[0].id).toBe('run');
-      expect(template[1].id).toBe('clear_console');
-      expect(template[2].type).toBe('separator');
-      expect(template[3].id).toBe('cut');
-      expect(template[4].id).toBe('copy');
-      expect(template[5].id).toBe('paste');
-      expect(template[6].type).toBe('separator');
-      expect(template[7].id).toBe('inspect');
+      expect(Menu.buildFromTemplate).toBeCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'run' }),
+          expect.objectContaining({ id: 'clear_console' }),
+          expect.objectContaining({ type: 'separator' }),
+          expect.objectContaining({ id: 'cut' }),
+          expect.objectContaining({ id: 'paste' }),
+          expect.objectContaining({ type: 'separator' }),
+          expect.objectContaining({ id: 'inspect' }),
+        ]),
+      );
     });
 
     it('creates a default context-menu without inspect in production', () => {
@@ -83,14 +83,18 @@ describe('context-menu', () => {
 
       mockWindow.webContents.emit('context-menu', null, mockFlags);
 
-      const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
-
-      expect(template[3].id).toBe('cut');
-      expect(template[3].enabled).toBe(false);
-      expect(template[4].id).toBe('copy');
-      expect(template[4].enabled).toBe(false);
-      expect(template[5].id).toBe('paste');
-      expect(template[5].enabled).toBe(false);
+      expect(Menu.buildFromTemplate).toBeCalledWith(
+        expect.arrayContaining([
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ id: 'cut', enabled: false }),
+          expect.objectContaining({ id: 'copy', enabled: false }),
+          expect.objectContaining({ id: 'paste', enabled: false }),
+          expect.anything(),
+          expect.anything(),
+        ]),
+      );
     });
 
     it('enables cut/copy/paste if in editFlags', () => {
@@ -108,14 +112,18 @@ describe('context-menu', () => {
         },
       });
 
-      const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
-
-      expect(template[3].id).toBe('cut');
-      expect(template[3].enabled).toBe(true);
-      expect(template[4].id).toBe('copy');
-      expect(template[4].enabled).toBe(true);
-      expect(template[5].id).toBe('paste');
-      expect(template[5].enabled).toBe(true);
+      expect(Menu.buildFromTemplate).toBeCalledWith(
+        expect.arrayContaining([
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ id: 'cut', enabled: true }),
+          expect.objectContaining({ id: 'copy', enabled: true }),
+          expect.objectContaining({ id: 'paste', enabled: true }),
+          expect.anything(),
+          expect.anything(),
+        ]),
+      );
     });
   });
 

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -55,10 +55,7 @@ describe('files', () => {
     it('tries to open an "open" dialog', async () => {
       await showOpenDialog();
 
-      const call = (dialog.showOpenDialog as jest.Mock).mock.calls[0];
-
-      expect(dialog.showOpenDialog).toHaveBeenCalled();
-      expect(call[0]).toEqual({
+      expect(dialog.showOpenDialog).toHaveBeenCalledWith({
         title: 'Open Fiddle',
         properties: ['openDirectory'],
       });
@@ -73,7 +70,6 @@ describe('files', () => {
     });
 
     it('adds the opened file path to recent files', async () => {
-      (app.addRecentDocument as jest.Mock).mock.calls[0];
       await showOpenDialog();
       expect(app.addRecentDocument).toHaveBeenCalled();
     });
@@ -83,10 +79,7 @@ describe('files', () => {
     it('tries to open an "open" dialog to be used as a save dialog', async () => {
       await showSaveDialog();
 
-      const call = (dialog.showOpenDialogSync as jest.Mock).mock.calls[0];
-
-      expect(dialog.showOpenDialogSync).toHaveBeenCalled();
-      expect(call[0]).toEqual({
+      expect(dialog.showOpenDialogSync).toHaveBeenCalledWith({
         buttonLabel: 'Save here',
         properties: ['openDirectory', 'createDirectory'],
         title: 'Save Fiddle',
@@ -96,10 +89,7 @@ describe('files', () => {
     it('tries to open an "open" dialog to be used as a save as dialog', async () => {
       await showSaveDialog(IpcEvents.FS_SAVE_FIDDLE, 'hello');
 
-      const call = (dialog.showOpenDialogSync as jest.Mock).mock.calls[0];
-
-      expect(dialog.showOpenDialogSync).toHaveBeenCalled();
-      expect(call[0]).toEqual({
+      expect(dialog.showOpenDialogSync).toHaveBeenCalledWith({
         buttonLabel: 'Save here',
         properties: ['openDirectory', 'createDirectory'],
         title: 'Save Fiddle as hello',

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -129,7 +129,7 @@ describe('Action button component', () => {
       () => (state.gitHubToken = 'github-token'),
     );
     await instance.handleClick();
-    expect(state.toggleAuthDialog as jest.Mock).toHaveBeenCalled();
+    expect(state.toggleAuthDialog).toHaveBeenCalled();
     expect(instance.performGistAction).toHaveBeenCalled();
   });
 

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -90,6 +90,6 @@ describe('Commands component', () => {
 
     wrapper.find(ControlGroup).at(0).find(Button).simulate('click');
 
-    expect(store.toggleSettings as jest.Mock).toHaveBeenCalled();
+    expect(store.toggleSettings).toHaveBeenCalled();
   });
 });

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -54,8 +54,6 @@ describe('VersionSelect component', () => {
       .find('VersionSelect')
       .prop('onVersionSelect');
     onVersionSelect(mockVersion1);
-    expect(store.setVersion as jest.Mock).toHaveBeenCalledWith(
-      mockVersion1.version,
-    );
+    expect(store.setVersion).toHaveBeenCalledWith(mockVersion1.version);
   });
 });

--- a/tests/renderer/components/dialog-add-theme-spec.tsx
+++ b/tests/renderer/components/dialog-add-theme-spec.tsx
@@ -45,7 +45,7 @@ describe('AddThemeDialog component', () => {
       } catch (err) {
         expect(err.message).toEqual(`Filename  not found`);
         expect(fs.outputJSON).toHaveBeenCalledTimes(0);
-        expect(store.setTheme as jest.Mock).toHaveBeenCalledTimes(0);
+        expect(store.setTheme).toHaveBeenCalledTimes(0);
         expect(shell.showItemInFolder).toHaveBeenCalledTimes(0);
       }
     });
@@ -73,7 +73,7 @@ describe('AddThemeDialog component', () => {
         'themes',
         'testingLight',
       );
-      expect(store.setTheme as jest.Mock).toHaveBeenCalledWith(themePath);
+      expect(store.setTheme).toHaveBeenCalledWith(themePath);
       expect(shell.showItemInFolder).toHaveBeenCalledWith(themePath);
     });
   });

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -110,7 +110,7 @@ describe('AddVersionDialog component', () => {
 
       await (wrapper.instance() as any).onSubmit();
 
-      expect(store.addLocalVersion as jest.Mock).toHaveBeenCalledTimes(0);
+      expect(store.addLocalVersion).toHaveBeenCalledTimes(0);
     });
 
     it('adds a local version using the given data', async () => {
@@ -123,12 +123,13 @@ describe('AddVersionDialog component', () => {
 
       await (wrapper.instance() as any).onSubmit();
 
-      expect(store.addLocalVersion as jest.Mock).toHaveBeenCalledTimes(1);
-
-      const result = (store.addLocalVersion as jest.Mock).mock.calls[0][0];
-
-      expect(result.localPath).toBe('/test/path');
-      expect(result.version).toBe('3.3.3');
+      expect(store.addLocalVersion).toHaveBeenCalledTimes(1);
+      expect(store.addLocalVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          localPath: '/test/path',
+          version: '3.3.3',
+        }),
+      );
     });
 
     it('shows dialog warning when adding duplicate local versions', async () => {

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -124,7 +124,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
       await instance.onSubmit();
       expect(Bisector).toHaveBeenCalledWith(versions.reverse());
       expect(store.Bisector).toBeDefined();
-      expect(store.setVersion as jest.Mock).toHaveBeenCalledWith(version);
+      expect(store.setVersion).toHaveBeenCalledWith(version);
     });
 
     it('does nothing if endIndex or startIndex are falsy', async () => {

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -42,7 +42,7 @@ describe('TokenDialog component', () => {
     );
     await instance.onTokenInputFocused();
 
-    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe(mockValidToken);
   });
 
@@ -55,7 +55,7 @@ describe('TokenDialog component', () => {
     );
     await instance.onTokenInputFocused();
 
-    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 
@@ -68,7 +68,7 @@ describe('TokenDialog component', () => {
     );
     await instance.onTokenInputFocused();
 
-    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 
@@ -81,7 +81,7 @@ describe('TokenDialog component', () => {
     );
     await instance.onTokenInputFocused();
 
-    expect(window.navigator.clipboard.readText as jest.Mock).toHaveBeenCalled();
+    expect(window.navigator.clipboard.readText).toHaveBeenCalled();
     expect(wrapper.state('tokenInput')).toBe('');
   });
 
@@ -130,7 +130,7 @@ describe('TokenDialog component', () => {
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
     instance.openGenerateTokenExternal();
 
-    expect(window.open as jest.Mock).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalled();
   });
 
   describe('onSubmitToken()', () => {

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -55,8 +55,8 @@ describe('Output component', () => {
       instance.outputRef.current = 'ref';
       await instance.initMonaco();
 
-      expect(monaco.editor.create as jest.Mock).toHaveBeenCalled();
-      expect(monaco.editor.createModel as jest.Mock).toHaveBeenCalled();
+      expect(monaco.editor.create).toHaveBeenCalled();
+      expect(monaco.editor.createModel).toHaveBeenCalled();
     });
   });
 
@@ -71,7 +71,7 @@ describe('Output component', () => {
     instance.componentWillUnmount();
 
     expect(
-      ((monaco as unknown) as MonacoMock).latestEditor.dispose as jest.Mock,
+      ((monaco as unknown) as MonacoMock).latestEditor.dispose,
     ).toHaveBeenCalled();
   });
 
@@ -131,8 +131,8 @@ describe('Output component', () => {
     await instance.initMonaco();
     instance.updateModel();
 
-    expect(monaco.editor.createModel as jest.Mock).toHaveBeenCalled();
-    expect(instance.editor.revealLine as jest.Mock).toHaveBeenCalled();
+    expect(monaco.editor.createModel).toHaveBeenCalled();
+    expect(instance.editor.revealLine).toHaveBeenCalled();
   });
 
   it('updateModel correctly observes and gets called when output is updated', async () => {

--- a/tests/renderer/components/settings-credits-spec.tsx
+++ b/tests/renderer/components/settings-credits-spec.tsx
@@ -61,6 +61,6 @@ describe('CreditsSettings component', () => {
     wrapper.setState({ contributors: mockContributors });
 
     wrapper.find('.contributor').simulate('click');
-    expect(window.open as jest.Mock).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalled();
   });
 });

--- a/tests/renderer/components/settings-general-appearance-spec.tsx
+++ b/tests/renderer/components/settings-general-appearance-spec.tsx
@@ -78,7 +78,7 @@ describe('AppearanceSettings component', () => {
     const instance: any = wrapper.instance() as any;
     instance.handleChange({ file: 'defaultLight' } as any);
 
-    expect(store.setTheme as jest.Mock).toHaveBeenCalledWith('defaultLight');
+    expect(store.setTheme).toHaveBeenCalledWith('defaultLight');
   });
 
   it('toggles popover toggle event', () => {

--- a/tests/renderer/components/settings-general-block-accelerators-spec.tsx
+++ b/tests/renderer/components/settings-general-block-accelerators-spec.tsx
@@ -27,7 +27,7 @@ describe('BlockAcceleratorsSettings component', () => {
         currentTarget: { checked: false, value: BlockableAccelerator.save },
       });
 
-      expect(store.removeAcceleratorToBlock as jest.Mock).toHaveBeenCalledWith(
+      expect(store.removeAcceleratorToBlock).toHaveBeenCalledWith(
         BlockableAccelerator.save,
       );
 
@@ -35,7 +35,7 @@ describe('BlockAcceleratorsSettings component', () => {
         currentTarget: { checked: true, value: BlockableAccelerator.save },
       });
 
-      expect(store.addAcceleratorToBlock as jest.Mock).toHaveBeenCalledWith(
+      expect(store.addAcceleratorToBlock).toHaveBeenCalledWith(
         BlockableAccelerator.save,
       );
     });

--- a/tests/renderer/components/tour-welcome-spec.tsx
+++ b/tests/renderer/components/tour-welcome-spec.tsx
@@ -45,7 +45,7 @@ describe('Header component', () => {
     instance.stopTour();
 
     expect(wrapper.state('isTourStarted')).toBe(false);
-    expect(store.disableTour as jest.Mock).toHaveBeenCalled();
+    expect(store.disableTour).toHaveBeenCalled();
   });
 
   describe('getWelcomeTour()', () => {

--- a/tests/renderer/npm-spec.ts
+++ b/tests/renderer/npm-spec.ts
@@ -24,7 +24,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('npm');
 
         expect(result).toBe(true);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('which npm');
+        expect(exec).toBeCalledWith(expect.anything(), 'which npm');
       });
 
       it('returns true if npm installed', async () => {
@@ -35,7 +35,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('npm', true);
 
         expect(result).toBe(true);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('where.exe npm');
+        expect(exec).toBeCalledWith(expect.anything(), 'where.exe npm');
       });
 
       it('returns false if npm not installed', async () => {
@@ -46,7 +46,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('npm', true);
 
         expect(result).toBe(false);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('which npm');
+        expect(exec).toBeCalledWith(expect.anything(), 'which npm');
       });
 
       it('uses the cache', async () => {
@@ -54,11 +54,11 @@ describe('npm', () => {
 
         const one = await getIsPackageManagerInstalled('npm', true);
         expect(one).toBe(true);
-        expect(exec as jest.Mock).toHaveBeenCalledTimes(1);
+        expect(exec).toHaveBeenCalledTimes(1);
 
         const two = await getIsPackageManagerInstalled('npm');
         expect(two).toBe(true);
-        expect(exec as jest.Mock).toHaveBeenCalledTimes(1);
+        expect(exec).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -77,7 +77,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('yarn');
 
         expect(result).toBe(true);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('which yarn');
+        expect(exec).toBeCalledWith(expect.anything(), 'which yarn');
       });
 
       it('returns true if yarn installed', async () => {
@@ -88,7 +88,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('yarn', true);
 
         expect(result).toBe(true);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('where.exe yarn');
+        expect(exec).toBeCalledWith(expect.anything(), 'where.exe yarn');
       });
 
       it('returns false if yarn not installed', async () => {
@@ -99,7 +99,7 @@ describe('npm', () => {
         const result = await getIsPackageManagerInstalled('yarn', true);
 
         expect(result).toBe(false);
-        expect((exec as jest.Mock).mock.calls[0][1]).toBe('which yarn');
+        expect(exec).toBeCalledWith(expect.anything(), 'which yarn');
       });
 
       it('uses the cache', async () => {
@@ -107,11 +107,11 @@ describe('npm', () => {
 
         const one = await getIsPackageManagerInstalled('yarn', true);
         expect(one).toBe(true);
-        expect(exec as jest.Mock).toHaveBeenCalledTimes(1);
+        expect(exec).toHaveBeenCalledTimes(1);
 
         const two = await getIsPackageManagerInstalled('yarn');
         expect(two).toBe(true);
-        expect(exec as jest.Mock).toHaveBeenCalledTimes(1);
+        expect(exec).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -296,7 +296,7 @@ describe('Runner component', () => {
       const result = await instance.autobisect(bisectRange);
 
       expect(result).toBe(RunResult.SUCCESS);
-      expect((store.setVersion as jest.Mock).mock.calls).toHaveLength(2);
+      expect(store.setVersion).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenNthCalledWith(1, LAST_GOOD);
       expect(spy).toHaveBeenNthCalledWith(2, FIRST_BAD);
       expect(store.pushOutput).toHaveBeenLastCalledWith(
@@ -339,9 +339,8 @@ describe('Runner component', () => {
       const bisectResult = await instance.autobisect(bisectRange);
 
       expect(bisectResult).toBe(RunResult.INVALID);
-      expect(store.pushOutput).toHaveBeenCalled();
-      expect((store.pushOutput as jest.Mock).mock.calls.pop()[0]).toMatch(
-        'both returned',
+      expect(store.pushOutput).toHaveBeenLastCalledWith(
+        expect.stringMatching('both returned'),
       );
     }
 

--- a/tests/renderer/themes-spec.tsx
+++ b/tests/renderer/themes-spec.tsx
@@ -19,10 +19,10 @@ describe('themes', () => {
 
       activateTheme(await getTheme());
 
-      expect(editor.defineTheme).toHaveBeenCalled();
       expect(editor.setTheme).toHaveBeenCalled();
-      expect((editor.defineTheme as jest.Mock).mock.calls[0][1].base).toBe(
-        'vs-dark',
+      expect(editor.defineTheme).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ base: 'vs-dark' }),
       );
     });
   });

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -114,11 +114,10 @@ describe('versions', () => {
 
       saveLocalVersions(mockLocalVersions as Array<RunnableVersion>);
 
-      const key = (window.localStorage.setItem as jest.Mock).mock.calls[0][0];
-      const value = (window.localStorage.setItem as jest.Mock).mock.calls[0][1];
-
-      expect(key).toBe(VersionKeys.local);
-      expect(value).toBe(JSON.stringify(mockLocalVersions));
+      expect(window.localStorage.setItem).toBeCalledWith(
+        VersionKeys.local,
+        JSON.stringify(mockLocalVersions),
+      );
     });
   });
 
@@ -171,7 +170,7 @@ describe('versions', () => {
       ];
 
       expect(result).toEqual(expected);
-      expect(window.localStorage.setItem as jest.Mock).toHaveBeenCalled();
+      expect(window.localStorage.setItem).toHaveBeenCalled();
     });
 
     it('fetches versions < 0.24.0', async () => {

--- a/tests/utils/check-first-run-spec.ts
+++ b/tests/utils/check-first-run-spec.ts
@@ -20,7 +20,7 @@ describe('isFirstRun', () => {
   it('reports a first run', () => {
     (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
     expect(isFirstRun()).toBe(true);
-    expect(fs.outputFileSync as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(fs.outputFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('handles an error', () => {

--- a/tests/utils/exec-spec.ts
+++ b/tests/utils/exec-spec.ts
@@ -32,10 +32,15 @@ describe('exec', () => {
       );
 
       const result = await execModule.exec('a/dir', 'echo hi');
-      const call = cpExec.mock.calls[0];
 
-      expect(call[0]).toBe('echo hi');
-      expect(call[1]).toEqual({ cwd: 'a/dir', maxBuffer: 20480000 });
+      expect(cpExec).toBeCalledWith(
+        'echo hi',
+        {
+          cwd: 'a/dir',
+          maxBuffer: 20480000,
+        },
+        expect.anything(),
+      );
       expect(result).toBe('hi');
     });
 


### PR DESCRIPTION
* Remove unnecessary `as jest.Mock` type assertions
* Prefer `toHaveBeenCalledWith` to accessing `.mock.calls` directly