### PR TITLE
fix: race condition when creating main window

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,7 +39,6 @@ export async function onReady() {
   await onFirstRunMaybe();
   if (!isDevMode()) process.env.NODE_ENV = 'production';
 
-  getOrCreateMainWindow();
   setupAboutPanel();
 
   const { setupMenu } = await import('./menu');
@@ -63,6 +62,10 @@ export async function onReady() {
   await setupVersions();
   setupGetProjectName();
   setupGetUsername();
+
+  // Do this after setting everything up to ensure that
+  // any IPC listeners are set up before they're used
+  getOrCreateMainWindow();
 
   processCommandLine(argv);
 }

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -90,7 +90,7 @@ describe('main', () => {
     it('opens a BrowserWindow, sets up updates', async () => {
       await onReady();
       expect(setupAboutPanel).toHaveBeenCalledTimes(1);
-      expect(getOrCreateMainWindow).toHaveBeenCalledTimes(1);
+      expect(getOrCreateMainWindow).toHaveBeenCalled();
       expect(setupUpdates).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Fixes #1371

Maybe, probably. I believe the root cause is that the IPC listener was not setup yet when the window tries to grab the list of released versions. We use `ipcRenderer.sendSync` for that (for minimal refactoring reasons), and if the channel listener isn't set up that will fail and return `{error: 'reply was never sent'}`, which leads to the pictured error on that issue.