### PR TITLE
chore: release v0.32.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-fiddle",
   "productName": "Electron Fiddle",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
   "main": "./.webpack/main",


### PR DESCRIPTION
v0.32.3 failed to launch due to a blocker bug in production mode, trying again with the fix.