### PR TITLE
fix: get Node.js typings for newly released versions

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,3 +1,4 @@
+import { ReleaseInfo } from '@electron/fiddle-core';
 import * as MonacoType from 'monaco-editor';
 
 import {
@@ -95,6 +96,7 @@ declare global {
       getLatestStable(): SemVer | undefined;
       getLocalVersionState(ver: Version): InstallState;
       getOldestSupportedMajor(): number | undefined;
+      getReleaseInfo(version: string): Promise<ReleaseInfo | undefined>;
       getReleasedVersions(): Array<Version>;
       isDevMode: boolean;
       isReleasedMajor(major: number): Promise<boolean>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,7 +24,6 @@ export interface Version {
   version: string;
   name?: string;
   localPath?: string;
-  node?: string;
 }
 
 export enum InstallState {

--- a/src/main/versions.ts
+++ b/src/main/versions.ts
@@ -98,6 +98,10 @@ export async function setupVersions() {
   ipcMainManager.on(IpcEvents.GET_RELEASED_VERSIONS, (event) => {
     event.returnValue = getReleasedVersions();
   });
+  ipcMainManager.handle(
+    IpcEvents.GET_RELEASE_INFO,
+    (_: IpcMainEvent, version) => knownVersions.getReleaseInfo(version),
+  );
 
   return knownVersions;
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -94,6 +94,9 @@ export async function setupFiddleGlobal() {
     getReleasedVersions() {
       return ipcRenderer.sendSync(IpcEvents.GET_RELEASED_VERSIONS);
     },
+    getReleaseInfo(version: string) {
+      return ipcRenderer.invoke(IpcEvents.GET_RELEASE_INFO, version);
+    },
     getAvailableThemes() {
       return ipcRenderer.invoke(IpcEvents.GET_AVAILABLE_THEMES);
     },

--- a/src/renderer/electron-types.ts
+++ b/src/renderer/electron-types.ts
@@ -7,9 +7,7 @@ import packageJson from 'package-json';
 import readdir from 'recursive-readdir';
 import semver from 'semver';
 
-import releases from '../../static/releases.json';
-import { RunnableVersion, Version, VersionSource } from '../interfaces';
-import { normalizeVersion } from '../utils/normalize-version';
+import { RunnableVersion, VersionSource } from '../interfaces';
 
 const ELECTRON_DTS = 'electron.d.ts';
 
@@ -63,9 +61,7 @@ export class ElectronTypes {
 
   private async setNodeTypes(version: string): Promise<void> {
     // Get the Node.js version corresponding to the current Electron version.
-    const v = releases.find((release: Version) => {
-      return normalizeVersion(release.version) === version;
-    })?.node;
+    const v = (await window.ElectronFiddle.getReleaseInfo(version))?.node;
 
     if (!v) return;
 

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -18,6 +18,7 @@ export class ElectronFiddleMock {
   public getLatestStable = jest.fn();
   public getLocalVersionState = jest.fn();
   public getOldestSupportedMajor = jest.fn();
+  public getReleaseInfo = jest.fn();
   public getReleasedVersions = jest.fn();
   public getTemplate = jest.fn();
   public getTemplateValues = jest.fn();

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -160,6 +160,10 @@ describe('ElectronTypes', () => {
     });
 
     it('fetches types', async () => {
+      (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue({
+        node: '16.2.0',
+      });
+
       const types = 'here are the types';
       const fetchSpy = makeFetchSpy(types);
 
@@ -214,6 +218,15 @@ describe('ElectronTypes', () => {
       const spy = makeFetchSpy('Cannot find package');
       await electronTypes.setVersion(remoteVersion);
       expect(spy).toHaveBeenCalledTimes(1);
+      expect(addExtraLib).not.toHaveBeenCalled();
+    });
+
+    it('does not crash if no release info', async () => {
+      (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue(
+        undefined,
+      );
+
+      await electronTypes.setVersion(remoteVersion);
       expect(addExtraLib).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Fixes #1222.