### PR TITLE
refactor: move remaining IPC to preload script

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,6 +1,16 @@
 import * as MonacoType from 'monaco-editor';
 
-import { EditorValues, FiddleEvent, SelectedLocalVersion } from './interfaces';
+import {
+  BisectRequest,
+  BlockableAccelerator,
+  EditorValues,
+  FiddleEvent,
+  MessageOptions,
+  OutputEntry,
+  RunResult,
+  SelectedLocalVersion,
+  TestRequest,
+} from './interfaces';
 import { App } from './renderer/app';
 
 declare global {
@@ -9,6 +19,11 @@ declare global {
       addEventListener(
         type: FiddleEvent,
         listener: () => void,
+        options?: { signal: AbortSignal },
+      ): void;
+      addEventListener(
+        type: 'bisect-task',
+        listener: (request: BisectRequest) => void,
         options?: { signal: AbortSignal },
       ): void;
       addEventListener(
@@ -42,19 +57,36 @@ declare global {
         listener: (filePath: string) => void,
       ): void;
       addEventListener(
+        type: 'test-task',
+        listener: (request: TestRequest) => void,
+        options?: { signal: AbortSignal },
+      ): void;
+      addEventListener(
         type: 'toggle-monaco-option',
         listener: (path: string) => void,
       ): void;
       app: App;
       appPaths: Record<string, string>;
       arch: string;
+      blockAccelerators(acceleratorsToBlock: BlockableAccelerator[]): void;
+      confirmQuit(): void;
       getTemplate(version: string): Promise<EditorValues>;
       getTemplateValues: (name: string) => Promise<EditorValues>;
       getTestTemplate(): Promise<EditorValues>;
+      macTitlebarClicked(): void;
       monaco: typeof MonacoType;
       platform: string;
+      pushOutputEntry(entry: OutputEntry): void;
+      reloadWindows(): void;
       removeAllListeners(type: FiddleEvent): void;
       selectLocalVersion: () => Promise<SelectedLocalVersion | undefined>;
+      sendReady(): void;
+      setNativeTheme(theme: 'dark' | 'light' | 'system'): void;
+      setShowMeTemplate(template?: string): void;
+      showSaveDialog(): void;
+      showWarningDialog(messageOptions: MessageOptions): void;
+      showWindow(): void;
+      taskDone(result: RunResult): void;
     };
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,6 +142,7 @@ export interface SelectedLocalVersion {
 
 export type FiddleEvent =
   | 'before-quit'
+  | 'bisect-task'
   | 'clear-console'
   | 'execute-monaco-command'
   | 'load-example'
@@ -161,6 +162,13 @@ export type FiddleEvent =
   | 'select-all-in-editor'
   | 'set-show-me-template'
   | 'show-welcome-tour'
+  | 'test-task'
   | 'toggle-bisect'
   | 'toggle-monaco-option'
   | 'undo-in-editor';
+
+export interface MessageOptions {
+  message: string;
+  detail?: string;
+  buttons?: string[];
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,10 +1,8 @@
 import * as path from 'path';
 
-import { ipcRenderer } from 'electron';
 import { autorun, reaction, when } from 'mobx';
 
 import { EditorValues, PACKAGE_NAME, SetFiddleOptions } from '../interfaces';
-import { IpcEvents, WEBCONTENTS_READY_FOR_IPC_SIGNAL } from '../ipc-events';
 import { PackageJsonOptions, getPackageJson } from '../utils/get-package';
 import { USER_DATA_PATH } from './constants';
 import { ElectronTypes } from './electron-types';
@@ -78,7 +76,7 @@ export class App {
     this.state.templateName = templateName;
 
     // update menu when a new Fiddle is loaded
-    ipcRenderer.send(IpcEvents.SET_SHOW_ME_TEMPLATE, templateName);
+    window.ElectronFiddle.setShowMeTemplate(templateName);
 
     return true;
   }
@@ -136,10 +134,10 @@ export class App {
     this.setupUnloadListeners();
     this.setupTypeListeners();
 
-    ipcRenderer.send(WEBCONTENTS_READY_FOR_IPC_SIGNAL);
+    window.ElectronFiddle.sendReady();
 
     window.ElectronFiddle.addEventListener('set-show-me-template', () => {
-      ipcRenderer.send(IpcEvents.SET_SHOW_ME_TEMPLATE, this.state.templateName);
+      window.ElectronFiddle.setShowMeTemplate(this.state.templateName);
     });
 
     return rendered;
@@ -169,7 +167,7 @@ export class App {
       () => this.state.isUsingSystemTheme,
       () => {
         if (this.state.isUsingSystemTheme) {
-          ipcRenderer.send(IpcEvents.SET_NATIVE_THEME, 'system');
+          window.ElectronFiddle.setNativeTheme('system');
 
           if (!!window.matchMedia) {
             const { matches } = window.matchMedia(
@@ -227,12 +225,12 @@ export class App {
     if (theme.isDark || theme.name.includes('dark')) {
       document.body.classList.add('bp3-dark');
       if (!this.state.isUsingSystemTheme) {
-        ipcRenderer.send(IpcEvents.SET_NATIVE_THEME, 'dark');
+        window.ElectronFiddle.setNativeTheme('dark');
       }
     } else {
       document.body.classList.remove('bp3-dark');
       if (!this.state.isUsingSystemTheme) {
-        ipcRenderer.send(IpcEvents.SET_NATIVE_THEME, 'light');
+        window.ElectronFiddle.setNativeTheme('light');
       }
     }
   }
@@ -293,7 +291,7 @@ export class App {
               // isQuitting checks if we're trying to quit the app
               // or just close the window
               if (state.isQuitting) {
-                ipcRenderer.send(IpcEvents.CONFIRM_QUIT);
+                window.ElectronFiddle.confirmQuit();
               }
               window.onbeforeunload = null;
               window.close();
@@ -301,7 +299,7 @@ export class App {
               state.isQuitting = false;
             }
           });
-          ipcRenderer.send(IpcEvents.SHOW_WINDOW);
+          window.ElectronFiddle.showWindow();
         });
 
         // return value doesn't matter, we just want to cancel the event

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -10,7 +10,6 @@ import {
   Position,
   Toaster,
 } from '@blueprintjs/core';
-import { ipcRenderer } from 'electron';
 import { when } from 'mobx';
 import { observer } from 'mobx-react';
 
@@ -19,7 +18,6 @@ import {
   GistActionState,
   GistActionType,
 } from '../../interfaces';
-import { IpcEvents } from '../../ipc-events';
 import { ensureRequiredFiles } from '../../utils/editor-utils';
 import { getOctokit } from '../../utils/octokit';
 import { AppState } from '../state';
@@ -164,13 +162,11 @@ export const GistActionButton = observer(
       } catch (error) {
         console.warn(`Could not publish gist`, { error });
 
-        const messageBoxOptions: Electron.MessageBoxOptions = {
+        window.ElectronFiddle.showWarningDialog({
           message:
             'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
           detail: `GitHub encountered the following error: ${error.message}`,
-        };
-
-        ipcRenderer.send(IpcEvents.SHOW_WARNING_DIALOG, messageBoxOptions);
+        });
 
         return false;
       }
@@ -240,14 +236,12 @@ export const GistActionButton = observer(
       } catch (error) {
         console.warn(`Could not update gist`, { error });
 
-        const messageBoxOptions: Electron.MessageBoxOptions = {
+        window.ElectronFiddle.showWarningDialog({
           message:
             'Updating Fiddle Gist failed. Are you connected to the Internet and is this your Gist?',
           detail: `GitHub encountered the following error: ${error.message}`,
           buttons: ['Ok'],
-        };
-
-        ipcRenderer.send(IpcEvents.SHOW_WARNING_DIALOG, messageBoxOptions);
+        });
       }
 
       appState.activeGistAction = GistActionState.none;
@@ -274,13 +268,11 @@ export const GistActionButton = observer(
       } catch (error) {
         console.warn(`Could not delete gist`, { error });
 
-        const messageBoxOptions: Electron.MessageBoxOptions = {
+        window.ElectronFiddle.showWarningDialog({
           message:
             'Deleting Fiddle Gist failed. Are you connected to the Internet, is this your Gist, and have you loaded it?',
           detail: `GitHub encountered the following error: ${error.message}`,
-        };
-
-        ipcRenderer.send(IpcEvents.SHOW_WARNING_DIALOG, messageBoxOptions);
+        });
       }
 
       appState.gistId = undefined;

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
 import { Button, ControlGroup } from '@blueprintjs/core';
-import { ipcRenderer } from 'electron';
 import { observer } from 'mobx-react';
 
-import { IpcEvents } from '../../ipc-events';
 import { AppState } from '../state';
 import { GistActionButton } from './commands-action-button';
 import { AddressBar } from './commands-address-bar';
@@ -32,7 +30,7 @@ export const Commands = observer(
     private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
       // Only maximize if the toolbar itself is clicked (ignore for buttons, input, etc)
       if (e.currentTarget === e.target) {
-        ipcRenderer.send(IpcEvents.CLICK_TITLEBAR_MAC);
+        window.ElectronFiddle.macTitlebarClicked();
       }
     };
 

--- a/src/renderer/components/settings-general-font.tsx
+++ b/src/renderer/components/settings-general-font.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
 import { Button, Callout, FormGroup, InputGroup } from '@blueprintjs/core';
-import { ipcRenderer } from 'electron';
 import { observer } from 'mobx-react';
 
-import { IpcEvents } from '../../ipc-events';
 import { AppState } from '../state';
 
 interface FontSettingsProps {
@@ -62,13 +60,6 @@ export class FontSettings extends React.Component<
     this.props.appState.fontSize = fontSize;
   }
 
-  /**
-   * Reloads the BrowserWindow.
-   */
-  private reloadWindow() {
-    ipcRenderer.send(IpcEvents.RELOAD_WINDOW);
-  }
-
   public render() {
     const { fontFamily, fontSize } = this.state;
     const fontSettingsInstructions =
@@ -97,7 +88,7 @@ export class FontSettings extends React.Component<
               }
             />
             <Button
-              onClick={this.reloadWindow}
+              onClick={window.ElectronFiddle.reloadWindows}
               icon="repeat"
               text="Reload Window"
             />

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { ipcRenderer } from 'electron';
 import * as fs from 'fs-extra';
 import semver from 'semver';
 
@@ -10,7 +9,6 @@ import {
   GenericDialogType,
   PACKAGE_NAME,
 } from '../interfaces';
-import { IpcEvents } from '../ipc-events';
 import { isKnownFile } from '../utils/editor-utils';
 import { DEFAULT_OPTIONS, PackageJsonOptions } from '../utils/get-package';
 import { readFiddle } from '../utils/read-fiddle';
@@ -142,7 +140,7 @@ export class FileManager {
     console.log(`FileManager: Asked to save to ${pathToSave}`);
 
     if (!pathToSave) {
-      ipcRenderer.send(IpcEvents.FS_SAVE_FIDDLE_DIALOG);
+      window.ElectronFiddle.showSaveDialog();
     } else {
       const files = await this.getFiles(undefined, ...transforms);
 
@@ -163,7 +161,7 @@ export class FileManager {
         this.appState.localPath = pathToSave;
         this.appState.gistId = undefined;
       }
-      ipcRenderer.send(IpcEvents.SET_SHOW_ME_TEMPLATE);
+      window.ElectronFiddle.setShowMeTemplate();
       this.appState.editorMosaic.isEdited = false;
     }
   }
@@ -270,7 +268,6 @@ export class FileManager {
       return await fs.outputFile(filePath, content, { encoding: 'utf-8' });
     } catch (error) {
       console.log(`FileManager: Could not save ${filePath}`, error);
-      ipcRenderer.send(IpcEvents.FS_SAVE_FIDDLE_ERROR, [filePath]);
     }
   }
 
@@ -287,7 +284,6 @@ export class FileManager {
       return await fs.remove(filePath);
     } catch (error) {
       console.log(`FileManager: Could not remove ${filePath}`, error);
-      ipcRenderer.send(IpcEvents.FS_SAVE_FIDDLE_ERROR, [filePath]);
     }
   }
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -5,7 +5,6 @@ import {
   ProgressObject,
   Runner,
 } from '@electron/fiddle-core';
-import { ipcRenderer } from 'electron';
 import * as fs from 'fs-extra';
 import {
   action,
@@ -30,7 +29,6 @@ import {
   Version,
   VersionSource,
 } from '../interfaces';
-import { IpcEvents } from '../ipc-events';
 import { getName } from '../utils/get-name';
 import { getUsername } from '../utils/get-username';
 import { normalizeVersion } from '../utils/normalize-version';
@@ -247,7 +245,6 @@ export class AppState {
       resetView: action,
       setIsQuitting: action,
       setPageHash: action,
-      setShowMeMenu: action,
       setTheme: action,
       setVersion: action,
       showChannels: action,
@@ -296,7 +293,6 @@ export class AppState {
     this.toggleBisectDialog = this.toggleBisectDialog.bind(this);
     this.updateElectronVersions = this.updateElectronVersions.bind(this);
     this.setIsQuitting = this.setIsQuitting.bind(this);
-    this.setShowMeMenu = this.setShowMeMenu.bind(this);
     this.addAcceleratorToBlock = this.addAcceleratorToBlock.bind(this);
     this.removeAcceleratorToBlock = this.removeAcceleratorToBlock.bind(this);
     this.hideChannels = this.hideChannels.bind(this);
@@ -378,9 +374,7 @@ export class AppState {
     this.pushOutput('Console ready 🔬');
 
     // set blocked shortcuts
-    ipcRenderer.send(IpcEvents.BLOCK_ACCELERATORS, [
-      ...this.acceleratorsToBlock,
-    ]);
+    window.ElectronFiddle.blockAccelerators([...this.acceleratorsToBlock]);
 
     this.setVersion(this.version);
 
@@ -869,7 +863,7 @@ export class AppState {
       text: strData.trim(),
       timeString: this.timeFmt.format(new Date()),
     };
-    ipcRenderer.send(IpcEvents.OUTPUT_ENTRY, entry);
+    window.ElectronFiddle.pushOutputEntry(entry);
     this.output.push(entry);
   }
 
@@ -885,16 +879,10 @@ export class AppState {
     console.warn(error);
   }
 
-  public async setShowMeMenu() {
-    ipcRenderer.send(IpcEvents.SET_SHOW_ME_TEMPLATE, this.templateName);
-  }
-
   public async addAcceleratorToBlock(acc: BlockableAccelerator) {
     if (!this.acceleratorsToBlock.includes(acc)) {
       this.acceleratorsToBlock = [...this.acceleratorsToBlock, acc];
-      ipcRenderer.send(IpcEvents.BLOCK_ACCELERATORS, [
-        ...this.acceleratorsToBlock,
-      ]);
+      window.ElectronFiddle.blockAccelerators([...this.acceleratorsToBlock]);
     }
   }
 
@@ -903,9 +891,7 @@ export class AppState {
       this.acceleratorsToBlock = this.acceleratorsToBlock.filter(
         (a) => a !== acc,
       );
-      ipcRenderer.send(IpcEvents.BLOCK_ACCELERATORS, [
-        ...this.acceleratorsToBlock,
-      ]);
+      window.ElectronFiddle.blockAccelerators([...this.acceleratorsToBlock]);
     }
   }
 

--- a/src/renderer/task-runner.ts
+++ b/src/renderer/task-runner.ts
@@ -1,5 +1,3 @@
-import { ipcRenderer } from 'electron';
-
 import {
   BisectRequest,
   ElectronReleaseChannel,
@@ -9,7 +7,6 @@ import {
   SetupRequest,
   TestRequest,
 } from '../interfaces';
-import { IpcEvents } from '../ipc-events';
 import { getVersionRange } from '../utils/get-version-range';
 import { normalizeVersion } from '../utils/normalize-version';
 import { App } from './app';
@@ -29,11 +26,10 @@ export class TaskRunner {
 
   constructor(app: App) {
     const { runner, state } = app;
-    const ipc = ipcRenderer;
 
     this.appState = state;
     this.autobisect = runner.autobisect.bind(runner);
-    this.done = (r: RunResult) => ipc.send(IpcEvents.TASK_DONE, r);
+    this.done = (r: RunResult) => window.ElectronFiddle.taskDone(r);
     this.hide = state.hideChannels.bind(state);
     this.showObsoleteVersions = (use: boolean) =>
       (state.showObsoleteVersions = use);
@@ -53,16 +49,19 @@ export class TaskRunner {
     this.show = state.showChannels.bind(state);
 
     this.bisect = this.bisect.bind(this);
-    let event = IpcEvents.TASK_BISECT;
-    ipc.removeAllListeners(event);
-    ipc.on(event, (_, r: BisectRequest) => {
-      this.bisect(r);
-    });
+    window.ElectronFiddle.removeAllListeners('bisect-task');
+    window.ElectronFiddle.addEventListener(
+      'bisect-task',
+      (r: BisectRequest) => {
+        this.bisect(r);
+      },
+    );
 
     this.test = this.test.bind(this);
-    event = IpcEvents.TASK_TEST;
-    ipc.removeAllListeners(event);
-    ipc.on(event, (_, r: TestRequest) => this.test(r));
+    window.ElectronFiddle.removeAllListeners('test-task');
+    window.ElectronFiddle.addEventListener('test-task', (r: TestRequest) =>
+      this.test(r),
+    );
   }
 
   private async bisect(req: BisectRequest) {

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -8,11 +8,23 @@ export class ElectronFiddleMock {
     home: `~`,
   };
   public arch = process.arch;
+  public blockAccelerators = jest.fn();
+  public confirmQuit = jest.fn();
   public getTemplate = jest.fn();
   public getTemplateValues = jest.fn();
   public getTestTemplate = jest.fn();
+  public macTitlebarClicked = jest.fn();
   public monaco = new MonacoMock();
   public platform = process.platform;
+  public pushOutputEntry = jest.fn();
+  public reloadWindows = jest.fn();
   public removeAllListeners = jest.fn();
   public selectLocalVersion = jest.fn();
+  public sendReady = jest.fn();
+  public setNativeTheme = jest.fn();
+  public setShowMeTemplate = jest.fn();
+  public showSaveDialog = jest.fn();
+  public showWarningDialog = jest.fn();
+  public showWindow = jest.fn();
+  public taskDone = jest.fn();
 }

--- a/tests/renderer/components/__snapshots__/settings-general-font-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-font-spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`FontSettings component renders 1`] = `
       />
       <Blueprint3.Button
         icon="repeat"
-        onClick={[Function]}
+        onClick={[MockFunction]}
         text="Reload Window"
       />
     </Blueprint3.FormGroup>

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { ipcRenderer } from 'electron';
 import { shallow } from 'enzyme';
 
 import {
@@ -9,7 +8,6 @@ import {
   GistActionType,
   MAIN_JS,
 } from '../../../src/interfaces';
-import { IpcEvents } from '../../../src/ipc-events';
 import { App } from '../../../src/renderer/app';
 import { GistActionButton } from '../../../src/renderer/components/commands-action-button';
 import { AppState } from '../../../src/renderer/state';
@@ -66,9 +64,6 @@ describe('Action button component', () => {
     // have the octokit getter use our mock
     mocktokit = new OctokitMock();
     (getOctokit as jest.Mock).mockImplementation(() => mocktokit);
-
-    // listen for generated ipc traffic
-    ipcRenderer.send = jest.fn();
 
     // build ExpectedGistCreateOpts
     const editorValues = createEditorValues();
@@ -303,8 +298,9 @@ describe('Action button component', () => {
 
       await instance.performGistAction();
 
-      expect(ipcRenderer.send).toHaveBeenCalledWith(
-        IpcEvents.SHOW_WARNING_DIALOG,
+      expect(
+        window.ElectronFiddle.showWarningDialog as jest.Mock,
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: expect.stringContaining(errorMessage),
           message: expect.stringContaining('Updating Fiddle Gist failed.'),
@@ -339,8 +335,9 @@ describe('Action button component', () => {
 
       await instance.performGistAction();
 
-      expect(ipcRenderer.send).toHaveBeenCalledWith(
-        IpcEvents.SHOW_WARNING_DIALOG,
+      expect(
+        window.ElectronFiddle.showWarningDialog as jest.Mock,
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: expect.stringContaining(errorMessage),
           message: expect.stringContaining('Deleting Fiddle Gist failed.'),

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
 import { Button, ControlGroup } from '@blueprintjs/core';
-import { ipcRenderer } from 'electron';
 import { shallow } from 'enzyme';
 
-import { IpcEvents } from '../../../src/ipc-events';
 import { Commands } from '../../../src/renderer/components/commands';
 import { BisectHandler } from '../../../src/renderer/components/commands-bisect';
 import { AppState } from '../../../src/renderer/state';
@@ -58,21 +56,18 @@ describe('Commands component', () => {
   });
 
   it('handleDoubleClick()', () => {
-    const spy = jest.spyOn(ipcRenderer, 'send');
-
     const wrapper = shallow(<Commands appState={store} />);
     const instance = wrapper.instance() as any;
 
     const tag = { tagName: 'DIV' };
     instance.handleDoubleClick({ target: tag, currentTarget: tag });
 
-    expect(spy).toHaveBeenCalledWith(IpcEvents.CLICK_TITLEBAR_MAC);
-    spy.mockRestore();
+    expect(
+      window.ElectronFiddle.macTitlebarClicked as jest.Mock,
+    ).toHaveBeenCalled();
   });
 
   it('handleDoubleClick() should not handle input tag', () => {
-    const spy = jest.spyOn(ipcRenderer, 'send');
-
     const wrapper = shallow(<Commands appState={store} />);
     const instance = wrapper.instance() as any;
 
@@ -81,8 +76,9 @@ describe('Commands component', () => {
       currentTarget: { tagName: 'DIV' },
     });
 
-    expect(spy).toHaveBeenCalledTimes(0);
-    spy.mockRestore();
+    expect(
+      window.ElectronFiddle.macTitlebarClicked as jest.Mock,
+    ).toHaveBeenCalledTimes(0);
   });
 
   it('show setting', () => {

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -1,5 +1,4 @@
 import { InstallState } from '@electron/fiddle-core';
-import { ipcRenderer } from 'electron';
 
 import {
   EditorValues,
@@ -33,7 +32,6 @@ describe('RemoteLoader', () => {
   beforeEach(() => {
     app = (window.ElectronFiddle.app as unknown) as AppMock;
     ({ state: store } = app);
-    ipcRenderer.send = jest.fn();
     store.channelsToShow = [ElectronReleaseChannel.stable];
     store.initVersions('4.0.0', {
       '4.0.0': { version: '4.0.0' },


### PR DESCRIPTION
Final PR in the `ipcRenderer` series. All usage of `ipcRenderer` is now in the preload script, ready for context isolation (still blocked on usage of Node.js APIs).