### PR TITLE
ci: use --url-prefix when uploading source maps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             export SENTRY_RELEASE=Electron-Fiddle@${CIRCLE_TAG:1}
             sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
             sentry-cli releases set-commits $SENTRY_RELEASE --auto
-            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps ./.webpack
+            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps --url-prefix=~/.webpack ./.webpack/
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
 


### PR DESCRIPTION
Did some testing over the last couple of releases and this seems necessary to get proper source mapping on Sentry.