### PR TITLE
feat: sync version download statuses between windows

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -2,7 +2,6 @@ import { ReleaseInfo } from '@electron/fiddle-core';
 import * as MonacoType from 'monaco-editor';
 
 import {
-  AppStateBroadcastMessage,
   BisectRequest,
   BlockableAccelerator,
   EditorValues,
@@ -125,9 +124,5 @@ declare global {
       taskDone(result: RunResult): void;
       themePath: string;
     };
-  }
-
-  interface AppStateBroadcastChannel extends BroadcastChannel {
-    postMessage<T = unknown>(params: AppStateBroadcastMessage<T>): void;
   }
 }

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -2,6 +2,7 @@ import { ReleaseInfo } from '@electron/fiddle-core';
 import * as MonacoType from 'monaco-editor';
 
 import {
+  AppStateBroadcastMessage,
   BisectRequest,
   BlockableAccelerator,
   EditorValues,
@@ -124,5 +125,9 @@ declare global {
       taskDone(result: RunResult): void;
       themePath: string;
     };
+  }
+
+  interface AppStateBroadcastChannel extends BroadcastChannel {
+    postMessage<T = unknown>(params: AppStateBroadcastMessage<T>): void;
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -217,10 +217,14 @@ export enum WindowSpecificSetting {
   version = 'version',
 }
 
-export interface AppStateBroadcastMessage<T = unknown> {
-  type: AppStateBroadcastMessageType;
-  payload: T;
+export interface AppStateBroadcastChannel extends BroadcastChannel {
+  postMessage(params: AppStateBroadcastMessage): void;
 }
+
+export type AppStateBroadcastMessage = {
+  type: AppStateBroadcastMessageType.syncVersion;
+  payload: RunnableVersion;
+};
 
 export enum AppStateBroadcastMessageType {
   syncVersion = 'syncVersion',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -221,11 +221,17 @@ export interface AppStateBroadcastChannel extends BroadcastChannel {
   postMessage(params: AppStateBroadcastMessage): void;
 }
 
-export type AppStateBroadcastMessage = {
-  type: AppStateBroadcastMessageType.syncVersions;
-  payload: RunnableVersion[];
-};
+export type AppStateBroadcastMessage =
+  | {
+      type: AppStateBroadcastMessageType.isDownloadingAll;
+      payload: boolean;
+    }
+  | {
+      type: AppStateBroadcastMessageType.syncVersions;
+      payload: RunnableVersion[];
+    };
 
 export enum AppStateBroadcastMessageType {
+  isDownloadingAll = 'isDownloadingAll',
   syncVersions = 'syncVersions',
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -222,10 +222,10 @@ export interface AppStateBroadcastChannel extends BroadcastChannel {
 }
 
 export type AppStateBroadcastMessage = {
-  type: AppStateBroadcastMessageType.syncVersion;
-  payload: RunnableVersion;
+  type: AppStateBroadcastMessageType.syncVersions;
+  payload: RunnableVersion[];
 };
 
 export enum AppStateBroadcastMessageType {
-  syncVersion = 'syncVersion',
+  syncVersions = 'syncVersions',
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -216,3 +216,12 @@ export enum WindowSpecificSetting {
   gitHubPublishAsPublic = 'gitHubPublishAsPublic',
   version = 'version',
 }
+
+export interface AppStateBroadcastMessage<T = unknown> {
+  type: AppStateBroadcastMessageType;
+  payload: T;
+}
+
+export enum AppStateBroadcastMessageType {
+  syncVersion = 'syncVersion',
+}

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -209,7 +209,7 @@ export class AppState {
   });
 
   // Used for communications between windows
-  public broadcastChannel: AppStateBroadcastChannel = new BroadcastChannel(
+  private broadcastChannel: AppStateBroadcastChannel = new BroadcastChannel(
     'AppState',
   );
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -477,6 +477,11 @@ export class AppState {
         const { type, payload } = event.data;
 
         switch (type) {
+          case AppStateBroadcastMessageType.isDownloadingAll: {
+            this.isDownloadingAll = payload;
+            break;
+          }
+
           case AppStateBroadcastMessageType.syncVersions: {
             this.setVersionStates(payload);
 
@@ -647,10 +652,18 @@ export class AppState {
 
   public startDownloadingAll() {
     this.isDownloadingAll = true;
+    this.broadcastChannel.postMessage({
+      type: AppStateBroadcastMessageType.isDownloadingAll,
+      payload: true,
+    });
   }
 
   public stopDownloadingAll() {
     this.isDownloadingAll = false;
+    this.broadcastChannel.postMessage({
+      type: AppStateBroadcastMessageType.isDownloadingAll,
+      payload: false,
+    });
   }
 
   public startDeletingAll() {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -16,6 +16,7 @@ import {
 } from 'mobx';
 
 import {
+  AppStateBroadcastChannel,
   AppStateBroadcastMessage,
   AppStateBroadcastMessageType,
   BlockableAccelerator,
@@ -214,7 +215,7 @@ export class AppState {
 
   // Notifies other windows that this version has changed so they can update their state to reflect that.
   private updateVersionDownloadStatus(version: RunnableVersion) {
-    this.broadcastChannel.postMessage<RunnableVersion>({
+    this.broadcastChannel.postMessage({
       type: AppStateBroadcastMessageType.syncVersion,
       payload: { ...version },
     });
@@ -461,7 +462,7 @@ export class AppState {
 
         switch (type) {
           case AppStateBroadcastMessageType.syncVersion: {
-            this.addNewVersions([payload as RunnableVersion]);
+            this.addNewVersions([payload]);
 
             break;
           }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -214,7 +214,7 @@ export class AppState {
   );
 
   // Notifies other windows that this version has changed so they can update their state to reflect that.
-  private updateVersionDownloadStatus(version: RunnableVersion) {
+  private updateVersionState(version: RunnableVersion) {
     this.broadcastChannel.postMessage({
       type: AppStateBroadcastMessageType.syncVersion,
       payload: { ...version },
@@ -768,7 +768,7 @@ export class AppState {
 
           await typeDefsCleaner();
 
-          this.updateVersionDownloadStatus(ver);
+          this.updateVersionState(ver);
         }
       } else {
         console.log(`State: Version ${version} already removed, doing nothing`);
@@ -807,7 +807,7 @@ export class AppState {
 
     console.log(`State: Downloading Electron ${version}`);
 
-    this.updateVersionDownloadStatus({
+    this.updateVersionState({
       ...ver,
       state: InstallState.downloading,
     });
@@ -825,13 +825,13 @@ export class AppState {
           if (ver.downloadProgress !== percent) {
             ver.downloadProgress = percent;
 
-            this.updateVersionDownloadStatus(ver);
+            this.updateVersionState(ver);
           }
         });
       },
     });
 
-    this.updateVersionDownloadStatus(ver);
+    this.updateVersionState(ver);
   }
 
   /**

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -225,7 +225,7 @@ export class AppState {
   }
 
   constructor(versions: RunnableVersion[]) {
-    makeObservable<AppState, 'setPageHash'>(this, {
+    makeObservable<AppState, 'setPageHash' | 'setVersionStates'>(this, {
       Bisector: observable,
       acceleratorsToBlock: observable,
       activeGistAction: observable,
@@ -288,6 +288,7 @@ export class AppState {
       setPageHash: action,
       setTheme: action,
       setVersion: action,
+      setVersionStates: action,
       showChannels: action,
       showConfirmDialog: action,
       showErrorDialog: action,

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -775,6 +775,10 @@ describe('AppState', () => {
       appState.isDownloadingAll = false;
       appState.startDownloadingAll();
       expect(appState.isDownloadingAll).toBe(true);
+      expect(broadcastMessageSpy).toHaveBeenCalledWith({
+        type: AppStateBroadcastMessageType.isDownloadingAll,
+        payload: true,
+      });
     });
 
     it('takes no action when isDownloadingAll is true', () => {
@@ -789,6 +793,10 @@ describe('AppState', () => {
       appState.isDownloadingAll = true;
       appState.stopDownloadingAll();
       expect(appState.isDownloadingAll).toBe(false);
+      expect(broadcastMessageSpy).toHaveBeenCalledWith({
+        type: AppStateBroadcastMessageType.isDownloadingAll,
+        payload: false,
+      });
     });
 
     it('takes no action when isDownloadingAll is false', () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,6 +1,8 @@
 import { reaction } from 'mobx';
 
 import {
+  AppStateBroadcastChannel,
+  AppStateBroadcastMessageType,
   BlockableAccelerator,
   ElectronReleaseChannel,
   GenericDialogType,
@@ -741,6 +743,30 @@ describe('AppState', () => {
       appState.editorMosaic.isEdited = true;
       const actual = appState.title;
       expect(actual).toBe(expected);
+    });
+  });
+
+  describe('broadcastChannel', () => {
+    it('updates the version state in response to changes in other windows', async () => {
+      const broadcastChannel: AppStateBroadcastChannel = new BroadcastChannel(
+        'AppState',
+      );
+
+      const fakeVersion = {
+        version: '13.9.9',
+        state: InstallState.downloading,
+      } as RunnableVersion;
+
+      expect(appState.versions[fakeVersion.version]).toBeFalsy();
+
+      broadcastChannel.postMessage({
+        type: AppStateBroadcastMessageType.syncVersions,
+        payload: [fakeVersion],
+      });
+
+      expect(appState.versions[fakeVersion.version].state).toEqual(
+        InstallState.downloading,
+      );
     });
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,3 @@
-const { BroadcastChannel } = require('worker_threads');
-
 const { configure: enzymeConfigure } = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const { createSerializer } = require('enzyme-to-json');
@@ -34,6 +32,20 @@ jest.mock('@sentry/electron/renderer', () => ({
   init: jest.fn(),
 }));
 
+function broadcastChannelMock() {
+  //
+}
+
+broadcastChannelMock.prototype.addEventListener = function () {
+  //
+};
+
+broadcastChannelMock.prototype.postMessage = function () {
+  //
+};
+
+global.BroadcastChannel = broadcastChannelMock;
+
 expect.addSnapshotSerializer(createSerializer({ mode: 'deep' }));
 
 // We want to detect jest sometimes
@@ -49,7 +61,6 @@ window.localStorage = {};
 
 window.navigator = window.navigator ?? {};
 window.navigator.clipboard = {};
-window.BroadcastChannel = BroadcastChannel;
 
 /**
  * Mock these properties twice so that they're available

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -32,19 +32,10 @@ jest.mock('@sentry/electron/renderer', () => ({
   init: jest.fn(),
 }));
 
-function broadcastChannelMock() {
-  //
-}
-
-broadcastChannelMock.prototype.addEventListener = function () {
-  //
+global.BroadcastChannel = class {
+  addEventListener = jest.fn();
+  postMessage = jest.fn();
 };
-
-broadcastChannelMock.prototype.postMessage = function () {
-  //
-};
-
-global.BroadcastChannel = broadcastChannelMock;
 
 expect.addSnapshotSerializer(createSerializer({ mode: 'deep' }));
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,3 +1,5 @@
+const { BroadcastChannel } = require('worker_threads');
+
 const { configure: enzymeConfigure } = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const { createSerializer } = require('enzyme-to-json');
@@ -41,6 +43,7 @@ global.__JEST__ = global.__JEST__ || {};
 global.window = global.window || {};
 global.document = global.document || { body: {} };
 global.fetch = window.fetch = jest.fn();
+global.BroadcastChannel = BroadcastChannel;
 
 delete window.localStorage;
 window.localStorage = {};

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -43,13 +43,13 @@ global.__JEST__ = global.__JEST__ || {};
 global.window = global.window || {};
 global.document = global.document || { body: {} };
 global.fetch = window.fetch = jest.fn();
-global.BroadcastChannel = BroadcastChannel;
 
 delete window.localStorage;
 window.localStorage = {};
 
 window.navigator = window.navigator ?? {};
 window.navigator.clipboard = {};
+window.BroadcastChannel = BroadcastChannel;
 
 /**
  * Mock these properties twice so that they're available


### PR DESCRIPTION
This allows the download status and progress to be shared between windows:

https://github.com/electron/fiddle/assets/19478575/6b666696-e298-4b4a-8236-ed2c8d238be7

I also tried to make the BroadcastChannel logic extensible so we can use it to sync other data in the future.