### PR TITLE
build: do initial fetch of releases in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:report": "jest --config=jest.json --json --bail=false --outputFile=report.json | true",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "node --unhandled-rejections=strict ./tools/fetch-releases.js",
-    "postinstall": "husky install"
+    "postinstall": "husky install && npm run electron-releases"
   },
   "keywords": [
     "Electron",


### PR DESCRIPTION
Improves the DX by ensuring that `static/releases.json` will be populated. In the current state without this change, a developer could clone the repo, run `yarn install`, and then later without network access run `yarn start` and find things wouldn't work due to the empty `static/releases.json`. Populating it in `postinstall` should prevent that since they'll likely have network access when they run `yarn install`.