### PR TITLE
fix: always use __dirname for STATIC_DIR in main process

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,0 +1,3 @@
+import * as path from 'path';
+
+export const STATIC_DIR = path.resolve(__dirname, '../static');

--- a/src/main/content.ts
+++ b/src/main/content.ts
@@ -7,13 +7,9 @@ import * as fs from 'fs-extra';
 import { EditorValues } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { readFiddle } from '../utils/read-fiddle';
+import { STATIC_DIR } from './constants';
 import { ipcMainManager } from './ipc';
 import { isReleasedMajor } from './versions';
-
-const STATIC_DIR =
-  process.env.NODE_ENV === 'production'
-    ? path.join(__dirname, '../../static')
-    : path.join(process.cwd(), './static');
 
 // parent directory of all the downloaded template fiddles
 const TEMPLATES_DIR = path.join(app.getPath('userData'), 'Templates');

--- a/src/main/templates.ts
+++ b/src/main/templates.ts
@@ -6,12 +6,8 @@ import { IpcMainEvent } from 'electron/main';
 import { EditorValues } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { readFiddle } from '../utils/read-fiddle';
+import { STATIC_DIR } from './constants';
 import { ipcMainManager } from './ipc';
-
-const STATIC_DIR =
-  process.env.NODE_ENV === 'production'
-    ? path.join(__dirname, '../../static')
-    : path.join(process.cwd(), './static');
 
 /**
  * Returns expected content for a given name.

--- a/tests/main/content-spec.ts
+++ b/tests/main/content-spec.ts
@@ -12,6 +12,9 @@ import { getTemplate, getTestTemplate } from '../../src/main/content';
 
 jest.mock('cross-fetch');
 jest.unmock('fs-extra');
+jest.mock('../../src/main/constants', () => ({
+  STATIC_DIR: path.join(__dirname, '../../static'),
+}));
 jest.mock('../../src/main/versions', () => ({
   isReleasedMajor: jest.fn().mockResolvedValue(true),
 }));

--- a/tests/main/templates-spec.ts
+++ b/tests/main/templates-spec.ts
@@ -1,8 +1,13 @@
+import * as path from 'path';
+
 import { MAIN_JS } from '../../src/interfaces';
 import { getTemplateValues } from '../../src/main/templates';
 import { getEmptyContent } from '../../src/utils/editor-utils';
 
 jest.unmock('fs-extra');
+jest.mock('../../src/main/constants', () => ({
+  STATIC_DIR: path.join(__dirname, '../../static'),
+}));
 
 describe('templates', () => {
   const KNOWN_GOOD_TEMPLATE = 'clipboard';


### PR DESCRIPTION
Discovered when testing release artifacts for v0.32.3. Tested in both dev mode and production. Since this code was moved to the main process there no longer needs to be a distinction, `__dirname` can be used unconditionally and it will be the right path.