### PR TITLE
ci: only persist .webpack on one job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
           root: .
           paths:
             - out
-            - .webpack
   win-build:
     parameters:
       arch:
@@ -105,7 +104,6 @@ jobs:
           root: .
           paths:
             - out
-            - .webpack
   linux-build:
     parameters:
       arch:
@@ -123,7 +121,7 @@ jobs:
           root: .
           paths:
             - out
-            - .webpack
+            - .webpack  # Only persist on one job, output is identical
   publish-to-github:
     docker:
       - image: cimg/base:stable


### PR DESCRIPTION
CircleCI doesn't like having multiple jobs persist the same file: "Concurrent upstream jobs persisted the same file(s) into the workspace". Refs https://app.circleci.com/pipelines/github/electron/fiddle/621/workflows/2f63652c-9b9c-4efd-a870-7b2fb9b3f08c/jobs/1664.

