### PR TITLE
fix: don't install version until run

### DIFF
--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -20,7 +20,13 @@ interface RunnerProps {
 export const Runner = observer(
   class Runner extends React.Component<RunnerProps> {
     public render() {
-      const { downloading, missing, installing, installed } = InstallState;
+      const {
+        downloaded,
+        downloading,
+        missing,
+        installing,
+        installed,
+      } = InstallState;
       const {
         isRunning,
         isInstallingModules,
@@ -53,6 +59,7 @@ export const Runner = observer(
           props.icon = <Spinner size={16} />;
           break;
         }
+        case downloaded:
         case installed: {
           props.disabled = false;
           if (isRunning) {

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -385,7 +385,7 @@ export const ElectronSettings = observer(
           buttonProps.onClick = () => {
             isLocal
               ? appState.removeVersion(ver)
-              : appState.downloadVersion(ver, { activate: false });
+              : appState.downloadVersion(ver);
           };
           break;
       }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -579,18 +579,12 @@ export class AppState {
   }
 
   /**
-   * Download a version of Electron and set it as the current
-   * version in use unless otherwise specified.
+   * Download a version of Electron.
    *
    * @param {RunnableVersion} ver
-   * @param {Object} opts
-   * @param {Boolean} [options.activate=true] - Whether to set ver as current
    * @returns {Promise<void>}
    */
-  public async downloadVersion(
-    ver: RunnableVersion,
-    opts: { activate: boolean } = { activate: true },
-  ): Promise<void> {
+  public async downloadVersion(ver: RunnableVersion): Promise<void> {
     const { source, state, version } = ver;
     const {
       electronMirror,
@@ -603,7 +597,7 @@ export class AppState {
     const isInstalling = state === InstallState.installing;
     const isReady = state === InstallState.installed;
 
-    if (isDownloading || isInstalling) {
+    if (isDownloaded || isDownloading || isInstalling) {
       console.log(`State: Already ${state} ${version}.`);
       return;
     }
@@ -613,15 +607,10 @@ export class AppState {
       return;
     }
 
-    if (isDownloaded) {
-      // The electron zip needs to be unzipped as well
-      await this.installer.install(version);
-      return;
-    }
-
     console.log(`State: Downloading Electron ${version}`);
 
-    const options = {
+    // Download the version without setting it as the current version.
+    await this.installer.ensureDownloaded(version, {
       mirror: {
         electronMirror,
         electronNightlyMirror,
@@ -635,15 +624,7 @@ export class AppState {
           }
         });
       },
-    };
-
-    // Download the version without setting it as the current version.
-    if (!opts.activate) {
-      await this.installer.ensureDownloaded(version, options);
-      return;
-    }
-
-    await this.installer.install(version, options);
+    });
   }
 
   /**

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -43,8 +43,9 @@ describe('AppState', () => {
   let appState: AppState;
   let mockVersions: Record<string, RunnableVersion>;
   let mockVersionsArray: RunnableVersion[];
-  let removeSpy: any;
-  let installSpy: any;
+  let removeSpy: jest.SpyInstance;
+  let installSpy: jest.SpyInstance;
+  let ensureDownloadedSpy: jest.SpyInstance;
 
   beforeEach(() => {
     ({ mockVersions, mockVersionsArray } = new VersionsMock());
@@ -61,6 +62,9 @@ describe('AppState', () => {
     installSpy = jest
       .spyOn(appState.installer, 'install')
       .mockResolvedValue('');
+    ensureDownloadedSpy = jest
+      .spyOn(appState.installer, 'ensureDownloaded')
+      .mockResolvedValue({ path: '', alreadyExtracted: false });
   });
 
   it('exists', () => {
@@ -337,7 +341,8 @@ describe('AppState', () => {
 
       await appState.downloadVersion(ver);
 
-      expect(installSpy).toHaveBeenCalled();
+      expect(ensureDownloadedSpy).toHaveBeenCalled();
+      expect(installSpy).not.toHaveBeenCalled();
     });
 
     it('does not download a version if already ready', async () => {
@@ -346,6 +351,7 @@ describe('AppState', () => {
 
       await appState.downloadVersion(ver);
 
+      expect(ensureDownloadedSpy).not.toHaveBeenCalled();
       expect(installSpy).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Refs #1366.

Don't do the install step for a version until the user tries to run a fiddle. Doing so avoids collision on disk from multiple versions being installed at once (see reference issue). Also provides a nicer UX by not showing the unzipping spinner every time on start. Trade off is slightly longer initial run for a version since it needs to be unzipped and installed, but subsequent runs with the same version skip that step.

Should hopefully clear up a number of the disk errors being seen on Sentry around version management.

This partially reverts #1242 since that behavior becomes the only behavior.