### PR TITLE
refactor: pull nightly ABI from release info

### DIFF
--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -1,11 +1,5 @@
-import { execSync } from 'child_process';
-import * as path from 'path';
-
-import { Installer } from '@electron/fiddle-core';
-
 import { Files, PACKAGE_NAME } from '../../interfaces';
 import { getForgeVersion } from '../../utils/get-package';
-import { ELECTRON_DOWNLOAD_PATH } from '../constants';
 
 /**
  * This transform turns the files into an electron-forge
@@ -47,15 +41,12 @@ export async function forgeTransform(files: Files): Promise<Files> {
       const nightlyVersion = devDependencies['electron-nightly'];
       if (nightlyVersion) {
         // Fetch forced ABI for nightly.
-        const binaryPath = Installer.getExecPath(
-          path.join(ELECTRON_DOWNLOAD_PATH, nightlyVersion),
-        );
-        const abi = execSync(
-          `ELECTRON_RUN_AS_NODE=1 "${binaryPath}" -p process.versions.modules`,
-        );
+        const { modules } = (await window.ElectronFiddle.getReleaseInfo(
+          nightlyVersion,
+        ))!;
 
         config.forge.electronRebuildConfig = {
-          forceABI: abi.toString().trim(),
+          forceABI: parseInt(modules.toString().trim()),
         };
       }
 

--- a/tests/transforms/forge-spec.ts
+++ b/tests/transforms/forge-spec.ts
@@ -57,4 +57,31 @@ describe('forgeTransform()', () => {
     const files = await forgeTransform(filesBefore);
     expect(files.get(PACKAGE_NAME)).toBe('garbage');
   });
+
+  it('forces ABI for nightly builds', async () => {
+    (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue({
+      version: '26.0.0-nightly.20230411',
+      modules: '116',
+    });
+    const filesBefore = new Map();
+    filesBefore.set(
+      PACKAGE_NAME,
+      JSON.stringify({
+        devDependencies: {
+          'electron-nightly': '26.0.0-nightly.20230411',
+        },
+      }),
+    );
+
+    const files = await forgeTransform(filesBefore);
+    expect(JSON.parse(files.get(PACKAGE_NAME)!)).toMatchObject({
+      config: {
+        forge: {
+          electronRebuildConfig: {
+            forceABI: 116,
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Don't need to run the nightly Electron executable just to get the ABI, that's available from `@electron/fiddle-core` now.