### PR TITLE
fix: await loadTheme in app setup

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -103,7 +103,7 @@ export class App {
    * render process.
    */
   public async setup(): Promise<void | Element | React.Component> {
-    this.loadTheme(this.state.theme || '');
+    await this.loadTheme(this.state.theme || '');
 
     const React = await import('react');
     const { render } = await import('react-dom');


### PR DESCRIPTION
There's currently a flash of light mode UI on window load if you're using dark mode, this fixes that by awaiting `loadTheme` so that the theme is correctly set before the UI is loaded.