### PR TITLE
fix: check if already installing version

### DIFF
--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -602,10 +602,11 @@ export class AppState {
     const isRemote = source === VersionSource.remote;
     const isDownloaded = state === InstallState.downloaded;
     const isDownloading = state === InstallState.downloading;
+    const isInstalling = state === InstallState.installing;
     const isReady = state === InstallState.installed;
 
-    if (isDownloading) {
-      console.log(`State: Already downloading ${version}.`);
+    if (isDownloading || isInstalling) {
+      console.log(`State: Already ${state} ${version}.`);
       return;
     }
 


### PR DESCRIPTION
Should fix this issue reported on Sentry.

---

Sentry Issue: [ELECTRON-FIDDLE-70G](https://electronjs.sentry.io/issues/4134810710/?referrer=github_integration)

```
Error: Currently installing "24.1.3"
  at Installer.install (./node_modules/@electron/fiddle-core/dist/installer.js:283:19)
  at t.AppState.downloadVersion (./src/renderer/state.ts:647:26)
  at executeAction (./node_modules/mobx/dist/mobx.esm.js:1255:15)
  at res (./node_modules/mobx/dist/mobx.esm.js:1239:12)
  at t.AppState.setVersion (./src/renderer/state.ts:740:16)
```