### PR TITLE
build: use @electron/fiddle-core to fetch releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@blueprintjs/core": "^3.36.0",
     "@blueprintjs/popover2": "^0.12.2",
     "@blueprintjs/select": "^3.15.0",
-    "@electron/fiddle-core": "^1.2.2",
+    "@electron/fiddle-core": "^1.3.0",
     "@octokit/rest": "^16.43.1",
     "@sentry/electron": "^4.4.0",
     "algoliasearch": "^4.12.0",

--- a/tools/fetch-releases.js
+++ b/tools/fetch-releases.js
@@ -1,30 +1,20 @@
 const path = require('path');
 
-const fetch = require('cross-fetch');
+const { ElectronVersions } = require('@electron/fiddle-core');
 const fs = require('fs-extra');
 
 const file = path.join(__dirname, '..', 'static', 'releases.json');
 
-async function getReleases() {
-  const url = 'https://releases.electronjs.org/releases.json';
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'Electron Fiddle',
-    },
-  });
-  return await response.json();
-}
-
 async function populateReleases() {
-  const data = await getReleases();
-  const releases = data.map(({ version, node }) => ({ version, node }));
+  const elves = await ElectronVersions.create(undefined, { ignoreCache: true });
+  const releases = elves.versions.map(({ version }) =>
+    elves.getReleaseInfo(version),
+  );
 
   console.log(`Updating local releases.json with ${releases.length} versions.`);
 
   await fs.remove(file);
-  await fs.outputFile(file, JSON.stringify(releases));
-
-  console.log('Updating tests with new expected version count.');
+  await fs.outputJSON(file, releases);
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,10 +922,10 @@
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
-"@electron/fiddle-core@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@electron/fiddle-core/-/fiddle-core-1.2.2.tgz#33a89618505c4918fd339f7f08ba8f1155551d84"
-  integrity sha512-3YVgKCFQrJ5KHy9CYxtUSO97FVXDPcTFJhQcifDuSh2gTiGRHvXY1sVVp59kUGdwa2kl0sNMhRkJCmHDR88tfw==
+"@electron/fiddle-core@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@electron/fiddle-core/-/fiddle-core-1.3.0.tgz#8303629badc72c2a0d5029d13e0cb701fd06d6a1"
+  integrity sha512-RlH4j0RtcRHMVQCaiC/xS8UmvmmgTqCJI8Iw+GIUTswzA7WrXRPCTX+izvb2NiBmpf0Ll/+GPuQ1VtV9v3P7pA==
   dependencies:
     "@electron/get" "^2.0.0"
     debug "^4.3.3"


### PR DESCRIPTION
Simplifies this script and ensures `static/releases.json` is in-sync with what `@electron/fiddle-core` expects since it is the consumer. To that end it now populates the full release info (effectively just `releases.json` unmodified) so that it can be used in future PRs to pull Node.js versions and ABI info.