### PR TITLE
fix: add Monaco theme

### DIFF
--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -37,7 +37,6 @@ export const AddThemeDialog = observer(
       this.onSubmit = this.onSubmit.bind(this);
       this.onClose = this.onClose.bind(this);
       this.onChangeFile = this.onChangeFile.bind(this);
-      this.reset = this.reset.bind(this);
     }
 
     /**
@@ -120,8 +119,9 @@ export const AddThemeDialog = observer(
     }
 
     public onClose() {
-      this.props.appState.isThemeDialogShowing = false;
-      this.reset();
+      this.setState(this.resetState, () => {
+        this.props.appState.isThemeDialogShowing = false;
+      });
     }
 
     public render() {
@@ -150,14 +150,6 @@ export const AddThemeDialog = observer(
           </div>
         </Dialog>
       );
-    }
-
-    /**
-     * Reset this component's state
-     */
-    private reset(): void {
-      this.setState(this.resetState);
-      return;
     }
   },
 );

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
 
-import * as path from 'path';
-
 import { Button, Dialog, FileInput } from '@blueprintjs/core';
-import { shell } from 'electron';
 import * as fs from 'fs-extra';
 import { observer } from 'mobx-react';
 import * as MonacoType from 'monaco-editor';
 
 import { AppState } from '../state';
-import { THEMES_PATH, getTheme } from '../themes';
-import { LoadedFiddleTheme, defaultDark } from '../themes-defaults';
+import { createThemeFile, getTheme } from '../themes';
+import { FiddleTheme, defaultDark } from '../themes-defaults';
 
 interface AddThemeDialogProps {
   appState: AppState;
@@ -74,9 +71,12 @@ export const AddThemeDialog = observer(
         const editor = fs.readJSONSync(file.path);
         if (!editor.base && !editor.rules)
           throw Error('File does not match specifications'); // has to have these attributes
-        defaultTheme.editor = editor as Partial<MonacoType.editor.IStandaloneThemeData>;
-        const newTheme = defaultTheme;
-        const name = editor.name ? editor.name : file.name;
+        const newTheme: FiddleTheme = { ...defaultTheme };
+        newTheme.editor = editor as Partial<MonacoType.editor.IStandaloneThemeData>;
+        // Use file.name if no editor.name, and strip file extension (should be .json)
+        const name: string = editor.name
+          ? editor.name
+          : file.name.split('.').reverse().slice(1).reverse().join('.');
         await this.createNewThemeFromMonaco(name, newTheme);
       } catch (error) {
         appState.showErrorDialog(`${error}, please pick a different file.`);
@@ -89,25 +89,14 @@ export const AddThemeDialog = observer(
 
     public async createNewThemeFromMonaco(
       name: string,
-      newTheme: LoadedFiddleTheme,
+      newTheme: FiddleTheme,
     ): Promise<void> {
       if (!name) {
         throw new Error(`Filename ${name} not found`);
       }
 
-      const themePath = path.join(THEMES_PATH, `${name}`);
-
-      await fs.outputJSON(
-        themePath,
-        {
-          ...newTheme,
-          name,
-        },
-        { spaces: 2 },
-      );
-
-      this.props.appState.setTheme(themePath);
-      shell.showItemInFolder(themePath);
+      const theme = await createThemeFile(newTheme, name);
+      this.props.appState.setTheme(theme.file);
     }
 
     get buttons() {

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -75,7 +75,7 @@ export const AddThemeDialog = observer(
         // Use file.name if no editor.name, and strip file extension (should be .json)
         const name: string = editor.name
           ? editor.name
-          : file.name.split('.').reverse().slice(1).reverse().join('.');
+          : file.name.slice(0, file.name.lastIndexOf('.'));
         await this.createNewThemeFromMonaco(name, newTheme);
       } catch (error) {
         appState.showErrorDialog(`${error}, please pick a different file.`);

--- a/src/renderer/themes.ts
+++ b/src/renderer/themes.ts
@@ -71,9 +71,7 @@ export async function createThemeFile(
     Object.entries(theme).filter(([key]) => !['file', 'css'].includes(key)),
   ) as FiddleTheme;
 
-  if (!name) {
-    name = namor.generate({ words: 2, numbers: 0 });
-  }
+  name = name || namor.generate({ words: 2, numbers: 0 });
 
   const file = name.endsWith('.json') ? name : `${name}.json`;
   const themePath = path.join(THEMES_PATH, file);

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -98,6 +98,7 @@ export class StateMock {
   public showInfoDialog = jest.fn();
   public showInputDialog = jest.fn();
   public signOutGitHub = jest.fn();
+  public toggleAddMonacoThemeDialog = jest.fn();
   public toggleAddVersionDialog = jest.fn();
   public toggleAuthDialog = jest.fn();
   public toggleSettings = jest.fn();

--- a/tests/renderer/components/dialog-add-theme-spec.tsx
+++ b/tests/renderer/components/dialog-add-theme-spec.tsx
@@ -19,15 +19,11 @@ jest.mock('../../../src/renderer/themes', () => ({
 }));
 
 class FileMock {
-  private bits: string[];
-  public readonly name: string;
-  public readonly path: string;
-
-  constructor(bits: string[], name: string, path: string) {
-    this.bits = bits;
-    this.name = name;
-    this.path = path;
-  }
+  constructor(
+    private bits: string[],
+    public name: string,
+    public path: string,
+  ) {}
 
   async text() {
     return this.bits.join('');


### PR DESCRIPTION
Fixes adding Monaco themes, which currently don't take effect (and logs warnings). Can be tested using a theme from https://github.com/brijeshb42/monaco-themes/tree/master/themes.

Also fixes a couple of other small bugs around themes in general, refactors out common code, and expands test coverage.