### PR TITLE
fix: ipc handling for isReleasedMajor()

### DIFF
--- a/src/main/versions.ts
+++ b/src/main/versions.ts
@@ -83,6 +83,10 @@ export async function setupVersions() {
     },
   );
 
+  ipcMainManager.handle(
+    IpcEvents.IS_RELEASED_MAJOR,
+    (_: IpcMainEvent, version: number) => isReleasedMajor(version),
+  );
   ipcMainManager.handle(IpcEvents.FETCH_VERSIONS, (_: IpcMainEvent) =>
     fetchVersions(),
   );


### PR DESCRIPTION
Refs https://github.com/electron/fiddle/pull/1345/

Adds missing ipc handler for `IS_RELEASED_MAJOR`