### PR TITLE
chore: don't import from electron/main

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,9 +1,13 @@
 // eslint-disable-next-line import/order
 import { initSentry } from '../sentry';
 initSentry();
-import { BrowserWindow, app, nativeTheme, systemPreferences } from 'electron';
-// eslint-disable-next-line import/no-unresolved
-import { IpcMainEvent } from 'electron/main';
+import {
+  BrowserWindow,
+  IpcMainEvent,
+  app,
+  nativeTheme,
+  systemPreferences,
+} from 'electron';
 
 import { IpcEvents } from '../ipc-events';
 import { isDevMode } from '../utils/devmode';

--- a/src/main/templates.ts
+++ b/src/main/templates.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 
-// eslint-disable-next-line import/no-unresolved
-import { IpcMainEvent } from 'electron/main';
+import { IpcMainEvent } from 'electron';
 
 import { EditorValues } from '../interfaces';
 import { IpcEvents } from '../ipc-events';


### PR DESCRIPTION
No need for the distinction, and gets to drop some `// eslint-disable-next-line` comments.