### PR TITLE
fix: improve behavior of setting sync between windows

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -212,11 +212,7 @@ export enum GlobalSetting {
   theme = 'theme',
 }
 
-export type GlobalSettingKey = keyof typeof GlobalSetting;
-
 export enum WindowSpecificSetting {
   gitHubPublishAsPublic = 'gitHubPublishAsPublic',
   version = 'version',
 }
-
-export type WindowSpecificSettingKey = keyof typeof WindowSpecificSetting;

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -12,11 +12,7 @@ import {
 } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
-import {
-  GlobalSetting,
-  GlobalSettingKey,
-  IPackageManager,
-} from '../../interfaces';
+import { GlobalSetting, IPackageManager } from '../../interfaces';
 import { AppState } from '../state';
 
 /**
@@ -122,11 +118,11 @@ export const ExecutionSettings = observer(
      * run with the Electron executable.
      *
      * @param {React.ChangeEvent<HTMLInputElement>} event
-     * @param {SettingItemType} type
+     * @param {GlobalSetting} type
      */
     public handleSettingsItemChange(
       event: React.ChangeEvent<HTMLInputElement>,
-      type: GlobalSettingKey,
+      type: GlobalSetting,
     ) {
       const { name, value } = event.currentTarget;
 
@@ -141,9 +137,9 @@ export const ExecutionSettings = observer(
     /**
      * Adds a new settings item input field.
      *
-     * @param {SettingItemType} type
+     * @param {GlobalSetting} type
      */
-    private addNewSettingsItem(type: GlobalSettingKey) {
+    private addNewSettingsItem(type: GlobalSetting) {
       const array = Object.entries(this.state[type]);
 
       this.setState((prevState) => ({
@@ -167,7 +163,7 @@ export const ExecutionSettings = observer(
       appState.packageManager = value as IPackageManager;
     };
 
-    public renderDeleteItem(idx: string, type: GlobalSettingKey): JSX.Element {
+    public renderDeleteItem(idx: string, type: GlobalSetting): JSX.Element {
       const updated = this.state[type];
 
       const removeFn = () => {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -407,7 +407,6 @@ export class AppState {
           case GlobalSetting.gitHubLogin:
           case GlobalSetting.gitHubName:
           case GlobalSetting.gitHubToken:
-          case GlobalSetting.hasShownTour:
           case GlobalSetting.isClearingConsoleOnRun:
           case GlobalSetting.isEnablingElectronLogging:
           case GlobalSetting.isKeepingUserDataDirs:

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -417,7 +417,7 @@ export class AppState {
           case GlobalSetting.showObsoleteVersions:
           case GlobalSetting.showUndownloadedVersions: {
             // Fall back to updating the state.
-            this[key] = parsedValue;
+            (this[key] as any) = parsedValue;
             break;
           }
 


### PR DESCRIPTION
Follow-up to #1376 which fixes a few bugs:

* Don't warn when `WindowSpecificSetting` settings are touched
* Fix cases where the enum value does not match the enum key
* Better handle several keys which do not exist on `AppState`
* Sync local versions properly between windows
* Update some JSDoc types which were changed in #1376

cc @erikian