### PR TITLE
fix: properly handle clearing font size setting

### DIFF
--- a/src/renderer/components/settings-general-font.tsx
+++ b/src/renderer/components/settings-general-font.tsx
@@ -51,12 +51,13 @@ export class FontSettings extends React.Component<
   }
 
   /**
-   * Handles a change in the editor font family.
+   * Handles a change in the editor font size.
    *
    * @param {React.FormEvent<HTMLInputElement>} event
    */
   public handleSetFontSize(event: React.FormEvent<HTMLInputElement>): void {
-    const fontSize = parseInt(event.currentTarget.value, 10);
+    const parsedFontSize = parseInt(event.currentTarget.value, 10);
+    const fontSize = isNaN(parsedFontSize) ? undefined : parsedFontSize;
     this.setState({ fontSize });
     this.props.appState.fontSize = fontSize;
   }

--- a/tests/renderer/components/settings-general-font-spec.tsx
+++ b/tests/renderer/components/settings-general-font-spec.tsx
@@ -60,5 +60,16 @@ describe('FontSettings component', () => {
       expect(store.fontSize).toBe(10);
       expect(instance.state.fontSize).toEqual(10);
     });
+
+    it('handles being cleared', async () => {
+      const wrapper = shallow(<FontSettings appState={store} />);
+      const instance = wrapper.instance() as any;
+      await instance.handleSetFontSize({
+        currentTarget: { value: '' },
+      });
+
+      expect(store.fontSize).toBeUndefined();
+      expect(instance.state.fontSize).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Fixes a bug where clearing the font size setting leads to "NaN" and can never be truly cleared.

<img width="878" alt="Screenshot 2023-04-18 at 10 15 55 PM" src="https://user-images.githubusercontent.com/5820654/232973422-88e3c449-ffc2-4fe0-a9b9-be29ab6906a2.png">
