### PR TITLE
feat: add protocol api example

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -21,6 +21,7 @@ export const SHOW_ME_TEMPLATES: Templates = {
     Notification: 'Notification',
     PowerMonitor: 'PowerMonitor',
     PowerSaveBlocker: 'PowerSaveBlocker',
+    Protocol: 'Protocol',
     Screen: 'Screen',
     Session: 'Session',
     Shell: 'Shell',

--- a/static/show-me/protocol/main.js
+++ b/static/show-me/protocol/main.js
@@ -1,0 +1,17 @@
+// Register and handle custom protocol
+//
+// For more info, see:
+// https://www.electronjs.org/docs/latest/api/protocol
+
+const { app, BrowserWindow, protocol } = require('electron')
+
+app.whenReady().then(() => {
+  protocol.handle('some-protocol', () => {
+    return new Response(
+      Buffer.from('<h1>Hello from protocol handler</h1>'), // Could also be a string or ReadableStream.
+      { headers: { 'content-type': 'text/html' } }
+    )
+  })
+  const mainWindow = new BrowserWindow({ height: 600, width: 600 })
+  mainWindow.loadURL('some-protocol://index.html')
+})


### PR DESCRIPTION
Note: Since this uses protocol.handle, an upgrade to electron 25 would be required

fixes https://github.com/electron/fiddle/issues/1364