### PR TITLE
perf: import modules in parallel during app setup

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -105,13 +105,19 @@ export class App {
   public async setup(): Promise<void | Element | React.Component> {
     await this.loadTheme(this.state.theme || '');
 
-    const React = await import('react');
-    const { render } = await import('react-dom');
-    const { Dialogs } = await import('./components/dialogs');
-    const { OutputEditorsWrapper } = await import(
-      './components/output-editors-wrapper'
-    );
-    const { Header } = await import('./components/header');
+    const [
+      { default: React },
+      { render },
+      { Dialogs },
+      { OutputEditorsWrapper },
+      { Header },
+    ] = await Promise.all([
+      import('react'),
+      import('react-dom'),
+      import('./components/dialogs'),
+      import('./components/output-editors-wrapper'),
+      import('./components/header'),
+    ]);
 
     // The AppState constructor started loading a fiddle.
     // Wait for it here so the UI doesn't start life in `nonIdealState`.


### PR DESCRIPTION
In theory this should result in better performance, in practice when trying to do some quick and dirty profiling the results were inconclusive. Doing these with `Promise.all` may smooth overall timings by ensuring one call taking a bit longer than usual for whatever reason doesn't slow all calls.

Since this is low risk, going to YOLO it under the assumption that at best it'll help things, at worse it's a no-op.