### PR TITLE
fix: use yarn install if no modules to add

### DIFF
--- a/src/main/npm.ts
+++ b/src/main/npm.ts
@@ -57,14 +57,15 @@ export async function addModules(
   ...names: Array<string>
 ): Promise<string> {
   let nameArgs: Array<string> = [];
+  let installCommand: string;
 
   if (packageManager === 'npm') {
+    installCommand = 'npm install';
     nameArgs = names.length > 0 ? ['-S', ...names] : ['--also=dev --prod'];
   } else {
+    installCommand = names.length > 0 ? 'yarn add' : 'yarn install';
     nameArgs = [...names];
   }
-
-  const installCommand = packageManager === 'npm' ? 'npm install' : 'yarn add';
 
   return exec(dir, [installCommand].concat(nameArgs).join(' '));
 }

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -483,12 +483,13 @@ export class Runner {
    * @memberof Runner
    */
   public async packageInstall(options: PMOperationOptions): Promise<boolean> {
+    const pm = options.packageManager;
     try {
-      this.appState.pushOutput(`Now running "npm install..."`);
+      this.appState.pushOutput(`Now running "${pm} install..."`);
       this.appState.pushOutput(await window.ElectronFiddle.addModules(options));
       return true;
     } catch (error) {
-      this.appState.pushError('Failed to run "npm install".', error);
+      this.appState.pushError(`Failed to run "${pm} install".`, error);
     }
 
     return false;

--- a/tests/main/npm-spec.ts
+++ b/tests/main/npm-spec.ts
@@ -158,7 +158,7 @@ describe('npm', () => {
       it('attempts to installs all modules', async () => {
         addModules({ dir: '/my/directory', packageManager: 'yarn' });
 
-        expect(exec).toHaveBeenCalledWith<any>('/my/directory', 'yarn add');
+        expect(exec).toHaveBeenCalledWith<any>('/my/directory', 'yarn install');
       });
     });
   });


### PR DESCRIPTION
`yarn add` run by itself causes an error, if there are no specific modules to add, you need to use `yarn install`.