### PR TITLE
ci: move Sentry environment variables to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,10 @@ jobs:
   notify-sentry-deploy:
     docker:
       - image: cimg/base:stable
+    environment:
+      SENTRY_ORG: electronjs
+      SENTRY_PROJECT: electron-fiddle
+      SENTRY_ENVIRONMENT: production
     steps:
       - install
       - attach_workspace:


### PR DESCRIPTION
I originally added these to the CircleCI project environment variables for simplicity, but forgot that would cause secrets masking for the values. Having `electronjs` masked in build output isn't a good DX, so push them into the config like Sentry's documentation shows.