### PR TITLE
fix: show exact match deprecated npm packages in search

### DIFF
--- a/src/renderer/npm-search.tsx
+++ b/src/renderer/npm-search.tsx
@@ -36,6 +36,7 @@ class NPMSearch {
     } else {
       const result = await this.index.search<AlgoliaHit>(query, {
         hitsPerPage: 5,
+        optionalFilters: [`objectID:${query}`],
       });
       this.searchCache.set(query, result);
       return result;

--- a/tests/renderer/npm-search-spec.ts
+++ b/tests/renderer/npm-search-spec.ts
@@ -1,0 +1,8 @@
+import { npmSearch } from '../../src/renderer/npm-search';
+
+describe('npm-search', () => {
+  it('can find deprecated packages by exact name', async () => {
+    const result = await npmSearch.search('webusb');
+    expect(result.hits.find((hit) => hit.name === 'webusb')).toBeDefined();
+  });
+});


### PR DESCRIPTION
The npm search functionality added in https://github.com/electron/fiddle/pull/959 only shows the top 5 results, and you can't force a package name, only select from that list of packages. For whatever reason, the boosting exact matches to the top doesn't occur (upstream issue) if the package is deprecated. The end result is you're unable to add deprecated packages since there will be 5 search results ahead of them in the list.

Tried various incantations to improve the situation, and this is the one that was effective. For unknown reasons filtering on `name` yields zero results, but filtering on `objectID` bumps the package to the top. Since `objectID === name` is (somewhat of) an implementation detail of `algolia/npm-search`, add a test to ensure it doesn't regress.