### PR TITLE
fix: update settings in all open windows

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,7 +185,7 @@ export interface PMOperationOptions {
   packageManager: IPackageManager;
 }
 
-export enum Setting {
+export enum GlobalSetting {
   acceleratorsToBlock = 'acceleratorsToBlock',
   channelsToShow = 'channelsToShow',
   electronMirror = 'electronMirror',
@@ -196,7 +196,6 @@ export enum Setting {
   gitHubAvatarUrl = 'gitHubAvatarUrl',
   gitHubLogin = 'gitHubLogin',
   gitHubName = 'gitHubName',
-  gitHubPublishAsPublic = 'gitHubPublishAsPublic',
   gitHubToken = 'gitHubToken',
   hasShownTour = 'hasShownTour',
   isClearingConsoleOnRun = 'isClearingConsoleOnRun',
@@ -211,7 +210,13 @@ export enum Setting {
   showObsoleteVersions = 'showObsoleteVersions',
   showUndownloadedVersions = 'showUndownloadedVersions',
   theme = 'theme',
+}
+
+export type GlobalSettingKey = keyof typeof GlobalSetting;
+
+export enum WindowSpecificSetting {
+  gitHubPublishAsPublic = 'gitHubPublishAsPublic',
   version = 'version',
 }
 
-export type SettingKey = keyof typeof Setting;
+export type WindowSpecificSettingKey = keyof typeof WindowSpecificSetting;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -184,3 +184,34 @@ export interface PMOperationOptions {
   dir: string;
   packageManager: IPackageManager;
 }
+
+export enum Setting {
+  acceleratorsToBlock = 'acceleratorsToBlock',
+  channelsToShow = 'channelsToShow',
+  electronMirror = 'electronMirror',
+  environmentVariables = 'environmentVariables',
+  executionFlags = 'executionFlags',
+  fontFamily = 'fontFamily',
+  fontSize = 'fontSize',
+  gitHubAvatarUrl = 'gitHubAvatarUrl',
+  gitHubLogin = 'gitHubLogin',
+  gitHubName = 'gitHubName',
+  gitHubPublishAsPublic = 'gitHubPublishAsPublic',
+  gitHubToken = 'gitHubToken',
+  hasShownTour = 'hasShownTour',
+  isClearingConsoleOnRun = 'isClearingConsoleOnRun',
+  isEnablingElectronLogging = 'isEnablingElectronLogging',
+  isKeepingUserDataDirs = 'isKeepingUserDataDirs',
+  isPublishingGistAsRevision = 'isPublishingGistAsRevision',
+  isUsingSystemTheme = 'isUsingSystemTheme',
+  knownVersion = 'known-electron-versions',
+  localVersion = 'local-electron-versions',
+  packageAuthor = 'packageAuthor',
+  packageManager = 'packageManager',
+  showObsoleteVersions = 'showObsoleteVersions',
+  showUndownloadedVersions = 'showUndownloadedVersions',
+  theme = 'theme',
+  version = 'version',
+}
+
+export type SettingKey = keyof typeof Setting;

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -12,15 +12,19 @@ import {
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
-import { IPackageManager, Setting, SettingKey } from '../../interfaces';
+import {
+  GlobalSetting,
+  GlobalSettingKey,
+  IPackageManager,
+} from '../../interfaces';
 import { AppState } from '../state';
 
 /**
  * @TODO make this a proper enum again once we update Typescript
  */
 export const SettingItemType = {
-  EnvVars: Setting.environmentVariables,
-  Flags: Setting.executionFlags,
+  EnvVars: GlobalSetting.environmentVariables,
+  Flags: GlobalSetting.executionFlags,
 } as const;
 
 interface ExecutionSettingsProps {
@@ -122,7 +126,7 @@ export const ExecutionSettings = observer(
      */
     public handleSettingsItemChange(
       event: React.ChangeEvent<HTMLInputElement>,
-      type: SettingKey,
+      type: GlobalSettingKey,
     ) {
       const { name, value } = event.currentTarget;
 
@@ -139,7 +143,7 @@ export const ExecutionSettings = observer(
      *
      * @param {SettingItemType} type
      */
-    private addNewSettingsItem(type: SettingKey) {
+    private addNewSettingsItem(type: GlobalSettingKey) {
       const array = Object.entries(this.state[type]);
 
       this.setState((prevState) => ({
@@ -163,7 +167,7 @@ export const ExecutionSettings = observer(
       appState.packageManager = value as IPackageManager;
     };
 
-    public renderDeleteItem(idx: string, type: SettingKey): JSX.Element {
+    public renderDeleteItem(idx: string, type: GlobalSettingKey): JSX.Element {
       const updated = this.state[type];
 
       const removeFn = () => {

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -12,13 +12,16 @@ import {
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
-import { IPackageManager } from '../../interfaces';
+import { IPackageManager, Setting, SettingKey } from '../../interfaces';
 import { AppState } from '../state';
 
-export enum SettingItemType {
-  EnvVars = 'environmentVariables',
-  Flags = 'executionFlags',
-}
+/**
+ * @TODO make this a proper enum again once we update Typescript
+ */
+export const SettingItemType = {
+  EnvVars: Setting.environmentVariables,
+  Flags: Setting.executionFlags,
+} as const;
 
 interface ExecutionSettingsProps {
   appState: AppState;
@@ -119,7 +122,7 @@ export const ExecutionSettings = observer(
      */
     public handleSettingsItemChange(
       event: React.ChangeEvent<HTMLInputElement>,
-      type: SettingItemType,
+      type: SettingKey,
     ) {
       const { name, value } = event.currentTarget;
 
@@ -136,7 +139,7 @@ export const ExecutionSettings = observer(
      *
      * @param {SettingItemType} type
      */
-    private addNewSettingsItem(type: SettingItemType) {
+    private addNewSettingsItem(type: SettingKey) {
       const array = Object.entries(this.state[type]);
 
       this.setState((prevState) => ({
@@ -160,7 +163,7 @@ export const ExecutionSettings = observer(
       appState.packageManager = value as IPackageManager;
     };
 
-    public renderDeleteItem(idx: string, type: SettingItemType): JSX.Element {
+    public renderDeleteItem(idx: string, type: SettingKey): JSX.Element {
       const updated = this.state[type];
 
       const removeFn = () => {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -413,6 +413,10 @@ export class AppState {
             this.settingKeyTypeGuard(key);
           }
         }
+      } else {
+        console.warn(
+          `"${key}" is not a recognized localStorage key. If you're using this key to persist a setting, please add it to the relevant enum.`,
+        );
       }
     });
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -67,6 +67,12 @@ export class AppState {
     timeStyle: 'medium',
   });
 
+  private settingKeyTypeGuard(key: never): never {
+    throw new Error(
+      `Unhandled setting ${key}, please handle it in the \`AppState\`.`,
+    );
+  }
+
   // -- Persisted settings ------------------
   public theme: string | null = localStorage.getItem(GlobalSetting.theme);
   public gitHubAvatarUrl: string | null = localStorage.getItem(
@@ -369,20 +375,43 @@ export class AppState {
       }
 
       if (key in GlobalSetting && key in this) {
-        // Any settings listed here need more than just updating the state directly.
-        const actions: Partial<Record<GlobalSettingKey, () => void>> = {
-          theme: () => {
+        switch (key) {
+          case 'theme': {
             this.setTheme(parsedValue as string);
-          },
-        };
+            break;
+          }
 
-        const action = actions[key];
+          case 'acceleratorsToBlock':
+          case 'channelsToShow':
+          case 'electronMirror':
+          case 'environmentVariables':
+          case 'executionFlags':
+          case 'fontFamily':
+          case 'fontSize':
+          case 'gitHubAvatarUrl':
+          case 'gitHubLogin':
+          case 'gitHubName':
+          case 'gitHubToken':
+          case 'hasShownTour':
+          case 'isClearingConsoleOnRun':
+          case 'isEnablingElectronLogging':
+          case 'isKeepingUserDataDirs':
+          case 'isPublishingGistAsRevision':
+          case 'isUsingSystemTheme':
+          case 'knownVersion':
+          case 'localVersion':
+          case 'packageAuthor':
+          case 'packageManager':
+          case 'showObsoleteVersions':
+          case 'showUndownloadedVersions': {
+            // Fall back to updating the state.
+            this[key] = parsedValue;
+            break;
+          }
 
-        if (typeof action === 'function') {
-          action();
-        } else {
-          // Fall back to updating the state.
-          this[key] = parsedValue;
+          default: {
+            this.settingKeyTypeGuard(key);
+          }
         }
       }
     });

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -27,6 +27,8 @@ import {
   OutputOptions,
   RunnableVersion,
   SetFiddleOptions,
+  Setting,
+  SettingKey,
   Version,
   VersionSource,
 } from '../interfaces';
@@ -64,62 +66,68 @@ export class AppState {
   });
 
   // -- Persisted settings ------------------
-  public theme: string | null = localStorage.getItem('theme');
+  public theme: string | null = localStorage.getItem(Setting.theme);
   public gitHubAvatarUrl: string | null = localStorage.getItem(
-    'gitHubAvatarUrl',
+    Setting.gitHubAvatarUrl,
   );
-  public gitHubName: string | null = localStorage.getItem('gitHubName');
-  public gitHubLogin: string | null = localStorage.getItem('gitHubLogin');
+  public gitHubName: string | null = localStorage.getItem(Setting.gitHubName);
+  public gitHubLogin: string | null = localStorage.getItem(Setting.gitHubLogin);
   public gitHubToken: string | null =
-    localStorage.getItem('gitHubToken') || null;
-  public gitHubPublishAsPublic = !!this.retrieve('gitHubPublishAsPublic');
+    localStorage.getItem(Setting.gitHubToken) || null;
+  public gitHubPublishAsPublic = !!this.retrieve(Setting.gitHubPublishAsPublic);
   public channelsToShow: Array<ElectronReleaseChannel> = (this.retrieve(
-    'channelsToShow',
+    Setting.channelsToShow,
   ) as Array<ElectronReleaseChannel>) || [
     ElectronReleaseChannel.stable,
     ElectronReleaseChannel.beta,
   ];
   public showObsoleteVersions = !!(
-    this.retrieve('showObsoleteVersions') ?? false
+    this.retrieve(Setting.showObsoleteVersions) ?? false
   );
   public showUndownloadedVersions = !!(
-    this.retrieve('showUndownloadedVersions') ?? true
+    this.retrieve(Setting.showUndownloadedVersions) ?? true
   );
-  public isKeepingUserDataDirs = !!this.retrieve('isKeepingUserDataDirs');
+  public isKeepingUserDataDirs = !!this.retrieve(Setting.isKeepingUserDataDirs);
   public isEnablingElectronLogging = !!this.retrieve(
-    'isEnablingElectronLogging',
+    Setting.isEnablingElectronLogging,
   );
-  public isClearingConsoleOnRun = !!this.retrieve('isClearingConsoleOnRun');
-  public isUsingSystemTheme = !!(this.retrieve('isUsingSystemTheme') ?? true);
+  public isClearingConsoleOnRun = !!this.retrieve(
+    Setting.isClearingConsoleOnRun,
+  );
+  public isUsingSystemTheme = !!(
+    this.retrieve(Setting.isUsingSystemTheme) ?? true
+  );
   public isPublishingGistAsRevision = !!(
-    this.retrieve('isPublishingGistAsRevision') ?? true
+    this.retrieve(Setting.isPublishingGistAsRevision) ?? true
   );
   public executionFlags: Array<string> =
-    (this.retrieve('executionFlags') as Array<string>) === null
+    (this.retrieve(Setting.executionFlags) as Array<string>) === null
       ? []
-      : (this.retrieve('executionFlags') as Array<string>);
+      : (this.retrieve(Setting.executionFlags) as Array<string>);
   public environmentVariables: Array<string> =
-    (this.retrieve('environmentVariables') as Array<string>) === null
+    (this.retrieve(Setting.environmentVariables) as Array<string>) === null
       ? []
-      : (this.retrieve('environmentVariables') as Array<string>);
+      : (this.retrieve(Setting.environmentVariables) as Array<string>);
   public packageManager: IPackageManager =
-    (localStorage.getItem('packageManager') as IPackageManager) || 'npm';
+    (localStorage.getItem(Setting.packageManager) as IPackageManager) || 'npm';
   public acceleratorsToBlock: Array<BlockableAccelerator> =
-    (this.retrieve('acceleratorsToBlock') as Array<BlockableAccelerator>) || [];
+    (this.retrieve(
+      Setting.acceleratorsToBlock,
+    ) as Array<BlockableAccelerator>) || [];
   public packageAuthor =
-    (localStorage.getItem('packageAuthor') as string) ??
+    (localStorage.getItem(Setting.packageAuthor) as string) ??
     window.ElectronFiddle.getUsername();
   public electronMirror: typeof ELECTRON_MIRROR =
-    (this.retrieve('electronMirror') as typeof ELECTRON_MIRROR) === null
+    (this.retrieve(Setting.electronMirror) as typeof ELECTRON_MIRROR) === null
       ? {
           ...ELECTRON_MIRROR,
           sourceType: navigator.language === 'zh-CN' ? 'CHINA' : 'DEFAULT',
         }
-      : (this.retrieve('electronMirror') as typeof ELECTRON_MIRROR);
+      : (this.retrieve(Setting.electronMirror) as typeof ELECTRON_MIRROR);
   public fontFamily: string | undefined =
-    (localStorage.getItem('fontFamily') as string) || undefined;
+    (localStorage.getItem(Setting.fontFamily) as string) || undefined;
   public fontSize: number | undefined =
-    ((localStorage.getItem('fontSize') as any) as number) || undefined;
+    ((localStorage.getItem(Setting.fontSize) as any) as number) || undefined;
 
   // -- Various session-only state ------------------
   public gistId: string | undefined = undefined;
@@ -158,7 +166,7 @@ export class AppState {
   public isSettingsShowing = false;
   public isThemeDialogShowing = false;
   public isTokenDialogShowing = false;
-  public isTourShowing = !localStorage.getItem('hasShownTour');
+  public isTourShowing = !localStorage.getItem(Setting.hasShownTour);
   public isUpdatingElectronVersions = false;
 
   // -- Editor Values stored when we close the editor ------------------
@@ -330,40 +338,59 @@ export class AppState {
     window.ElectronFiddle.addEventListener('before-quit', this.setIsQuitting);
 
     // Setup auto-runs
-    autorun(() => this.save('theme', this.theme));
+    autorun(() => this.save(Setting.theme, this.theme));
     autorun(() =>
-      this.save('isClearingConsoleOnRun', this.isClearingConsoleOnRun),
-    );
-    autorun(() => this.save('isUsingSystemTheme', this.isUsingSystemTheme));
-    autorun(() =>
-      this.save('isPublishingGistAsRevision', this.isPublishingGistAsRevision),
-    );
-    autorun(() => this.save('gitHubAvatarUrl', this.gitHubAvatarUrl));
-    autorun(() => this.save('gitHubLogin', this.gitHubLogin));
-    autorun(() => this.save('gitHubName', this.gitHubName));
-    autorun(() => this.save('gitHubToken', this.gitHubToken));
-    autorun(() =>
-      this.save('gitHubPublishAsPublic', this.gitHubPublishAsPublic),
+      this.save(Setting.isClearingConsoleOnRun, this.isClearingConsoleOnRun),
     );
     autorun(() =>
-      this.save('isKeepingUserDataDirs', this.isKeepingUserDataDirs),
+      this.save(Setting.isUsingSystemTheme, this.isUsingSystemTheme),
     );
     autorun(() =>
-      this.save('isEnablingElectronLogging', this.isEnablingElectronLogging),
+      this.save(
+        Setting.isPublishingGistAsRevision,
+        this.isPublishingGistAsRevision,
+      ),
     );
-    autorun(() => this.save('executionFlags', this.executionFlags));
-    autorun(() => this.save('version', this.version));
-    autorun(() => this.save('channelsToShow', this.channelsToShow));
+    autorun(() => this.save(Setting.gitHubAvatarUrl, this.gitHubAvatarUrl));
+    autorun(() => this.save(Setting.gitHubLogin, this.gitHubLogin));
+    autorun(() => this.save(Setting.gitHubName, this.gitHubName));
+    autorun(() => this.save(Setting.gitHubToken, this.gitHubToken));
     autorun(() =>
-      this.save('showUndownloadedVersions', this.showUndownloadedVersions),
+      this.save(Setting.gitHubPublishAsPublic, this.gitHubPublishAsPublic),
     );
-    autorun(() => this.save('showObsoleteVersions', this.showObsoleteVersions));
-    autorun(() => this.save('packageManager', this.packageManager ?? 'npm'));
-    autorun(() => this.save('acceleratorsToBlock', this.acceleratorsToBlock));
-    autorun(() => this.save('packageAuthor', this.packageAuthor));
-    autorun(() => this.save('electronMirror', this.electronMirror as any));
-    autorun(() => this.save('fontFamily', this.fontFamily as any));
-    autorun(() => this.save('fontSize', this.fontSize as any));
+    autorun(() =>
+      this.save(Setting.isKeepingUserDataDirs, this.isKeepingUserDataDirs),
+    );
+    autorun(() =>
+      this.save(
+        Setting.isEnablingElectronLogging,
+        this.isEnablingElectronLogging,
+      ),
+    );
+    autorun(() => this.save(Setting.executionFlags, this.executionFlags));
+    autorun(() => this.save(Setting.version, this.version));
+    autorun(() => this.save(Setting.channelsToShow, this.channelsToShow));
+    autorun(() =>
+      this.save(
+        Setting.showUndownloadedVersions,
+        this.showUndownloadedVersions,
+      ),
+    );
+    autorun(() =>
+      this.save(Setting.showObsoleteVersions, this.showObsoleteVersions),
+    );
+    autorun(() =>
+      this.save(Setting.packageManager, this.packageManager ?? 'npm'),
+    );
+    autorun(() =>
+      this.save(Setting.acceleratorsToBlock, this.acceleratorsToBlock),
+    );
+    autorun(() => this.save(Setting.packageAuthor, this.packageAuthor));
+    autorun(() =>
+      this.save(Setting.electronMirror, this.electronMirror as any),
+    );
+    autorun(() => this.save(Setting.fontFamily, this.fontFamily as any));
+    autorun(() => this.save(Setting.fontSize, this.fontSize as any));
 
     // Update our known versions
     this.updateElectronVersions();
@@ -514,7 +541,7 @@ export class AppState {
 
   public disableTour() {
     this.resetView();
-    localStorage.setItem('hasShownTour', 'true');
+    localStorage.setItem(Setting.hasShownTour, 'true');
   }
 
   public showTour() {
@@ -935,7 +962,7 @@ export class AppState {
    * @param {(string | number | Array<any> | Record<string, unknown> | null | boolean)} [value]
    */
   private save(
-    key: string,
+    key: SettingKey,
     value?:
       | string
       | number
@@ -961,7 +988,7 @@ export class AppState {
    * @param {string} key
    * @returns {(T | string | null)}
    */
-  private retrieve<T>(key: string): T | string | null {
+  private retrieve<T>(key: SettingKey): T | string | null {
     const value = localStorage.getItem(key);
 
     return JSON.parse(value || 'null') as T;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -369,7 +369,7 @@ export class AppState {
       }
 
       if (key in GlobalSetting && key in this) {
-        // Any settings listed here need morethan just updating the state directly.
+        // Any settings listed here need more than just updating the state directly.
         const actions: Partial<Record<GlobalSettingKey, () => void>> = {
           theme: () => {
             this.setTheme(parsedValue as string);

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -1,10 +1,11 @@
 import {
   ElectronReleaseChannel,
+  GlobalSetting,
   InstallState,
   RunnableVersion,
-  Setting,
   Version,
   VersionSource,
+  WindowSpecificSetting,
 } from '../interfaces';
 import { normalizeVersion } from './utils/normalize-version';
 
@@ -15,7 +16,7 @@ import { normalizeVersion } from './utils/normalize-version';
  * @returns {string}
  */
 export function getDefaultVersion(versions: RunnableVersion[]): string {
-  const key = localStorage.getItem(Setting.version);
+  const key = localStorage.getItem(WindowSpecificSetting.version);
   if (key && versions.some(({ version }) => version === key)) {
     return key;
   }
@@ -110,7 +111,7 @@ export function getLocalVersionForPath(
  * @returns {Array<Version>}
  */
 export function getLocalVersions(): Array<Version> {
-  const fromLs = window.localStorage.getItem(Setting.localVersion);
+  const fromLs = window.localStorage.getItem(GlobalSetting.localVersion);
 
   if (fromLs) {
     try {
@@ -146,12 +147,12 @@ export function saveLocalVersions(
   });
 
   const stringified = JSON.stringify(filteredVersions);
-  window.localStorage.setItem(Setting.localVersion, stringified);
+  window.localStorage.setItem(GlobalSetting.localVersion, stringified);
 }
 
 function getReleasedVersions(): Array<Version> {
   const versions = window.ElectronFiddle.getReleasedVersions();
-  const fromLs = window.localStorage.getItem(Setting.knownVersion);
+  const fromLs = window.localStorage.getItem(GlobalSetting.knownVersion);
 
   if (fromLs) {
     try {
@@ -179,7 +180,7 @@ export async function fetchVersions(): Promise<Version[]> {
 
   // Migrate away from known versions being stored in localStorage
   // Now that we've fetched new versions, it's safe to delete
-  window.localStorage.removeItem(Setting.knownVersion);
+  window.localStorage.removeItem(GlobalSetting.knownVersion);
 
   console.log(`Fetched ${versions.length} new Electron versions`);
   return versions;

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -2,6 +2,7 @@ import {
   ElectronReleaseChannel,
   InstallState,
   RunnableVersion,
+  Setting,
   Version,
   VersionSource,
 } from '../interfaces';
@@ -14,8 +15,10 @@ import { normalizeVersion } from './utils/normalize-version';
  * @returns {string}
  */
 export function getDefaultVersion(versions: RunnableVersion[]): string {
-  const key = localStorage.getItem('version');
-  if (key && versions.some(({ version }) => version === key)) return key;
+  const key = localStorage.getItem(Setting.version);
+  if (key && versions.some(({ version }) => version === key)) {
+    return key;
+  }
 
   const latestStable = window.ElectronFiddle.getLatestStable();
   if (latestStable) return latestStable.version;
@@ -46,11 +49,6 @@ export function getReleaseChannel(
 
   // Must be a stable version, right?
   return ElectronReleaseChannel.stable;
-}
-
-export const enum VersionKeys {
-  local = 'local-electron-versions',
-  known = 'known-electron-versions',
 }
 
 export function makeRunnable(ver: Version): RunnableVersion {
@@ -112,7 +110,7 @@ export function getLocalVersionForPath(
  * @returns {Array<Version>}
  */
 export function getLocalVersions(): Array<Version> {
-  const fromLs = window.localStorage.getItem(VersionKeys.local);
+  const fromLs = window.localStorage.getItem(Setting.localVersion);
 
   if (fromLs) {
     try {
@@ -148,12 +146,12 @@ export function saveLocalVersions(
   });
 
   const stringified = JSON.stringify(filteredVersions);
-  window.localStorage.setItem(VersionKeys.local, stringified);
+  window.localStorage.setItem(Setting.localVersion, stringified);
 }
 
 function getReleasedVersions(): Array<Version> {
   const versions = window.ElectronFiddle.getReleasedVersions();
-  const fromLs = window.localStorage.getItem(VersionKeys.known);
+  const fromLs = window.localStorage.getItem(Setting.knownVersion);
 
   if (fromLs) {
     try {
@@ -181,7 +179,7 @@ export async function fetchVersions(): Promise<Version[]> {
 
   // Migrate away from known versions being stored in localStorage
   // Now that we've fetched new versions, it's safe to delete
-  window.localStorage.removeItem(VersionKeys.known);
+  window.localStorage.removeItem(Setting.knownVersion);
 
   console.log(`Fetched ${versions.length} new Electron versions`);
   return versions;

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,10 +1,10 @@
 import {
   ElectronReleaseChannel,
   RunnableVersion,
+  Setting,
   VersionSource,
 } from '../../src/interfaces';
 import {
-  VersionKeys,
   addLocalVersion,
   fetchVersions,
   getDefaultVersion,
@@ -109,7 +109,7 @@ describe('versions', () => {
       saveLocalVersions(mockLocalVersions as Array<RunnableVersion>);
 
       expect(window.localStorage.setItem).toBeCalledWith(
-        VersionKeys.local,
+        Setting.localVersion,
         JSON.stringify(mockLocalVersions),
       );
     });
@@ -152,7 +152,9 @@ describe('versions', () => {
     it('removes knownVersions from localStorage', async () => {
       (window.ElectronFiddle.fetchVersions as jest.Mock).mockResolvedValue([]);
       await fetchVersions();
-      expect(localStorage.removeItem).toHaveBeenCalledWith(VersionKeys.known);
+      expect(localStorage.removeItem).toHaveBeenCalledWith(
+        Setting.knownVersion,
+      );
     });
   });
 });

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,7 +1,7 @@
 import {
   ElectronReleaseChannel,
+  GlobalSetting,
   RunnableVersion,
-  Setting,
   VersionSource,
 } from '../../src/interfaces';
 import {
@@ -109,7 +109,7 @@ describe('versions', () => {
       saveLocalVersions(mockLocalVersions as Array<RunnableVersion>);
 
       expect(window.localStorage.setItem).toBeCalledWith(
-        Setting.localVersion,
+        GlobalSetting.localVersion,
         JSON.stringify(mockLocalVersions),
       );
     });
@@ -153,7 +153,7 @@ describe('versions', () => {
       (window.ElectronFiddle.fetchVersions as jest.Mock).mockResolvedValue([]);
       await fetchVersions();
       expect(localStorage.removeItem).toHaveBeenCalledWith(
-        Setting.knownVersion,
+        GlobalSetting.knownVersion,
       );
     });
   });


### PR DESCRIPTION
Here's my stab at #1352. I mostly followed the approach suggested in that issue, except that I'm listening for updates in the settings using the [`storage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) event instead of using IPC, so we can get the same result for free without touching the main process.

Just a consideration: any open windows (except the one in which the setting was changed) updates its `AppState` object in response to a setting being changed. However, this PR doesn't (directly) change anything related to the UI state. As you can see in the video below, if I have two windows with the Settings modal opened and I make changes in one of them, checkboxes are checked/unchecked in both windows, while text inputs don't change in the other window (unless I close and reopen the Settings modal manually). This is purely a side effect of how the respective components handle their state; if "simultaneous edition" is desired, it will require some changes (maybe just triggering a re-render of the Settings modal on focus, or even changing how the components respond to updates in the global state) that might or might not be part of the scope here, so I decided to check before going any further.

https://github.com/electron/fiddle/assets/19478575/b6207a00-258e-4840-a5fd-631155b818c3

Fixes #1352.