### PR TITLE
build: don't clobber existing releases.json on fetch failure

### DIFF
--- a/tools/fetch-releases.js
+++ b/tools/fetch-releases.js
@@ -11,10 +11,20 @@ async function populateReleases() {
     elves.getReleaseInfo(version),
   );
 
-  console.log(`Updating local releases.json with ${releases.length} versions.`);
+  if (releases.length) {
+    console.log(
+      `Updating local releases.json with ${releases.length} versions.`,
+    );
 
-  await fs.remove(file);
-  await fs.outputJSON(file, releases);
+    await fs.remove(file);
+    await fs.outputJSON(file, releases);
+  } else if (process.env.CI) {
+    throw new Error('Failed to fetch latest releases.json');
+  } else {
+    console.warn(
+      'Failed to fetch latest releases.json, falling back to whatever exists on disk',
+    );
+  }
 }
 
 module.exports = {

--- a/tools/fetch-releases.js
+++ b/tools/fetch-releases.js
@@ -16,7 +16,6 @@ async function populateReleases() {
       `Updating local releases.json with ${releases.length} versions.`,
     );
 
-    await fs.remove(file);
     await fs.outputJSON(file, releases);
   } else if (process.env.CI) {
     throw new Error('Failed to fetch latest releases.json');


### PR DESCRIPTION
Better handles things like doing a build with no network access after previously having done a build (clobbers `static/releases.json` at the moment) and allows for builds in a clean environment with no network access to patch `static/releases.json` and not have it clobbered.