### PR TITLE
chore: only one console log for monaco Node.js lib update

### DIFF
--- a/src/renderer/electron-types.ts
+++ b/src/renderer/electron-types.ts
@@ -81,16 +81,17 @@ export class ElectronTypes {
 
   private async setTypesFromDir(dir: string, version: string) {
     try {
-      const files = await readdir(dir);
+      const files = (await readdir(dir)).filter((f) => f.endsWith('.d.ts'));
+      console.log(
+        `Updating Monaco with files for Node.js ${version}:`,
+        files.map((f) => path.parse(f).base),
+      );
+
       for (const file of files) {
-        if (file.endsWith('.d.ts')) {
-          const { base: filename } = path.parse(file);
-          console.log(`Updating Monaco with "${filename}@${version}"`);
-          const lib = this.monaco.languages.typescript.javascriptDefaults.addExtraLib(
-            fs.readFileSync(file, 'utf8'),
-          );
-          this.disposables.push(lib);
-        }
+        const lib = this.monaco.languages.typescript.javascriptDefaults.addExtraLib(
+          fs.readFileSync(file, 'utf8'),
+        );
+        this.disposables.push(lib);
       }
     } catch (err) {
       console.debug(`Unable to read types from "${dir}": ${err.message}`);


### PR DESCRIPTION
Cleans up logging when switching Node.js versions to reduce console clutter:

<details><summary>Before</summary>
<img width="560" alt="Screenshot 2023-05-16 at 11 35 22 AM" src="https://github.com/electron/fiddle/assets/2036040/a6a2aa1e-16b1-4aed-b269-193c026a0d6f">
</details>

<details><summary>After</summary>
<img width="574" alt="Screenshot 2023-05-16 at 11 36 16 AM" src="https://github.com/electron/fiddle/assets/2036040/2e719a4e-1199-4ffb-b814-2560a97b5325">
</details>