### PR TITLE
refactor: mirror InstallState from @electron/fiddle-core

### DIFF
--- a/rtl-spec/commands-bisect.spec.tsx
+++ b/rtl-spec/commands-bisect.spec.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { InstallState } from '../src/interfaces';
 import { BisectHandler } from '../src/renderer/components/commands-bisect';
 import { AppState } from '../src/renderer/state';
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,3 @@
-import { InstallState } from '@electron/fiddle-core';
-
 export type Files = Map<string, string>;
 
 export type FileTransform = (files: Files) => Promise<Files>;
@@ -27,6 +25,14 @@ export interface Version {
   name?: string;
   localPath?: string;
   node?: string;
+}
+
+export enum InstallState {
+  missing = 'missing',
+  downloading = 'downloading',
+  downloaded = 'downloaded',
+  installing = 'installing',
+  installed = 'installed',
 }
 
 export enum RunResult {

--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { Button } from '@blueprintjs/core';
-import { InstallState } from '@electron/fiddle-core';
 import { observer } from 'mobx-react';
 
+import { InstallState } from '../../interfaces';
 import { AppState } from '../state';
 
 interface BisectHandlerProps {

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { Button, ButtonProps, Spinner } from '@blueprintjs/core';
-import { InstallState } from '@electron/fiddle-core';
 import { observer } from 'mobx-react';
 
+import { InstallState } from '../../interfaces';
 import { AppState } from '../state';
 
 interface RunnerProps {

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -14,11 +14,11 @@ import {
   Spinner,
   Tooltip,
 } from '@blueprintjs/core';
-import { InstallState } from '@electron/fiddle-core';
 import { observer } from 'mobx-react';
 
 import {
   ElectronReleaseChannel,
+  InstallState,
   RunnableVersion,
   VersionSource,
 } from '../../interfaces';

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -16,12 +16,11 @@ import {
   ItemRenderer,
   Select,
 } from '@blueprintjs/select';
-import { InstallState } from '@electron/fiddle-core';
 import { observer } from 'mobx-react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import semver from 'semver';
 
-import { RunnableVersion, VersionSource } from '../../interfaces';
+import { InstallState, RunnableVersion, VersionSource } from '../../interfaces';
 import { disableDownload } from '../../utils/disable-download';
 import { highlightText } from '../../utils/highlight-text';
 import { AppState } from '../state';

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -1,10 +1,10 @@
-import { InstallState } from '@electron/fiddle-core';
 import semver from 'semver';
 
 import {
   EditorValues,
   ElectronReleaseChannel,
   GenericDialogType,
+  InstallState,
   PACKAGE_NAME,
   VersionSource,
 } from '../interfaces';

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -1,9 +1,14 @@
 import { ChildProcess } from 'child_process';
 import * as path from 'path';
 
-import { InstallState, Installer } from '@electron/fiddle-core';
+import { Installer } from '@electron/fiddle-core';
 
-import { FileTransform, RunResult, RunnableVersion } from '../interfaces';
+import {
+  FileTransform,
+  InstallState,
+  RunResult,
+  RunnableVersion,
+} from '../interfaces';
 import { PackageJsonOptions } from '../utils/get-package';
 import { maybePlural } from '../utils/plural-maybe';
 import { Bisector } from './bisect';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -1,6 +1,5 @@
 import {
   BaseVersions,
-  InstallState,
   Installer,
   ProgressObject,
   Runner,
@@ -22,6 +21,7 @@ import {
   GenericDialogOptions,
   GenericDialogType,
   GistActionState,
+  InstallState,
   OutputEntry,
   OutputOptions,
   RunnableVersion,

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -1,10 +1,11 @@
-import { InstallState, Installer } from '@electron/fiddle-core';
+import { Installer } from '@electron/fiddle-core';
 import * as fs from 'fs-extra';
 import semver from 'semver';
 
 import releasesJSON from '../../static/releases.json';
 import {
   ElectronReleaseChannel,
+  InstallState,
   RunnableVersion,
   Version,
   VersionSource,

--- a/tests/install-state-spec.ts
+++ b/tests/install-state-spec.ts
@@ -1,0 +1,9 @@
+import { InstallState as FiddleCoreInstallState } from '@electron/fiddle-core';
+
+import { InstallState } from '../src/interfaces';
+
+describe('InstallState', () => {
+  it('is in-sync with @electron/fiddle-core', async () => {
+    expect(InstallState).toStrictEqual(FiddleCoreInstallState);
+  });
+});

--- a/tests/mocks/electron-versions.ts
+++ b/tests/mocks/electron-versions.ts
@@ -1,6 +1,8 @@
-import { InstallState } from '@electron/fiddle-core';
-
-import { RunnableVersion, VersionSource } from '../../src/interfaces';
+import {
+  InstallState,
+  RunnableVersion,
+  VersionSource,
+} from '../../src/interfaces';
 
 export class VersionsMock {
   public readonly mockVersions: Record<string, RunnableVersion>;

--- a/tests/mocks/fiddle-core.ts
+++ b/tests/mocks/fiddle-core.ts
@@ -1,5 +1,6 @@
-import { InstallState, Installer } from '@electron/fiddle-core';
+import { Installer } from '@electron/fiddle-core';
 
+import { InstallState } from '../../src/interfaces';
 import { ChildProcessMock } from './child-process';
 
 export class InstallerMock extends Installer {

--- a/tests/renderer/bisect-spec.ts
+++ b/tests/renderer/bisect-spec.ts
@@ -1,6 +1,4 @@
-import { InstallState } from '@electron/fiddle-core';
-
-import { VersionSource } from '../../src/interfaces';
+import { InstallState, VersionSource } from '../../src/interfaces';
 import { Bisector } from '../../src/renderer/bisect';
 
 const generateVersionRange = (rangeLength: number) =>

--- a/tests/renderer/components/commands-runner-spec.tsx
+++ b/tests/renderer/components/commands-runner-spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { shallow } from 'enzyme';
 
+import { InstallState } from '../../../src/interfaces';
 import { Runner } from '../../../src/renderer/components/commands-runner';
 import { AppState } from '../../../src/renderer/state';
 

--- a/tests/renderer/components/commands-version-chooser-spec.tsx
+++ b/tests/renderer/components/commands-version-chooser-spec.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { mount, shallow } from 'enzyme';
 
-import { ElectronReleaseChannel, VersionSource } from '../../../src/interfaces';
+import {
+  ElectronReleaseChannel,
+  InstallState,
+  VersionSource,
+} from '../../../src/interfaces';
 import { VersionChooser } from '../../../src/renderer/components/commands-version-chooser';
 import { AppState } from '../../../src/renderer/state';
 import { StateMock, VersionsMock } from '../../mocks/mocks';

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { shallow } from 'enzyme';
 
 import {
   ElectronReleaseChannel,
+  InstallState,
   RunResult,
   VersionSource,
 } from '../../../src/interfaces';

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { mount, shallow } from 'enzyme';
 
 import {
   ElectronReleaseChannel,
+  InstallState,
   RunnableVersion,
   VersionSource,
 } from '../../../src/interfaces';

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import { InstallState } from '@electron/fiddle-core';
 import { shallow } from 'enzyme';
 
 import {
   ElectronReleaseChannel,
+  InstallState,
   RunnableVersion,
   VersionSource,
 } from '../../../src/interfaces';

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -1,10 +1,13 @@
 import * as path from 'path';
 
-import { InstallState } from '@electron/fiddle-core';
 import * as fs from 'fs-extra';
 import * as tmp from 'tmp';
 
-import { RunnableVersion, VersionSource } from '../../src/interfaces';
+import {
+  InstallState,
+  RunnableVersion,
+  VersionSource,
+} from '../../src/interfaces';
 import { ElectronTypes } from '../../src/renderer/electron-types';
 import { MonacoMock, NodeTypesMock } from '../mocks/mocks';
 import { waitFor } from '../utils';

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -1,8 +1,7 @@
-import { InstallState } from '@electron/fiddle-core';
-
 import {
   EditorValues,
   ElectronReleaseChannel,
+  InstallState,
   MAIN_JS,
   PACKAGE_NAME,
   VersionSource,

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -1,9 +1,9 @@
 import * as path from 'path';
 
-import { InstallState } from '@electron/fiddle-core';
 import * as semver from 'semver';
 
 import {
+  InstallState,
   RunResult,
   RunnableVersion,
   VersionSource,

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,10 +1,10 @@
-import { InstallState } from '@electron/fiddle-core';
 import { reaction } from 'mobx';
 
 import {
   BlockableAccelerator,
   ElectronReleaseChannel,
   GenericDialogType,
+  InstallState,
   MAIN_JS,
   RunnableVersion,
   Version,

--- a/tests/renderer/task-runner-spec.tsx
+++ b/tests/renderer/task-runner-spec.tsx
@@ -1,9 +1,8 @@
-import { InstallState } from '@electron/fiddle-core';
-
 import {
   BisectRequest,
   ElectronReleaseChannel,
   FiddleEvent,
+  InstallState,
   RunResult,
   RunnableVersion,
   TestRequest,

--- a/tests/utils/sort-versions-spec.ts
+++ b/tests/utils/sort-versions-spec.ts
@@ -1,6 +1,8 @@
-import { InstallState } from '@electron/fiddle-core';
-
-import { RunnableVersion, VersionSource } from '../../src/interfaces';
+import {
+  InstallState,
+  RunnableVersion,
+  VersionSource,
+} from '../../src/interfaces';
 import { sortVersions } from '../../src/utils/sort-versions';
 
 describe('sort-versions', () => {


### PR DESCRIPTION
Extracted from #1204, with a test added to ensure it doesn't diverge from `@electron/fiddle-core` - although in most cases usage would cause a TypeScript error if something did change.

There may be more elegant ways to accomplish this, but this was the quickest/simplest. For full context, `@electron/fiddle-core` can't imported in the renderer process because it uses Node.js APIs.