### PR TITLE
refactor: use @observer class decorator

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -41,430 +41,427 @@ interface IGistActionButtonState {
  * @class GistActionButton
  * @extends {React.Component<GistActionButtonProps, GistActionButtonState>}
  */
-export const GistActionButton = observer(
-  class GistActionButton extends React.Component<
-    GistActionButtonProps,
-    IGistActionButtonState
-  > {
-    public constructor(props: GistActionButtonProps) {
-      super(props);
-      this.handleClick = this.handleClick.bind(this);
-      this.performGistAction = this.performGistAction.bind(this);
-      this.setPrivate = this.setPrivate.bind(this);
-      this.setPublic = this.setPublic.bind(this);
+@observer
+export class GistActionButton extends React.Component<
+  GistActionButtonProps,
+  IGistActionButtonState
+> {
+  public constructor(props: GistActionButtonProps) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.performGistAction = this.performGistAction.bind(this);
+    this.setPrivate = this.setPrivate.bind(this);
+    this.setPublic = this.setPublic.bind(this);
 
-      this.state = {
-        isUpdating: false,
-        isDeleting: false,
-        actionType: GistActionType.publish,
-      };
-
-      window.ElectronFiddle.removeAllListeners('save-fiddle-gist');
-    }
-
-    private toaster: Toaster;
-    private refHandlers = {
-      toaster: (ref: Toaster) => (this.toaster = ref),
+    this.state = {
+      isUpdating: false,
+      isDeleting: false,
+      actionType: GistActionType.publish,
     };
 
-    public componentDidMount() {
-      window.ElectronFiddle.addEventListener(
-        'save-fiddle-gist',
-        this.handleClick,
-      );
+    window.ElectronFiddle.removeAllListeners('save-fiddle-gist');
+  }
+
+  private toaster: Toaster;
+  private refHandlers = {
+    toaster: (ref: Toaster) => (this.toaster = ref),
+  };
+
+  public componentDidMount() {
+    window.ElectronFiddle.addEventListener(
+      'save-fiddle-gist',
+      this.handleClick,
+    );
+  }
+
+  public componentWillUnmount() {
+    window.ElectronFiddle.removeAllListeners('save-fiddle-gist');
+  }
+
+  /**
+   * When the user clicks the publish button, we either show the
+   * authentication dialog or publish right away.
+   *
+   * If we're showing the authentication dialog, we wait for it
+   * to be closed again (or a GitHub token to show up) before
+   * we publish
+   *
+   * @returns {Promise<void>}
+   * @memberof GistActionButton
+   */
+  public async handleClick(): Promise<void> {
+    const { appState } = this.props;
+
+    if (!appState.gitHubToken) {
+      appState.toggleAuthDialog();
     }
 
-    public componentWillUnmount() {
-      window.ElectronFiddle.removeAllListeners('save-fiddle-gist');
+    // Wait for the dialog to be closed again
+    await when(() => !appState.isTokenDialogShowing);
+
+    if (appState.gitHubToken) {
+      return this.performGistAction();
     }
+  }
 
-    /**
-     * When the user clicks the publish button, we either show the
-     * authentication dialog or publish right away.
-     *
-     * If we're showing the authentication dialog, we wait for it
-     * to be closed again (or a GitHub token to show up) before
-     * we publish
-     *
-     * @returns {Promise<void>}
-     * @memberof GistActionButton
-     */
-    public async handleClick(): Promise<void> {
-      const { appState } = this.props;
+  private getFiddleDescriptionFromUser(): Promise<string | undefined> {
+    const placeholder = 'Electron Fiddle Gist' as const;
+    return this.props.appState.showInputDialog({
+      defaultInput: placeholder,
+      label: 'Please provide a brief description for your Fiddle Gist',
+      ok: 'Publish',
+      placeholder,
+    });
+  }
 
-      if (!appState.gitHubToken) {
-        appState.toggleAuthDialog();
-      }
+  private async publishGist(description: string): Promise<boolean> {
+    const { appState } = this.props;
 
-      // Wait for the dialog to be closed again
-      await when(() => !appState.isTokenDialogShowing);
+    const octo = await getOctokit(appState);
+    const { gitHubPublishAsPublic } = appState;
+    const options = { includeDependencies: true, includeElectron: true };
+    const defaultGistValues = await window.ElectronFiddle.getTemplate(
+      appState.version,
+    );
+    const currentEditorValues = await window.ElectronFiddle.app.getEditorValues(
+      options,
+    );
 
-      if (appState.gitHubToken) {
-        return this.performGistAction();
-      }
-    }
+    defaultGistValues[PACKAGE_NAME as EditorId] =
+      currentEditorValues[PACKAGE_NAME as EditorId];
 
-    private getFiddleDescriptionFromUser(): Promise<string | undefined> {
-      const placeholder = 'Electron Fiddle Gist' as const;
-      return this.props.appState.showInputDialog({
-        defaultInput: placeholder,
-        label: 'Please provide a brief description for your Fiddle Gist',
-        ok: 'Publish',
-        placeholder,
+    try {
+      const gistFilesList = appState.isPublishingGistAsRevision
+        ? this.gistFilesList(defaultGistValues)
+        : this.gistFilesList(currentEditorValues);
+
+      const gist = await octo.gists.create({
+        public: !!gitHubPublishAsPublic,
+        description,
+        files: gistFilesList,
       });
+
+      appState.gistId = gist.data.id;
+      appState.localPath = undefined;
+
+      if (appState.isPublishingGistAsRevision) {
+        await this.handleUpdate(appState.isPublishingGistAsRevision);
+      }
+
+      console.log(`Publish Button: Publishing complete`, { gist });
+      this.renderToast({
+        message: 'Successfully published gist!',
+        action: {
+          text: 'Copy link',
+          icon: 'clipboard',
+          onClick: () => navigator.clipboard.writeText(gist.data.html_url),
+        },
+      });
+
+      // Only set action type to update if publish completed successfully.
+      this.setActionType(GistActionType.update);
+
+      return true;
+    } catch (error) {
+      console.warn(`Could not publish gist`, { error });
+
+      window.ElectronFiddle.showWarningDialog({
+        message:
+          'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
+        detail: `GitHub encountered the following error: ${error.message}`,
+      });
+
+      return false;
     }
+  }
 
-    private async publishGist(description: string): Promise<boolean> {
-      const { appState } = this.props;
+  /**
+   * Publish a new GitHub gist.
+   */
+  public async handlePublish() {
+    const { appState } = this.props;
+    appState.activeGistAction = GistActionState.publishing;
 
-      const octo = await getOctokit(appState);
-      const { gitHubPublishAsPublic } = appState;
-      const options = { includeDependencies: true, includeElectron: true };
-      const defaultGistValues = await window.ElectronFiddle.getTemplate(
-        appState.version,
-      );
-      const currentEditorValues = await window.ElectronFiddle.app.getEditorValues(
-        options,
-      );
+    try {
+      const description = await this.getFiddleDescriptionFromUser();
 
-      defaultGistValues[PACKAGE_NAME as EditorId] =
-        currentEditorValues[PACKAGE_NAME as EditorId];
-
-      try {
-        const gistFilesList = appState.isPublishingGistAsRevision
-          ? this.gistFilesList(defaultGistValues)
-          : this.gistFilesList(currentEditorValues);
-
-        const gist = await octo.gists.create({
-          public: !!gitHubPublishAsPublic,
-          description,
-          files: gistFilesList,
-        });
-
-        appState.gistId = gist.data.id;
-        appState.localPath = undefined;
-
-        if (appState.isPublishingGistAsRevision) {
-          await this.handleUpdate(appState.isPublishingGistAsRevision);
+      if (description) {
+        if (await this.publishGist(description)) {
+          appState.editorMosaic.isEdited = false;
         }
+      }
+    } finally {
+      appState.activeGistAction = GistActionState.none;
+    }
+  }
 
-        console.log(`Publish Button: Publishing complete`, { gist });
+  /**
+   * Update an existing GitHub gist.
+   * silently updates the gist when publishing as a revision
+   */
+  public async handleUpdate(silent = false) {
+    const { appState } = this.props;
+    const octo = await getOctokit(this.props.appState);
+    const options = { includeDependencies: true, includeElectron: true };
+    const values = await window.ElectronFiddle.app.getEditorValues(options);
+
+    appState.activeGistAction = GistActionState.updating;
+
+    try {
+      const {
+        data: { files: oldFiles },
+      } = await octo.gists.get({ gist_id: appState.gistId! });
+
+      const files = this.gistFilesList(values);
+      for (const id of Object.keys(oldFiles)) {
+        // Gist files are deleted by setting content to an empty string.
+        if (!(id in files)) files[id] = { content: '' };
+      }
+
+      const gist = await octo.gists.update({
+        gist_id: appState.gistId!,
+        files,
+      });
+
+      appState.editorMosaic.isEdited = false;
+      console.log('Updating: Updating done', { gist });
+
+      if (!silent) {
         this.renderToast({
-          message: 'Successfully published gist!',
+          message: 'Successfully updated gist!',
           action: {
             text: 'Copy link',
             icon: 'clipboard',
             onClick: () => navigator.clipboard.writeText(gist.data.html_url),
           },
         });
-
-        // Only set action type to update if publish completed successfully.
-        this.setActionType(GistActionType.update);
-
-        return true;
-      } catch (error) {
-        console.warn(`Could not publish gist`, { error });
-
-        window.ElectronFiddle.showWarningDialog({
-          message:
-            'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
-          detail: `GitHub encountered the following error: ${error.message}`,
-        });
-
-        return false;
       }
+    } catch (error) {
+      console.warn(`Could not update gist`, { error });
+
+      window.ElectronFiddle.showWarningDialog({
+        message:
+          'Updating Fiddle Gist failed. Are you connected to the Internet and is this your Gist?',
+        detail: `GitHub encountered the following error: ${error.message}`,
+        buttons: ['Ok'],
+      });
     }
 
-    /**
-     * Publish a new GitHub gist.
-     */
-    public async handlePublish() {
-      const { appState } = this.props;
-      appState.activeGistAction = GistActionState.publishing;
+    appState.activeGistAction = GistActionState.none;
+    this.setActionType(GistActionType.update);
+  }
 
-      try {
-        const description = await this.getFiddleDescriptionFromUser();
+  /**
+   * Delete an existing GitHub gist.
+   */
+  public async handleDelete() {
+    const { appState } = this.props;
+    const octo = await getOctokit(this.props.appState);
 
-        if (description) {
-          if (await this.publishGist(description)) {
-            appState.editorMosaic.isEdited = false;
-          }
-        }
-      } finally {
-        appState.activeGistAction = GistActionState.none;
-      }
+    appState.activeGistAction = GistActionState.deleting;
+
+    try {
+      const gist = await octo.gists.delete({
+        gist_id: appState.gistId!,
+      });
+
+      appState.editorMosaic.isEdited = true;
+      console.log('Deleting: Deleting done', { gist });
+      this.renderToast({ message: 'Successfully deleted gist!' });
+    } catch (error) {
+      console.warn(`Could not delete gist`, { error });
+
+      window.ElectronFiddle.showWarningDialog({
+        message:
+          'Deleting Fiddle Gist failed. Are you connected to the Internet, is this your Gist, and have you loaded it?',
+        detail: `GitHub encountered the following error: ${error.message}`,
+      });
     }
 
-    /**
-     * Update an existing GitHub gist.
-     * silently updates the gist when publishing as a revision
-     */
-    public async handleUpdate(silent = false) {
-      const { appState } = this.props;
-      const octo = await getOctokit(this.props.appState);
-      const options = { includeDependencies: true, includeElectron: true };
-      const values = await window.ElectronFiddle.app.getEditorValues(options);
+    appState.gistId = undefined;
+    appState.activeGistAction = GistActionState.none;
+    this.setActionType(GistActionType.publish);
+  }
 
-      appState.activeGistAction = GistActionState.updating;
+  /**
+   * Connect with GitHub, perform a publish/update/delete action,
+   * and update all related properties in the app state.
+   */
+  public async performGistAction(): Promise<void> {
+    const { gistId } = this.props.appState;
 
-      try {
-        const {
-          data: { files: oldFiles },
-        } = await octo.gists.get({ gist_id: appState.gistId! });
+    const actionType = gistId ? this.state.actionType : GistActionType.publish;
 
-        const files = this.gistFilesList(values);
-        for (const id of Object.keys(oldFiles)) {
-          // Gist files are deleted by setting content to an empty string.
-          if (!(id in files)) files[id] = { content: '' };
-        }
+    switch (actionType) {
+      case GistActionType.delete:
+        return this.handleDelete();
 
-        const gist = await octo.gists.update({
-          gist_id: appState.gistId!,
-          files,
-        });
+      case GistActionType.publish:
+        return this.handlePublish();
 
-        appState.editorMosaic.isEdited = false;
-        console.log('Updating: Updating done', { gist });
-
-        if (!silent) {
-          this.renderToast({
-            message: 'Successfully updated gist!',
-            action: {
-              text: 'Copy link',
-              icon: 'clipboard',
-              onClick: () => navigator.clipboard.writeText(gist.data.html_url),
-            },
-          });
-        }
-      } catch (error) {
-        console.warn(`Could not update gist`, { error });
-
-        window.ElectronFiddle.showWarningDialog({
-          message:
-            'Updating Fiddle Gist failed. Are you connected to the Internet and is this your Gist?',
-          detail: `GitHub encountered the following error: ${error.message}`,
-          buttons: ['Ok'],
-        });
-      }
-
-      appState.activeGistAction = GistActionState.none;
-      this.setActionType(GistActionType.update);
+      case GistActionType.update:
+        return this.handleUpdate();
     }
+  }
 
-    /**
-     * Delete an existing GitHub gist.
-     */
-    public async handleDelete() {
-      const { appState } = this.props;
-      const octo = await getOctokit(this.props.appState);
+  /**
+   * Publish fiddles as private.
+   *
+   * @memberof GistActionButton
+   */
+  public setPrivate() {
+    this.setPrivacy(false);
+  }
 
-      appState.activeGistAction = GistActionState.deleting;
+  /**
+   * Publish fiddles as public.
+   *
+   * @memberof GistActionButton
+   */
+  public setPublic() {
+    this.setPrivacy(true);
+  }
 
-      try {
-        const gist = await octo.gists.delete({
-          gist_id: appState.gistId!,
-        });
+  public render() {
+    const { gistId, activeGistAction } = this.props.appState;
+    const { actionType } = this.state;
 
-        appState.editorMosaic.isEdited = true;
-        console.log('Deleting: Deleting done', { gist });
-        this.renderToast({ message: 'Successfully deleted gist!' });
-      } catch (error) {
-        console.warn(`Could not delete gist`, { error });
-
-        window.ElectronFiddle.showWarningDialog({
-          message:
-            'Deleting Fiddle Gist failed. Are you connected to the Internet, is this your Gist, and have you loaded it?',
-          detail: `GitHub encountered the following error: ${error.message}`,
-        });
+    const getTextForButton = () => {
+      let text;
+      if (gistId) {
+        text = actionType;
+      } else if (activeGistAction === GistActionState.updating) {
+        text = 'Updating...';
+      } else if (activeGistAction === GistActionState.publishing) {
+        text = 'Publishing...';
+      } else if (activeGistAction === GistActionState.deleting) {
+        text = 'Deleting...';
+      } else {
+        text = 'Publish';
       }
+      return text;
+    };
 
-      appState.gistId = undefined;
-      appState.activeGistAction = GistActionState.none;
-      this.setActionType(GistActionType.publish);
-    }
-
-    /**
-     * Connect with GitHub, perform a publish/update/delete action,
-     * and update all related properties in the app state.
-     */
-    public async performGistAction(): Promise<void> {
-      const { gistId } = this.props.appState;
-
-      const actionType = gistId
-        ? this.state.actionType
-        : GistActionType.publish;
-
+    const getActionIcon = () => {
       switch (actionType) {
-        case GistActionType.delete:
-          return this.handleDelete();
-
         case GistActionType.publish:
-          return this.handlePublish();
-
+          return 'upload';
         case GistActionType.update:
-          return this.handleUpdate();
+          return 'refresh';
+        case GistActionType.delete:
+          return 'delete';
       }
-    }
-
-    /**
-     * Publish fiddles as private.
-     *
-     * @memberof GistActionButton
-     */
-    public setPrivate() {
-      this.setPrivacy(false);
-    }
-
-    /**
-     * Publish fiddles as public.
-     *
-     * @memberof GistActionButton
-     */
-    public setPublic() {
-      this.setPrivacy(true);
-    }
-
-    public render() {
-      const { gistId, activeGistAction } = this.props.appState;
-      const { actionType } = this.state;
-
-      const getTextForButton = () => {
-        let text;
-        if (gistId) {
-          text = actionType;
-        } else if (activeGistAction === GistActionState.updating) {
-          text = 'Updating...';
-        } else if (activeGistAction === GistActionState.publishing) {
-          text = 'Publishing...';
-        } else if (activeGistAction === GistActionState.deleting) {
-          text = 'Deleting...';
-        } else {
-          text = 'Publish';
-        }
-        return text;
-      };
-
-      const getActionIcon = () => {
-        switch (actionType) {
-          case GistActionType.publish:
-            return 'upload';
-          case GistActionType.update:
-            return 'refresh';
-          case GistActionType.delete:
-            return 'delete';
-        }
-      };
-
-      const isPerformingAction = activeGistAction !== GistActionState.none;
-      return (
-        <>
-          <fieldset disabled={isPerformingAction}>
-            <ButtonGroup className="button-gist-action">
-              {this.renderPrivacyMenu()}
-              <Button
-                onClick={this.handleClick}
-                loading={isPerformingAction}
-                icon={getActionIcon()}
-                text={getTextForButton()}
-              />
-              {this.renderGistActionMenu()}
-            </ButtonGroup>
-          </fieldset>
-          <Toaster
-            position={Position.BOTTOM_RIGHT}
-            ref={this.refHandlers.toaster}
-          />
-        </>
-      );
-    }
-
-    private renderGistActionMenu = () => {
-      const { gistId } = this.props.appState;
-      const { actionType } = this.state;
-
-      if (!gistId) {
-        return null;
-      }
-
-      const menu = (
-        <Menu>
-          <MenuItem
-            text="Publish"
-            active={actionType === GistActionType.publish}
-            onClick={() => this.setActionType(GistActionType.publish)}
-          />
-          <MenuItem
-            text="Update"
-            active={actionType === GistActionType.update}
-            onClick={() => this.setActionType(GistActionType.update)}
-          />
-          <MenuItem
-            text="Delete"
-            active={actionType === GistActionType.delete}
-            onClick={() => this.setActionType(GistActionType.delete)}
-          />
-        </Menu>
-      );
-
-      return (
-        <Popover content={menu} position={Position.BOTTOM}>
-          <Button icon="wrench" />
-        </Popover>
-      );
     };
 
-    private renderPrivacyMenu = () => {
-      const { gitHubPublishAsPublic, gistId } = this.props.appState;
-      const { actionType } = this.state;
+    const isPerformingAction = activeGistAction !== GistActionState.none;
+    return (
+      <>
+        <fieldset disabled={isPerformingAction}>
+          <ButtonGroup className="button-gist-action">
+            {this.renderPrivacyMenu()}
+            <Button
+              onClick={this.handleClick}
+              loading={isPerformingAction}
+              icon={getActionIcon()}
+              text={getTextForButton()}
+            />
+            {this.renderGistActionMenu()}
+          </ButtonGroup>
+        </fieldset>
+        <Toaster
+          position={Position.BOTTOM_RIGHT}
+          ref={this.refHandlers.toaster}
+        />
+      </>
+    );
+  }
 
-      if (gistId && actionType !== GistActionType.publish) {
-        return null;
-      }
+  private renderGistActionMenu = () => {
+    const { gistId } = this.props.appState;
+    const { actionType } = this.state;
 
-      const privacyIcon = gitHubPublishAsPublic ? 'unlock' : 'lock';
-      const privacyMenu = (
-        <Menu>
-          <MenuItem
-            text="Private"
-            icon="lock"
-            active={!gitHubPublishAsPublic}
-            onClick={this.setPrivate}
-          />
-          <MenuItem
-            text="Public"
-            icon="unlock"
-            active={gitHubPublishAsPublic}
-            onClick={this.setPublic}
-          />
-        </Menu>
-      );
-
-      return (
-        <Popover content={privacyMenu} position={Position.BOTTOM}>
-          <Button icon={privacyIcon} />
-        </Popover>
-      );
-    };
-
-    private setActionType = (actionType: GistActionType) => {
-      this.setState({ actionType });
-    };
-
-    private setPrivacy(publishAsPublic: boolean) {
-      this.props.appState.gitHubPublishAsPublic = publishAsPublic;
+    if (!gistId) {
+      return null;
     }
 
-    private renderToast = (toast: IToastProps) => {
-      this.toaster?.show(toast);
-    };
+    const menu = (
+      <Menu>
+        <MenuItem
+          text="Publish"
+          active={actionType === GistActionType.publish}
+          onClick={() => this.setActionType(GistActionType.publish)}
+        />
+        <MenuItem
+          text="Update"
+          active={actionType === GistActionType.update}
+          onClick={() => this.setActionType(GistActionType.update)}
+        />
+        <MenuItem
+          text="Delete"
+          active={actionType === GistActionType.delete}
+          onClick={() => this.setActionType(GistActionType.delete)}
+        />
+      </Menu>
+    );
 
-    private gistFilesList = (values: EditorValues) => {
-      values = ensureRequiredFiles(values);
-      return Object.fromEntries(
-        Object.entries(values)
-          .filter(([, content]) => Boolean(content))
-          .map(([id, content]) => [id, { content }]),
-      );
-    };
-  },
-);
+    return (
+      <Popover content={menu} position={Position.BOTTOM}>
+        <Button icon="wrench" />
+      </Popover>
+    );
+  };
+
+  private renderPrivacyMenu = () => {
+    const { gitHubPublishAsPublic, gistId } = this.props.appState;
+    const { actionType } = this.state;
+
+    if (gistId && actionType !== GistActionType.publish) {
+      return null;
+    }
+
+    const privacyIcon = gitHubPublishAsPublic ? 'unlock' : 'lock';
+    const privacyMenu = (
+      <Menu>
+        <MenuItem
+          text="Private"
+          icon="lock"
+          active={!gitHubPublishAsPublic}
+          onClick={this.setPrivate}
+        />
+        <MenuItem
+          text="Public"
+          icon="unlock"
+          active={gitHubPublishAsPublic}
+          onClick={this.setPublic}
+        />
+      </Menu>
+    );
+
+    return (
+      <Popover content={privacyMenu} position={Position.BOTTOM}>
+        <Button icon={privacyIcon} />
+      </Popover>
+    );
+  };
+
+  private setActionType = (actionType: GistActionType) => {
+    this.setState({ actionType });
+  };
+
+  private setPrivacy(publishAsPublic: boolean) {
+    this.props.appState.gitHubPublishAsPublic = publishAsPublic;
+  }
+
+  private renderToast = (toast: IToastProps) => {
+    this.toaster?.show(toast);
+  };
+
+  private gistFilesList = (values: EditorValues) => {
+    values = ensureRequiredFiles(values);
+    return Object.fromEntries(
+      Object.entries(values)
+        .filter(([, content]) => Boolean(content))
+        .map(([id, content]) => [id, { content }]),
+    );
+  };
+}

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -21,134 +21,134 @@ interface AddressBarState {
   };
 }
 
-export const AddressBar = observer(
-  class AddressBar extends React.Component<AddressBarProps, AddressBarState> {
-    constructor(props: AddressBarProps) {
-      super(props);
-      this.handleSubmit = this.handleSubmit.bind(this);
-      this.handleChange = this.handleChange.bind(this);
-      this.handleBlur = this.handleBlur.bind(this);
-      this.submit = this.submit.bind(this);
+@observer
+export class AddressBar extends React.Component<
+  AddressBarProps,
+  AddressBarState
+> {
+  constructor(props: AddressBarProps) {
+    super(props);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+    this.submit = this.submit.bind(this);
 
-      const { gistId } = this.props.appState;
-      const value = urlFromId(gistId);
+    const { gistId } = this.props.appState;
+    const value = urlFromId(gistId);
 
-      const { remoteLoader } = window.ElectronFiddle.app;
+    const { remoteLoader } = window.ElectronFiddle.app;
 
-      this.state = {
-        value,
-        loaders: {
-          gist: remoteLoader.loadFiddleFromGist.bind(remoteLoader),
-          example: remoteLoader.loadFiddleFromElectronExample.bind(
-            remoteLoader,
-          ),
-        },
-      };
-    }
+    this.state = {
+      value,
+      loaders: {
+        gist: remoteLoader.loadFiddleFromGist.bind(remoteLoader),
+        example: remoteLoader.loadFiddleFromElectronExample.bind(remoteLoader),
+      },
+    };
+  }
 
-    /**
-     * Handle the form's submit event, trying to load whatever
-     * URL was entered.
-     *
-     * @param {React.SyntheticEvent<HTMLFormElement>} event
-     */
-    private handleSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
-      event.preventDefault();
-      this.submit();
-    }
+  /**
+   * Handle the form's submit event, trying to load whatever
+   * URL was entered.
+   *
+   * @param {React.SyntheticEvent<HTMLFormElement>} event
+   */
+  private handleSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault();
+    this.submit();
+  }
 
-    /**
-     * Commit the address bar's value to app state and load the fiddle.
-     *
-     * @memberof AddressBar
-     */
-    private submit() {
-      const { remoteLoader } = window.ElectronFiddle.app;
-      if (this.state.value) {
-        remoteLoader.fetchGistAndLoad(
-          idFromUrl(this.state.value) || this.state.value,
-        );
-      }
-    }
-
-    /**
-     * Once the component mounts, we'll subscribe to gistId changes
-     */
-    public componentDidMount() {
-      const { appState } = this.props;
-      const { loaders } = this.state;
-      reaction(
-        () => appState.gistId,
-        (gistId: string) => this.setState({ value: urlFromId(gistId) }),
-      );
-      window.ElectronFiddle.addEventListener('load-gist', loaders.gist);
-      window.ElectronFiddle.addEventListener('load-example', loaders.example);
-    }
-
-    public componentWillUnmount() {
-      window.ElectronFiddle.removeAllListeners('load-gist');
-      window.ElectronFiddle.removeAllListeners('load-example');
-    }
-
-    /**
-     * Handle the change event, which usually just updates the address bar's value
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     */
-    private handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-      this.setState({ value: event.target.value });
-    }
-
-    private handleBlur(event: React.FocusEvent<HTMLInputElement>) {
-      const { gistId } = this.props.appState;
-      const url = urlFromId(gistId);
-
-      const shouldResetURL =
-        url === event.target.value || event.target.value === '';
-      if (url && shouldResetURL) {
-        this.setState({ value: url });
-      }
-    }
-
-    private renderLoadButton(isValueCorrect: boolean): JSX.Element {
-      return (
-        <Button
-          disabled={!isValueCorrect}
-          icon="cloud-download"
-          text="Load Fiddle"
-          onClick={this.submit}
-        />
+  /**
+   * Commit the address bar's value to app state and load the fiddle.
+   *
+   * @memberof AddressBar
+   */
+  private submit() {
+    const { remoteLoader } = window.ElectronFiddle.app;
+    if (this.state.value) {
+      remoteLoader.fetchGistAndLoad(
+        idFromUrl(this.state.value) || this.state.value,
       );
     }
+  }
 
-    public render() {
-      const { activeGistAction } = this.props.appState;
-      const { isEdited } = this.props.appState.editorMosaic;
-      const { value } = this.state;
-      const isCorrect = /https:\/\/gist\.github\.com\/(.+)$/.test(value);
-      const className = classnames('address-bar', isEdited, { empty: !value });
+  /**
+   * Once the component mounts, we'll subscribe to gistId changes
+   */
+  public componentDidMount() {
+    const { appState } = this.props;
+    const { loaders } = this.state;
+    reaction(
+      () => appState.gistId,
+      (gistId: string) => this.setState({ value: urlFromId(gistId) }),
+    );
+    window.ElectronFiddle.addEventListener('load-gist', loaders.gist);
+    window.ElectronFiddle.addEventListener('load-example', loaders.example);
+  }
 
-      const isPerformingAction = activeGistAction !== GistActionState.none;
-      return (
-        <form
-          className={className}
-          aria-label={'Enter Fiddle Gist URL'}
-          onSubmit={this.handleSubmit}
-        >
-          <fieldset disabled={isPerformingAction}>
-            <InputGroup
-              key="addressbar"
-              leftIcon="geosearch"
-              intent={isCorrect || !value ? undefined : Intent.DANGER}
-              onChange={this.handleChange}
-              onBlur={this.handleBlur}
-              placeholder="https://gist.github.com/..."
-              value={value}
-              rightElement={this.renderLoadButton(isCorrect)}
-            />
-          </fieldset>
-        </form>
-      );
+  public componentWillUnmount() {
+    window.ElectronFiddle.removeAllListeners('load-gist');
+    window.ElectronFiddle.removeAllListeners('load-example');
+  }
+
+  /**
+   * Handle the change event, which usually just updates the address bar's value
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  private handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    this.setState({ value: event.target.value });
+  }
+
+  private handleBlur(event: React.FocusEvent<HTMLInputElement>) {
+    const { gistId } = this.props.appState;
+    const url = urlFromId(gistId);
+
+    const shouldResetURL =
+      url === event.target.value || event.target.value === '';
+    if (url && shouldResetURL) {
+      this.setState({ value: url });
     }
-  },
-);
+  }
+
+  private renderLoadButton(isValueCorrect: boolean): JSX.Element {
+    return (
+      <Button
+        disabled={!isValueCorrect}
+        icon="cloud-download"
+        text="Load Fiddle"
+        onClick={this.submit}
+      />
+    );
+  }
+
+  public render() {
+    const { activeGistAction } = this.props.appState;
+    const { isEdited } = this.props.appState.editorMosaic;
+    const { value } = this.state;
+    const isCorrect = /https:\/\/gist\.github\.com\/(.+)$/.test(value);
+    const className = classnames('address-bar', isEdited, { empty: !value });
+
+    const isPerformingAction = activeGistAction !== GistActionState.none;
+    return (
+      <form
+        className={className}
+        aria-label={'Enter Fiddle Gist URL'}
+        onSubmit={this.handleSubmit}
+      >
+        <fieldset disabled={isPerformingAction}>
+          <InputGroup
+            key="addressbar"
+            leftIcon="geosearch"
+            intent={isCorrect || !value ? undefined : Intent.DANGER}
+            onChange={this.handleChange}
+            onBlur={this.handleBlur}
+            placeholder="https://gist.github.com/..."
+            value={value}
+            rightElement={this.renderLoadButton(isCorrect)}
+          />
+        </fieldset>
+      </form>
+    );
+  }
+}

--- a/src/renderer/components/commands-bisect.tsx
+++ b/src/renderer/components/commands-bisect.tsx
@@ -10,90 +10,89 @@ interface BisectHandlerProps {
   appState: AppState;
 }
 
-export const BisectHandler = observer(
-  class BisectHandler extends React.Component<BisectHandlerProps> {
-    constructor(props: BisectHandlerProps) {
-      super(props);
+@observer
+export class BisectHandler extends React.Component<BisectHandlerProps> {
+  constructor(props: BisectHandlerProps) {
+    super(props);
 
-      this.continueBisect = this.continueBisect.bind(this);
-      this.terminateBisect = this.terminateBisect.bind(this);
+    this.continueBisect = this.continueBisect.bind(this);
+    this.terminateBisect = this.terminateBisect.bind(this);
+  }
+
+  private continueBisect(isGood: boolean) {
+    window.ElectronFiddle.app.runner.stop();
+
+    const { appState } = this.props;
+    const response = appState.Bisector!.continue(isGood);
+
+    if (Array.isArray(response)) {
+      this.terminateBisect();
+
+      const [minRev, maxRev] = response;
+      const [minVer, maxVer] = [minRev.version, maxRev.version];
+      const label = (
+        <>
+          Bisect complete. Check the range{' '}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href={`https://github.com/electron/electron/compare/v${minVer}...v${maxVer}`}
+          >
+            {minVer}...{maxVer}
+          </a>
+          .
+        </>
+      );
+
+      appState.pushOutput(`[BISECT] Complete: ${minVer}...${maxVer}`);
+      appState.showInfoDialog(label);
+    } else {
+      appState.setVersion(response.version);
     }
+  }
 
-    private continueBisect(isGood: boolean) {
-      window.ElectronFiddle.app.runner.stop();
+  private terminateBisect() {
+    const { appState } = this.props;
+    appState.Bisector = undefined;
+  }
 
-      const { appState } = this.props;
-      const response = appState.Bisector!.continue(isGood);
-
-      if (Array.isArray(response)) {
-        this.terminateBisect();
-
-        const [minRev, maxRev] = response;
-        const [minVer, maxVer] = [minRev.version, maxRev.version];
-        const label = (
-          <>
-            Bisect complete. Check the range{' '}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={`https://github.com/electron/electron/compare/v${minVer}...v${maxVer}`}
-            >
-              {minVer}...{maxVer}
-            </a>
-            .
-          </>
-        );
-
-        appState.pushOutput(`[BISECT] Complete: ${minVer}...${maxVer}`);
-        appState.showInfoDialog(label);
-      } else {
-        appState.setVersion(response.version);
-      }
-    }
-
-    private terminateBisect() {
-      const { appState } = this.props;
-      appState.Bisector = undefined;
-    }
-
-    public render() {
-      const { appState } = this.props;
-      if (!!appState.Bisector) {
-        const isDownloading =
-          appState.currentElectronVersion.state === InstallState.downloading;
-        return (
-          <>
-            <Button
-              icon={'thumbs-up'}
-              aria-label={'Mark commit as good'}
-              onClick={() => this.continueBisect(true)}
-              disabled={isDownloading}
-            />
-            <Button
-              icon={'thumbs-down'}
-              aria-label={'Mark commit as bad'}
-              onClick={() => this.continueBisect(false)}
-              disabled={isDownloading}
-            />
-            <Button
-              aria-label={'Cancel bisect'}
-              icon={'cross'}
-              onClick={this.terminateBisect}
-            >
-              Cancel Bisect
-            </Button>
-          </>
-        );
-      } else {
-        return (
+  public render() {
+    const { appState } = this.props;
+    if (!!appState.Bisector) {
+      const isDownloading =
+        appState.currentElectronVersion.state === InstallState.downloading;
+      return (
+        <>
           <Button
-            icon="git-branch"
-            text="Bisect"
-            disabled={appState.isAutoBisecting}
-            onClick={appState.toggleBisectDialog}
+            icon={'thumbs-up'}
+            aria-label={'Mark commit as good'}
+            onClick={() => this.continueBisect(true)}
+            disabled={isDownloading}
           />
-        );
-      }
+          <Button
+            icon={'thumbs-down'}
+            aria-label={'Mark commit as bad'}
+            onClick={() => this.continueBisect(false)}
+            disabled={isDownloading}
+          />
+          <Button
+            aria-label={'Cancel bisect'}
+            icon={'cross'}
+            onClick={this.terminateBisect}
+          >
+            Cancel Bisect
+          </Button>
+        </>
+      );
+    } else {
+      return (
+        <Button
+          icon="git-branch"
+          text="Bisect"
+          disabled={appState.isAutoBisecting}
+          onClick={appState.toggleBisectDialog}
+        />
+      );
     }
-  },
-);
+  }
+}

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -17,73 +17,69 @@ interface RunnerProps {
  * @class Runner
  * @extends {React.Component<RunnerProps>}
  */
-export const Runner = observer(
-  class Runner extends React.Component<RunnerProps> {
-    public render() {
-      const {
-        downloaded,
-        downloading,
-        missing,
-        installing,
-        installed,
-      } = InstallState;
-      const {
-        isRunning,
-        isInstallingModules,
-        currentElectronVersion,
-        isOnline,
-      } = this.props.appState;
+@observer
+export class Runner extends React.Component<RunnerProps> {
+  public render() {
+    const {
+      downloaded,
+      downloading,
+      missing,
+      installing,
+      installed,
+    } = InstallState;
+    const {
+      isRunning,
+      isInstallingModules,
+      currentElectronVersion,
+      isOnline,
+    } = this.props.appState;
 
-      const state = currentElectronVersion?.state;
-      const props: ButtonProps = { className: 'button-run', disabled: true };
+    const state = currentElectronVersion?.state;
+    const props: ButtonProps = { className: 'button-run', disabled: true };
 
-      if ([downloading, missing].includes(state) && !isOnline) {
-        props.text = 'Offline';
-        props.icon = 'satellite';
-        return <Button {...props} type={undefined} />;
-      }
-
-      switch (state) {
-        case downloading: {
-          props.text = 'Downloading';
-          props.icon = (
-            <Spinner
-              size={16}
-              value={currentElectronVersion?.downloadProgress}
-            />
-          );
-          break;
-        }
-        case installing: {
-          props.text = 'Unzipping';
-          props.icon = <Spinner size={16} />;
-          break;
-        }
-        case downloaded:
-        case installed: {
-          props.disabled = false;
-          if (isRunning) {
-            props.active = true;
-            props.text = 'Stop';
-            props.onClick = window.ElectronFiddle.app.runner.stop;
-            props.icon = 'stop';
-          } else if (isInstallingModules) {
-            props.text = 'Installing modules';
-            props.icon = <Spinner size={16} />;
-          } else {
-            props.text = 'Run';
-            props.onClick = window.ElectronFiddle.app.runner.run;
-            props.icon = 'play';
-          }
-          break;
-        }
-        default: {
-          props.text = 'Checking status';
-          props.icon = <Spinner size={16} />;
-        }
-      }
-
+    if ([downloading, missing].includes(state) && !isOnline) {
+      props.text = 'Offline';
+      props.icon = 'satellite';
       return <Button {...props} type={undefined} />;
     }
-  },
-);
+
+    switch (state) {
+      case downloading: {
+        props.text = 'Downloading';
+        props.icon = (
+          <Spinner size={16} value={currentElectronVersion?.downloadProgress} />
+        );
+        break;
+      }
+      case installing: {
+        props.text = 'Unzipping';
+        props.icon = <Spinner size={16} />;
+        break;
+      }
+      case downloaded:
+      case installed: {
+        props.disabled = false;
+        if (isRunning) {
+          props.active = true;
+          props.text = 'Stop';
+          props.onClick = window.ElectronFiddle.app.runner.stop;
+          props.icon = 'stop';
+        } else if (isInstallingModules) {
+          props.text = 'Installing modules';
+          props.icon = <Spinner size={16} />;
+        } else {
+          props.text = 'Run';
+          props.onClick = window.ElectronFiddle.app.runner.run;
+          props.icon = 'play';
+        }
+        break;
+      }
+      default: {
+        props.text = 'Checking status';
+        props.icon = <Spinner size={16} />;
+      }
+    }
+
+    return <Button {...props} type={undefined} />;
+  }
+}

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -21,67 +21,66 @@ interface CommandsProps {
  * @class Commands
  * @extends {React.Component<CommandsProps>}
  */
-export const Commands = observer(
-  class Commands extends React.Component<CommandsProps> {
-    constructor(props: CommandsProps) {
-      super(props);
+@observer
+export class Commands extends React.Component<CommandsProps> {
+  constructor(props: CommandsProps) {
+    super(props);
+  }
+
+  private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Only maximize if the toolbar itself is clicked (ignore for buttons, input, etc)
+    if (e.currentTarget === e.target) {
+      window.ElectronFiddle.macTitlebarClicked();
     }
+  };
 
-    private handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-      // Only maximize if the toolbar itself is clicked (ignore for buttons, input, etc)
-      if (e.currentTarget === e.target) {
-        window.ElectronFiddle.macTitlebarClicked();
-      }
-    };
+  public render() {
+    const { appState } = this.props;
+    const { isBisectCommandShowing, title } = appState;
 
-    public render() {
-      const { appState } = this.props;
-      const { isBisectCommandShowing, title } = appState;
-
-      return (
-        <div
-          className={
-            window.ElectronFiddle.platform === 'darwin'
-              ? 'commands is-mac'
-              : 'commands'
-          }
-          onDoubleClick={this.handleDoubleClick}
-        >
-          <div>
+    return (
+      <div
+        className={
+          window.ElectronFiddle.platform === 'darwin'
+            ? 'commands is-mac'
+            : 'commands'
+        }
+        onDoubleClick={this.handleDoubleClick}
+      >
+        <div>
+          <ControlGroup fill={true} vertical={false}>
+            <Button
+              icon="cog"
+              title="Setting"
+              onClick={appState.toggleSettings}
+            />
+          </ControlGroup>
+          <ControlGroup fill={true} vertical={false}>
+            <VersionChooser appState={appState} />
+            <Runner appState={appState} />
+          </ControlGroup>
+          {isBisectCommandShowing && (
             <ControlGroup fill={true} vertical={false}>
-              <Button
-                icon="cog"
-                title="Setting"
-                onClick={appState.toggleSettings}
-              />
+              <BisectHandler appState={appState} />
             </ControlGroup>
-            <ControlGroup fill={true} vertical={false}>
-              <VersionChooser appState={appState} />
-              <Runner appState={appState} />
-            </ControlGroup>
-            {isBisectCommandShowing && (
-              <ControlGroup fill={true} vertical={false}>
-                <BisectHandler appState={appState} />
-              </ControlGroup>
-            )}
-            <ControlGroup fill={true} vertical={false}>
-              <Button
-                active={appState.isConsoleShowing}
-                icon="console"
-                text="Console"
-                onClick={appState.toggleConsole}
-              />
-            </ControlGroup>
-          </div>
-          {window.ElectronFiddle.platform === 'darwin' ? (
-            <div className="title">{title}</div>
-          ) : undefined}
-          <div>
-            <AddressBar appState={appState} />
-            <GistActionButton appState={appState} />
-          </div>
+          )}
+          <ControlGroup fill={true} vertical={false}>
+            <Button
+              active={appState.isConsoleShowing}
+              icon="console"
+              text="Console"
+              onClick={appState.toggleConsole}
+            />
+          </ControlGroup>
         </div>
-      );
-    }
-  },
-);
+        {window.ElectronFiddle.platform === 'darwin' ? (
+          <div className="title">{title}</div>
+        ) : undefined}
+        <div>
+          <AddressBar appState={appState} />
+          <GistActionButton appState={appState} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -35,220 +35,214 @@ interface AddVersionDialogState {
  * @class AddVersionDialog
  * @extends {React.Component<AddVersionDialogProps, AddVersionDialogState>}
  */
-export const AddVersionDialog = observer(
-  class AddVersionDialog extends React.Component<
-    AddVersionDialogProps,
-    AddVersionDialogState
-  > {
-    constructor(props: AddVersionDialogProps) {
-      super(props);
+@observer
+export class AddVersionDialog extends React.Component<
+  AddVersionDialogProps,
+  AddVersionDialogState
+> {
+  constructor(props: AddVersionDialogProps) {
+    super(props);
 
-      this.state = {
-        isValidVersion: false,
-        isValidElectron: false,
-        version: '',
-      };
+    this.state = {
+      isValidVersion: false,
+      isValidElectron: false,
+      version: '',
+    };
 
-      this.onSubmit = this.onSubmit.bind(this);
-      this.onClose = this.onClose.bind(this);
-      this.onChangeVersion = this.onChangeVersion.bind(this);
-    }
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onClose = this.onClose.bind(this);
+    this.onChangeVersion = this.onChangeVersion.bind(this);
+  }
 
-    /**
-     * Show dialog to select a local version and update state
-     */
-    public async selectLocalVersion(): Promise<void> {
-      const selected = await window.ElectronFiddle.selectLocalVersion();
-      if (selected) {
-        const { folderPath, isValidElectron, localName } = selected;
-        const existingLocalVersion = getLocalVersionForPath(folderPath);
-
-        this.setState({
-          existingLocalVersion,
-          folderPath,
-          isValidElectron,
-          localName,
-        });
-      }
-    }
-
-    /**
-     * Handles a change of the file input
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     */
-    public onChangeVersion(event: React.ChangeEvent<HTMLInputElement>) {
-      const version = event.target.value || '';
-      const isValidVersion = !!semver.valid(version);
+  /**
+   * Show dialog to select a local version and update state
+   */
+  public async selectLocalVersion(): Promise<void> {
+    const selected = await window.ElectronFiddle.selectLocalVersion();
+    if (selected) {
+      const { folderPath, isValidElectron, localName } = selected;
+      const existingLocalVersion = getLocalVersionForPath(folderPath);
 
       this.setState({
-        version,
-        isValidVersion,
-      });
-    }
-
-    /**
-     * Handles the submission of the dialog
-     *
-     * @returns {Promise<void>}
-     */
-    public async onSubmit(): Promise<void> {
-      const {
+        existingLocalVersion,
         folderPath,
-        version,
         isValidElectron,
-        existingLocalVersion,
         localName,
-      } = this.state;
-
-      if (!folderPath) return;
-
-      const toAdd: Version = {
-        localPath: folderPath,
-        version,
-        name: localName,
-      };
-
-      // swap to old local electron version if the user adds a new one with the same path
-      if (isValidElectron && existingLocalVersion?.localPath) {
-        // set previous version as active version
-        this.props.appState.setVersion(existingLocalVersion.version);
-      } else {
-        this.props.appState.addLocalVersion(toAdd);
-      }
-      this.onClose();
-    }
-
-    /**
-     * Closes the dialog
-     */
-    public onClose() {
-      this.props.appState.isAddVersionDialogShowing = false;
-      this.reset();
-    }
-
-    get buttons() {
-      const {
-        isValidElectron,
-        isValidVersion,
-        existingLocalVersion,
-      } = this.state;
-      const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
-      const canSwitch = isValidElectron && existingLocalVersion;
-
-      return [
-        <Button
-          icon="add"
-          key="submit"
-          disabled={!canAdd && !canSwitch}
-          onClick={this.onSubmit}
-          text={canSwitch ? 'Switch' : 'Add'}
-        />,
-        <Button
-          icon="cross"
-          key="cancel"
-          onClick={this.onClose}
-          text="Cancel"
-        />,
-      ];
-    }
-
-    public render() {
-      const { isAddVersionDialogShowing } = this.props.appState;
-      const inputProps = {
-        onClick: async (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-          e.preventDefault();
-          await this.selectLocalVersion();
-        },
-      };
-      const { folderPath } = this.state;
-
-      const text =
-        folderPath ||
-        `Select the folder containing ${getElectronNameForPlatform()}...`;
-
-      return (
-        <Dialog
-          isOpen={isAddVersionDialogShowing}
-          onClose={this.onClose}
-          title="Add local Electron build"
-          className="dialog-add-version"
-        >
-          <div className="bp3-dialog-body">
-            <FileInput
-              id="custom-electron-version"
-              inputProps={inputProps}
-              text={text}
-            />
-            <br />
-            {this.renderPath()}
-          </div>
-          <div className="bp3-dialog-footer">
-            <div className="bp3-dialog-footer-actions">{this.buttons}</div>
-          </div>
-        </Dialog>
-      );
-    }
-
-    private renderPath(): JSX.Element | null {
-      const { isValidElectron, folderPath, existingLocalVersion } = this.state;
-      const canSwitch = isValidElectron && existingLocalVersion;
-
-      if (!folderPath) return null;
-      return (
-        <Callout>
-          {this.buildDialogText()}
-          {!canSwitch && this.renderVersionInput()}
-        </Callout>
-      );
-    }
-
-    private buildDialogText(): string {
-      const { isValidElectron, existingLocalVersion } = this.state;
-      const canSwitch = isValidElectron && existingLocalVersion;
-
-      if (canSwitch)
-        return `This folder is already in use as version "${
-          existingLocalVersion!.version
-        }". Would you like to switch to that version now?`;
-
-      if (isValidElectron)
-        return `We found an ${getElectronNameForPlatform()} in this folder.`;
-
-      return `We did not find a ${getElectronNameForPlatform()} in this folder...`;
-    }
-
-    private renderVersionInput(): JSX.Element | null {
-      const { isValidElectron, isValidVersion, version } = this.state;
-      if (!isValidElectron) return null;
-
-      return (
-        <>
-          <p>
-            Please specify a version, used for typings and the name. Must be{' '}
-            <code>semver</code> compliant.
-          </p>
-          <InputGroup
-            intent={isValidVersion ? undefined : Intent.DANGER}
-            value={version}
-            onChange={this.onChangeVersion}
-            placeholder="4.0.0"
-          />
-        </>
-      );
-    }
-
-    /**
-     * Reset this component's state
-     */
-    private reset(): void {
-      this.setState({
-        isValidElectron: false,
-        isValidVersion: false,
-        version: '',
-        folderPath: undefined,
-        localName: undefined,
       });
     }
-  },
-);
+  }
+
+  /**
+   * Handles a change of the file input
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  public onChangeVersion(event: React.ChangeEvent<HTMLInputElement>) {
+    const version = event.target.value || '';
+    const isValidVersion = !!semver.valid(version);
+
+    this.setState({
+      version,
+      isValidVersion,
+    });
+  }
+
+  /**
+   * Handles the submission of the dialog
+   *
+   * @returns {Promise<void>}
+   */
+  public async onSubmit(): Promise<void> {
+    const {
+      folderPath,
+      version,
+      isValidElectron,
+      existingLocalVersion,
+      localName,
+    } = this.state;
+
+    if (!folderPath) return;
+
+    const toAdd: Version = {
+      localPath: folderPath,
+      version,
+      name: localName,
+    };
+
+    // swap to old local electron version if the user adds a new one with the same path
+    if (isValidElectron && existingLocalVersion?.localPath) {
+      // set previous version as active version
+      this.props.appState.setVersion(existingLocalVersion.version);
+    } else {
+      this.props.appState.addLocalVersion(toAdd);
+    }
+    this.onClose();
+  }
+
+  /**
+   * Closes the dialog
+   */
+  public onClose() {
+    this.props.appState.isAddVersionDialogShowing = false;
+    this.reset();
+  }
+
+  get buttons() {
+    const {
+      isValidElectron,
+      isValidVersion,
+      existingLocalVersion,
+    } = this.state;
+    const canAdd = isValidElectron && isValidVersion && !existingLocalVersion;
+    const canSwitch = isValidElectron && existingLocalVersion;
+
+    return [
+      <Button
+        icon="add"
+        key="submit"
+        disabled={!canAdd && !canSwitch}
+        onClick={this.onSubmit}
+        text={canSwitch ? 'Switch' : 'Add'}
+      />,
+      <Button icon="cross" key="cancel" onClick={this.onClose} text="Cancel" />,
+    ];
+  }
+
+  public render() {
+    const { isAddVersionDialogShowing } = this.props.appState;
+    const inputProps = {
+      onClick: async (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+        e.preventDefault();
+        await this.selectLocalVersion();
+      },
+    };
+    const { folderPath } = this.state;
+
+    const text =
+      folderPath ||
+      `Select the folder containing ${getElectronNameForPlatform()}...`;
+
+    return (
+      <Dialog
+        isOpen={isAddVersionDialogShowing}
+        onClose={this.onClose}
+        title="Add local Electron build"
+        className="dialog-add-version"
+      >
+        <div className="bp3-dialog-body">
+          <FileInput
+            id="custom-electron-version"
+            inputProps={inputProps}
+            text={text}
+          />
+          <br />
+          {this.renderPath()}
+        </div>
+        <div className="bp3-dialog-footer">
+          <div className="bp3-dialog-footer-actions">{this.buttons}</div>
+        </div>
+      </Dialog>
+    );
+  }
+
+  private renderPath(): JSX.Element | null {
+    const { isValidElectron, folderPath, existingLocalVersion } = this.state;
+    const canSwitch = isValidElectron && existingLocalVersion;
+
+    if (!folderPath) return null;
+    return (
+      <Callout>
+        {this.buildDialogText()}
+        {!canSwitch && this.renderVersionInput()}
+      </Callout>
+    );
+  }
+
+  private buildDialogText(): string {
+    const { isValidElectron, existingLocalVersion } = this.state;
+    const canSwitch = isValidElectron && existingLocalVersion;
+
+    if (canSwitch)
+      return `This folder is already in use as version "${
+        existingLocalVersion!.version
+      }". Would you like to switch to that version now?`;
+
+    if (isValidElectron)
+      return `We found an ${getElectronNameForPlatform()} in this folder.`;
+
+    return `We did not find a ${getElectronNameForPlatform()} in this folder...`;
+  }
+
+  private renderVersionInput(): JSX.Element | null {
+    const { isValidElectron, isValidVersion, version } = this.state;
+    if (!isValidElectron) return null;
+
+    return (
+      <>
+        <p>
+          Please specify a version, used for typings and the name. Must be{' '}
+          <code>semver</code> compliant.
+        </p>
+        <InputGroup
+          intent={isValidVersion ? undefined : Intent.DANGER}
+          value={version}
+          onChange={this.onChangeVersion}
+          placeholder="4.0.0"
+        />
+      </>
+    );
+  }
+
+  /**
+   * Reset this component's state
+   */
+  private reset(): void {
+    this.setState({
+      isValidElectron: false,
+      isValidVersion: false,
+      version: '',
+      folderPath: undefined,
+      localName: undefined,
+    });
+  }
+}

--- a/src/renderer/components/dialog-bisect.tsx
+++ b/src/renderer/components/dialog-bisect.tsx
@@ -25,245 +25,238 @@ interface BisectDialogState {
  * @class BisectDialog
  * @extends {React.Component<BisectDialogProps, BisectDialogState>}
  */
-export const BisectDialog = observer(
-  class BisectDialog extends React.Component<
-    BisectDialogProps,
-    BisectDialogState
-  > {
-    constructor(props: BisectDialogProps) {
-      super(props);
+@observer
+export class BisectDialog extends React.Component<
+  BisectDialogProps,
+  BisectDialogState
+> {
+  constructor(props: BisectDialogProps) {
+    super(props);
 
-      this.onSubmit = this.onSubmit.bind(this);
-      this.onAuto = this.onAuto.bind(this);
-      this.onClose = this.onClose.bind(this);
-      this.onBeginSelect = this.onBeginSelect.bind(this);
-      this.onEndSelect = this.onEndSelect.bind(this);
-      this.showHelp = this.showHelp.bind(this);
-      this.isEarliestItemDisabled = this.isEarliestItemDisabled.bind(this);
-      this.isLatestItemDisabled = this.isLatestItemDisabled.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onAuto = this.onAuto.bind(this);
+    this.onClose = this.onClose.bind(this);
+    this.onBeginSelect = this.onBeginSelect.bind(this);
+    this.onEndSelect = this.onEndSelect.bind(this);
+    this.showHelp = this.showHelp.bind(this);
+    this.isEarliestItemDisabled = this.isEarliestItemDisabled.bind(this);
+    this.isLatestItemDisabled = this.isLatestItemDisabled.bind(this);
 
-      const allVersions = this.props.appState.versionsToShow;
+    const allVersions = this.props.appState.versionsToShow;
 
-      this.state = {
-        allVersions,
-        startIndex: allVersions.length > 10 ? 10 : allVersions.length - 1,
-        endIndex: 0,
-      };
+    this.state = {
+      allVersions,
+      startIndex: allVersions.length > 10 ? 10 : allVersions.length - 1,
+      endIndex: 0,
+    };
+  }
+
+  public onBeginSelect(version: RunnableVersion) {
+    this.setState({ startIndex: this.state.allVersions.indexOf(version) });
+  }
+
+  public onEndSelect(version: RunnableVersion) {
+    this.setState({ endIndex: this.state.allVersions.indexOf(version) });
+  }
+
+  getBisectRange(): RunnableVersion[] {
+    const { endIndex, startIndex, allVersions } = this.state;
+    return endIndex !== undefined && startIndex !== undefined
+      ? allVersions.slice(endIndex, startIndex + 1).reverse()
+      : [];
+  }
+
+  /**
+   * Handles the submission of the dialog
+   *
+   * @returns {Promise<void>}
+   */
+  public async onSubmit(): Promise<void> {
+    const range = this.getBisectRange();
+    if (range.length > 1) {
+      const { appState } = this.props;
+      appState.Bisector = new Bisector(range);
+      const initialBisectPivot = appState.Bisector.getCurrentVersion().version;
+      appState.setVersion(initialBisectPivot);
+      this.onClose();
     }
+  }
 
-    public onBeginSelect(version: RunnableVersion) {
-      this.setState({ startIndex: this.state.allVersions.indexOf(version) });
+  public async onAuto(): Promise<void> {
+    const range = this.getBisectRange();
+    if (range.length > 1) {
+      window.ElectronFiddle.app.runner.autobisect(range);
+      this.onClose();
     }
+  }
 
-    public onEndSelect(version: RunnableVersion) {
-      this.setState({ endIndex: this.state.allVersions.indexOf(version) });
-    }
+  /**
+   * Closes the dialog
+   */
+  public onClose() {
+    this.props.appState.isBisectDialogShowing = false;
+  }
 
-    getBisectRange(): RunnableVersion[] {
-      const { endIndex, startIndex, allVersions } = this.state;
-      return endIndex !== undefined && startIndex !== undefined
-        ? allVersions.slice(endIndex, startIndex + 1).reverse()
-        : [];
-    }
+  /**
+   * Shows the additional help
+   */
+  public showHelp() {
+    this.setState({ showHelp: true });
+  }
 
-    /**
-     * Handles the submission of the dialog
-     *
-     * @returns {Promise<void>}
-     */
-    public async onSubmit(): Promise<void> {
-      const range = this.getBisectRange();
-      if (range.length > 1) {
-        const { appState } = this.props;
-        appState.Bisector = new Bisector(range);
-        const initialBisectPivot = appState.Bisector.getCurrentVersion()
-          .version;
-        appState.setVersion(initialBisectPivot);
-        this.onClose();
-      }
-    }
+  /**
+   * Can we get this show on the road?
+   */
+  get canSubmit(): boolean {
+    return this.state.startIndex > this.state.endIndex;
+  }
 
-    public async onAuto(): Promise<void> {
-      const range = this.getBisectRange();
-      if (range.length > 1) {
-        window.ElectronFiddle.app.runner.autobisect(range);
-        this.onClose();
-      }
-    }
+  /**
+   * Can we autobisect?
+   */
+  get canAuto(): boolean {
+    return this.canSubmit;
+  }
 
-    /**
-     * Closes the dialog
-     */
-    public onClose() {
-      this.props.appState.isBisectDialogShowing = false;
-    }
+  /**
+   * Renders the buttons
+   */
+  get buttons() {
+    return [
+      <Button
+        icon="play"
+        key="submit"
+        disabled={!this.canSubmit}
+        onClick={this.onSubmit}
+        text="Begin"
+      />,
+      <Button
+        icon="lab-test"
+        key="auto"
+        disabled={!this.canAuto}
+        onClick={this.onAuto}
+        text="Auto"
+      />,
+      <Button icon="cross" key="cancel" onClick={this.onClose} text="Cancel" />,
+    ];
+  }
 
-    /**
-     * Shows the additional help
-     */
-    public showHelp() {
-      this.setState({ showHelp: true });
-    }
+  /**
+   * Renders the help
+   */
+  get help() {
+    let moreHelp = (
+      <Button icon="help" text="Show help" onClick={this.showHelp} />
+    );
 
-    /**
-     * Can we get this show on the road?
-     */
-    get canSubmit(): boolean {
-      return this.state.startIndex > this.state.endIndex;
-    }
-
-    /**
-     * Can we autobisect?
-     */
-    get canAuto(): boolean {
-      return this.canSubmit;
-    }
-
-    /**
-     * Renders the buttons
-     */
-    get buttons() {
-      return [
-        <Button
-          icon="play"
-          key="submit"
-          disabled={!this.canSubmit}
-          onClick={this.onSubmit}
-          text="Begin"
-        />,
-        <Button
-          icon="lab-test"
-          key="auto"
-          disabled={!this.canAuto}
-          onClick={this.onAuto}
-          text="Auto"
-        />,
-        <Button
-          icon="cross"
-          key="cancel"
-          onClick={this.onClose}
-          text="Cancel"
-        />,
-      ];
-    }
-
-    /**
-     * Renders the help
-     */
-    get help() {
-      let moreHelp = (
-        <Button icon="help" text="Show help" onClick={this.showHelp} />
-      );
-
-      if (this.state.showHelp) {
-        moreHelp = (
-          <>
-            <p>
-              First, write a fiddle that reproduces a bug or an issue. Then,
-              select the earliest version to start your search with. Typically,
-              that&apos;s the &quot;last known good&quot; version that did not
-              have the bug. Then, select that latest version to end the search
-              with, usually the &quot;first known bad&quot; version.
-            </p>
-            <p>
-              Once you begin your bisect, Fiddle will run your fiddle with a
-              number of Electron versions, closing in on the version that
-              introduced the bug. Once completed, you will know which Electron
-              version introduced your issue.
-            </p>
-          </>
-        );
-      }
-
-      return (
-        <Callout style={{ marginTop: 0, marginBottom: '1rem' }}>
+    if (this.state.showHelp) {
+      moreHelp = (
+        <>
           <p>
-            A &quot;bisect&quot; is a popular method{' '}
-            <a
-              href="https://git-scm.com/docs/git-bisect"
-              target="_blank"
-              rel="noreferrer"
-            >
-              borrowed from <code>git</code>
-            </a>{' '}
-            for learning which version of Electron introduced a bug. This tool
-            helps you perform a bisect.
+            First, write a fiddle that reproduces a bug or an issue. Then,
+            select the earliest version to start your search with. Typically,
+            that&apos;s the &quot;last known good&quot; version that did not
+            have the bug. Then, select that latest version to end the search
+            with, usually the &quot;first known bad&quot; version.
           </p>
-          {moreHelp}
-        </Callout>
+          <p>
+            Once you begin your bisect, Fiddle will run your fiddle with a
+            number of Electron versions, closing in on the version that
+            introduced the bug. Once completed, you will know which Electron
+            version introduced your issue.
+          </p>
+        </>
       );
     }
 
-    public render() {
-      const { isBisectDialogShowing } = this.props.appState;
-      const { startIndex, endIndex, allVersions } = this.state;
+    return (
+      <Callout style={{ marginTop: 0, marginBottom: '1rem' }}>
+        <p>
+          A &quot;bisect&quot; is a popular method{' '}
+          <a
+            href="https://git-scm.com/docs/git-bisect"
+            target="_blank"
+            rel="noreferrer"
+          >
+            borrowed from <code>git</code>
+          </a>{' '}
+          for learning which version of Electron introduced a bug. This tool
+          helps you perform a bisect.
+        </p>
+        {moreHelp}
+      </Callout>
+    );
+  }
 
-      return (
-        <Dialog
-          isOpen={isBisectDialogShowing}
-          onClose={this.onClose}
-          title="Start a bisect session"
-          className="dialog-add-version"
-        >
-          <div className="bp3-dialog-body">
-            {this.help}
-            <Label>
-              Earliest Version (Last &quot;known good&quot; version)
-              <ButtonGroup fill={true}>
-                <VersionSelect
-                  currentVersion={allVersions[startIndex]}
-                  appState={this.props.appState}
-                  onVersionSelect={this.onBeginSelect}
-                  itemDisabled={this.isEarliestItemDisabled}
-                />
-              </ButtonGroup>
-            </Label>
-            <Label>
-              Latest Version (First &quot;known bad&quot; version)
-              <ButtonGroup fill={true}>
-                <VersionSelect
-                  currentVersion={allVersions[endIndex]}
-                  appState={this.props.appState}
-                  onVersionSelect={this.onEndSelect}
-                  itemDisabled={this.isLatestItemDisabled}
-                />
-              </ButtonGroup>
-            </Label>
-          </div>
-          <div className="bp3-dialog-footer">
-            <div className="bp3-dialog-footer-actions">{this.buttons}</div>
-          </div>
-        </Dialog>
-      );
-    }
+  public render() {
+    const { isBisectDialogShowing } = this.props.appState;
+    const { startIndex, endIndex, allVersions } = this.state;
 
-    /**
-     * Should an item in the "earliest version" dropdown be disabled?
-     *
-     * @param {RunnableVersion} version
-     * @returns {boolean}
-     */
-    public isEarliestItemDisabled(version: RunnableVersion): boolean {
-      const { allVersions, endIndex } = this.state;
+    return (
+      <Dialog
+        isOpen={isBisectDialogShowing}
+        onClose={this.onClose}
+        title="Start a bisect session"
+        className="dialog-add-version"
+      >
+        <div className="bp3-dialog-body">
+          {this.help}
+          <Label>
+            Earliest Version (Last &quot;known good&quot; version)
+            <ButtonGroup fill={true}>
+              <VersionSelect
+                currentVersion={allVersions[startIndex]}
+                appState={this.props.appState}
+                onVersionSelect={this.onBeginSelect}
+                itemDisabled={this.isEarliestItemDisabled}
+              />
+            </ButtonGroup>
+          </Label>
+          <Label>
+            Latest Version (First &quot;known bad&quot; version)
+            <ButtonGroup fill={true}>
+              <VersionSelect
+                currentVersion={allVersions[endIndex]}
+                appState={this.props.appState}
+                onVersionSelect={this.onEndSelect}
+                itemDisabled={this.isLatestItemDisabled}
+              />
+            </ButtonGroup>
+          </Label>
+        </div>
+        <div className="bp3-dialog-footer">
+          <div className="bp3-dialog-footer-actions">{this.buttons}</div>
+        </div>
+      </Dialog>
+    );
+  }
 
-      // In the array, "newer" versions will have a lower index.
-      // 0: 5.0.0
-      // 1: 4.0.0
-      // 2: 3.0.0
-      // ...
-      return allVersions.indexOf(version) < endIndex + 1;
-    }
+  /**
+   * Should an item in the "earliest version" dropdown be disabled?
+   *
+   * @param {RunnableVersion} version
+   * @returns {boolean}
+   */
+  public isEarliestItemDisabled(version: RunnableVersion): boolean {
+    const { allVersions, endIndex } = this.state;
 
-    /**
-     * Should an item in the "latest version" dropdown be disabled?
-     *
-     * @param {RunnableVersion} version
-     * @returns {boolean}
-     */
-    public isLatestItemDisabled(version: RunnableVersion): boolean {
-      const { allVersions, startIndex } = this.state;
+    // In the array, "newer" versions will have a lower index.
+    // 0: 5.0.0
+    // 1: 4.0.0
+    // 2: 3.0.0
+    // ...
+    return allVersions.indexOf(version) < endIndex + 1;
+  }
 
-      return allVersions.indexOf(version) > startIndex - 1;
-    }
-  },
-);
+  /**
+   * Should an item in the "latest version" dropdown be disabled?
+   *
+   * @param {RunnableVersion} version
+   * @returns {boolean}
+   */
+  public isLatestItemDisabled(version: RunnableVersion): boolean {
+    const { allVersions, startIndex } = this.state;
+
+    return allVersions.indexOf(version) > startIndex - 1;
+  }
+}

--- a/src/renderer/components/dialog-generic.tsx
+++ b/src/renderer/components/dialog-generic.tsx
@@ -17,91 +17,90 @@ interface GenericDialogProps {
  * @class GenericDialog
  * @extends {React.Component<GenericDialogProps, GenericDialogState>}
  */
-export const GenericDialog = observer(
-  class GenericDialog extends React.Component<GenericDialogProps> {
-    constructor(props: GenericDialogProps) {
-      super(props);
+@observer
+export class GenericDialog extends React.Component<GenericDialogProps> {
+  constructor(props: GenericDialogProps) {
+    super(props);
 
-      this.onClose = this.onClose.bind(this);
-      this.enterSubmit = this.enterSubmit.bind(this);
+    this.onClose = this.onClose.bind(this);
+    this.enterSubmit = this.enterSubmit.bind(this);
+  }
+
+  public onClose(result: boolean) {
+    const input = document.getElementById('input') as HTMLInputElement;
+
+    this.props.appState.genericDialogLastInput =
+      input && input.value !== '' ? input.value : null;
+    this.props.appState.genericDialogLastResult = result;
+    this.props.appState.isGenericDialogShowing = false;
+  }
+
+  public enterSubmit(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      this.onClose(true);
+    }
+  }
+
+  public render() {
+    const {
+      isGenericDialogShowing,
+      genericDialogOptions,
+    } = this.props.appState;
+    const {
+      type,
+      ok,
+      cancel,
+      label,
+      wantsInput,
+      placeholder,
+    } = genericDialogOptions;
+
+    let intent: Intent;
+    let icon: IconName;
+    switch (type) {
+      case GenericDialogType.warning:
+        intent = Intent.DANGER;
+        icon = 'warning-sign';
+        break;
+      case GenericDialogType.confirm:
+        intent = Intent.PRIMARY;
+        icon = 'help';
+        break;
+      case GenericDialogType.success:
+        intent = Intent.SUCCESS;
+        icon = 'info-sign';
+        break;
+      default:
+        intent = Intent.NONE;
+        icon = 'help';
+        break;
     }
 
-    public onClose(result: boolean) {
-      const input = document.getElementById('input') as HTMLInputElement;
-
-      this.props.appState.genericDialogLastInput =
-        input && input.value !== '' ? input.value : null;
-      this.props.appState.genericDialogLastResult = result;
-      this.props.appState.isGenericDialogShowing = false;
-    }
-
-    public enterSubmit(e: React.KeyboardEvent<HTMLInputElement>) {
-      if (e.key === 'Enter') {
-        this.onClose(true);
-      }
-    }
-
-    public render() {
-      const {
-        isGenericDialogShowing,
-        genericDialogOptions,
-      } = this.props.appState;
-      const {
-        type,
-        ok,
-        cancel,
-        label,
-        wantsInput,
-        placeholder,
-      } = genericDialogOptions;
-
-      let intent: Intent;
-      let icon: IconName;
-      switch (type) {
-        case GenericDialogType.warning:
-          intent = Intent.DANGER;
-          icon = 'warning-sign';
-          break;
-        case GenericDialogType.confirm:
-          intent = Intent.PRIMARY;
-          icon = 'help';
-          break;
-        case GenericDialogType.success:
-          intent = Intent.SUCCESS;
-          icon = 'info-sign';
-          break;
-        default:
-          intent = Intent.NONE;
-          icon = 'help';
-          break;
-      }
-
-      let dialogInput;
-      if (wantsInput) {
-        dialogInput = placeholder ? (
-          <InputGroup
-            id="input"
-            placeholder={placeholder}
-            onKeyDown={this.enterSubmit}
-          />
-        ) : (
-          <InputGroup id="input" onKeyDown={this.enterSubmit} />
-        );
-      }
-
-      return (
-        <Alert
-          isOpen={isGenericDialogShowing}
-          onClose={this.onClose}
-          icon={icon}
-          confirmButtonText={ok}
-          cancelButtonText={cancel}
-          intent={intent}
-        >
-          <p>{label}</p>
-          {wantsInput && dialogInput}
-        </Alert>
+    let dialogInput;
+    if (wantsInput) {
+      dialogInput = placeholder ? (
+        <InputGroup
+          id="input"
+          placeholder={placeholder}
+          onKeyDown={this.enterSubmit}
+        />
+      ) : (
+        <InputGroup id="input" onKeyDown={this.enterSubmit} />
       );
     }
-  },
-);
+
+    return (
+      <Alert
+        isOpen={isGenericDialogShowing}
+        onClose={this.onClose}
+        icon={icon}
+        confirmButtonText={ok}
+        cancelButtonText={cancel}
+        intent={intent}
+      >
+        <p>{label}</p>
+        {wantsInput && dialogInput}
+      </Alert>
+    );
+  }
+}

--- a/src/renderer/components/dialogs.tsx
+++ b/src/renderer/components/dialogs.tsx
@@ -20,47 +20,46 @@ interface DialogsProps {
  * @class Dialogs
  * @extends {React.Component<DialogsProps, {}>}
  */
-export const Dialogs = observer(
-  class Dialogs extends React.Component<DialogsProps> {
-    public render() {
-      const { appState } = this.props;
-      const {
-        isTokenDialogShowing,
-        isSettingsShowing,
-        isAddVersionDialogShowing,
-        isThemeDialogShowing,
-        isBisectDialogShowing,
-        isGenericDialogShowing,
-      } = appState;
-      const maybeToken = isTokenDialogShowing ? (
-        <TokenDialog key="dialogs" appState={appState} />
-      ) : null;
-      const maybeSettings = isSettingsShowing ? (
-        <Settings key="settings" appState={appState} />
-      ) : null;
-      const maybeAddLocalVersion = isAddVersionDialogShowing ? (
-        <AddVersionDialog key="add-version-dialog" appState={appState} />
-      ) : null;
-      const maybeMonaco = isThemeDialogShowing ? (
-        <AddThemeDialog appState={appState} />
-      ) : null;
-      const maybeBisect = isBisectDialogShowing ? (
-        <BisectDialog key="bisect-dialog" appState={appState} />
-      ) : null;
-      const genericDialog = isGenericDialogShowing ? (
-        <GenericDialog appState={appState} />
-      ) : null;
+@observer
+export class Dialogs extends React.Component<DialogsProps> {
+  public render() {
+    const { appState } = this.props;
+    const {
+      isTokenDialogShowing,
+      isSettingsShowing,
+      isAddVersionDialogShowing,
+      isThemeDialogShowing,
+      isBisectDialogShowing,
+      isGenericDialogShowing,
+    } = appState;
+    const maybeToken = isTokenDialogShowing ? (
+      <TokenDialog key="dialogs" appState={appState} />
+    ) : null;
+    const maybeSettings = isSettingsShowing ? (
+      <Settings key="settings" appState={appState} />
+    ) : null;
+    const maybeAddLocalVersion = isAddVersionDialogShowing ? (
+      <AddVersionDialog key="add-version-dialog" appState={appState} />
+    ) : null;
+    const maybeMonaco = isThemeDialogShowing ? (
+      <AddThemeDialog appState={appState} />
+    ) : null;
+    const maybeBisect = isBisectDialogShowing ? (
+      <BisectDialog key="bisect-dialog" appState={appState} />
+    ) : null;
+    const genericDialog = isGenericDialogShowing ? (
+      <GenericDialog appState={appState} />
+    ) : null;
 
-      return (
-        <div key="dialogs" className="dialogs">
-          {maybeToken}
-          {maybeSettings}
-          {maybeAddLocalVersion}
-          {maybeMonaco}
-          {maybeBisect}
-          {genericDialog}
-        </div>
-      );
-    }
-  },
-);
+    return (
+      <div key="dialogs" className="dialogs">
+        {maybeToken}
+        {maybeSettings}
+        {maybeAddLocalVersion}
+        {maybeMonaco}
+        {maybeBisect}
+        {genericDialog}
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/editors-toolbar-button.tsx
+++ b/src/renderer/components/editors-toolbar-button.tsx
@@ -17,7 +17,7 @@ interface ToolbarButtonProps {
 
 abstract class ToolbarButton extends React.PureComponent<ToolbarButtonProps> {
   public static contextType = MosaicWindowContext;
-  public context: MosaicWindowContext;
+  declare context: MosaicWindowContext;
 
   constructor(props: ToolbarButtonProps) {
     super(props);

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -36,256 +36,255 @@ interface EditorsState {
   monacoOptions: MonacoType.editor.IEditorOptions;
 }
 
-export const Editors = observer(
-  class Editors extends React.Component<EditorsProps, EditorsState> {
-    constructor(props: EditorsProps) {
-      super(props);
+@observer
+export class Editors extends React.Component<EditorsProps, EditorsState> {
+  constructor(props: EditorsProps) {
+    super(props);
 
-      this.onChange = this.onChange.bind(this);
-      this.renderEditor = this.renderEditor.bind(this);
-      this.renderTile = this.renderTile.bind(this);
-      this.setFocused = this.setFocused.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.renderEditor = this.renderEditor.bind(this);
+    this.renderTile = this.renderTile.bind(this);
+    this.setFocused = this.setFocused.bind(this);
 
-      this.state = {
-        monaco: window.ElectronFiddle.monaco,
-        monacoOptions: defaultMonacoOptions,
-      };
-    }
+    this.state = {
+      monaco: window.ElectronFiddle.monaco,
+      monacoOptions: defaultMonacoOptions,
+    };
+  }
 
-    /**
-     * Executed right after the component mounts. We'll setup the IPC listeners here.
-     *
-     * @memberof Editors
-     */
-    public async componentDidMount() {
-      this.stopListening();
+  /**
+   * Executed right after the component mounts. We'll setup the IPC listeners here.
+   *
+   * @memberof Editors
+   */
+  public async componentDidMount() {
+    this.stopListening();
 
-      window.ElectronFiddle.addEventListener(
-        'execute-monaco-command',
-        (cmd: string) => {
-          this.executeCommand(cmd);
-        },
-      );
+    window.ElectronFiddle.addEventListener(
+      'execute-monaco-command',
+      (cmd: string) => {
+        this.executeCommand(cmd);
+      },
+    );
 
-      window.ElectronFiddle.addEventListener('new-fiddle', async () => {
-        const { modules, version } = this.props.appState;
-        const values = await window.ElectronFiddle.getTemplate(version);
-        const options: SetFiddleOptions = { templateName: version };
+    window.ElectronFiddle.addEventListener('new-fiddle', async () => {
+      const { modules, version } = this.props.appState;
+      const values = await window.ElectronFiddle.getTemplate(version);
+      const options: SetFiddleOptions = { templateName: version };
 
-        // Clear previously installed modules.
-        modules.clear();
+      // Clear previously installed modules.
+      modules.clear();
 
-        await window.ElectronFiddle.app.replaceFiddle(values, options);
-      });
+      await window.ElectronFiddle.app.replaceFiddle(values, options);
+    });
 
-      window.ElectronFiddle.addEventListener('new-test', async () => {
-        const values = await window.ElectronFiddle.getTestTemplate();
-        const options: SetFiddleOptions = { templateName: 'Test' };
+    window.ElectronFiddle.addEventListener('new-test', async () => {
+      const values = await window.ElectronFiddle.getTestTemplate();
+      const options: SetFiddleOptions = { templateName: 'Test' };
 
-        await window.ElectronFiddle.app.replaceFiddle(values, options);
-      });
+      await window.ElectronFiddle.app.replaceFiddle(values, options);
+    });
 
-      window.ElectronFiddle.addEventListener(
-        'toggle-monaco-option',
-        (cmd: string) => {
-          this.toggleEditorOption(cmd);
-        },
-      );
+    window.ElectronFiddle.addEventListener(
+      'toggle-monaco-option',
+      (cmd: string) => {
+        this.toggleEditorOption(cmd);
+      },
+    );
 
-      window.ElectronFiddle.addEventListener('redo-in-editor', () => {
-        const editor = this.props.appState.editorMosaic.focusedEditor();
-        if (editor) {
-          const model = editor.getModel();
-          if (model) (model as any).redo();
-        }
-      });
-
-      window.ElectronFiddle.addEventListener('undo-in-editor', () => {
-        const editor = this.props.appState.editorMosaic.focusedEditor();
-        if (editor) {
-          const model = editor.getModel();
-          if (model) (model as any).undo();
-        }
-      });
-
-      window.ElectronFiddle.addEventListener('select-all-in-editor', () => {
-        const editor = this.props.appState.editorMosaic.focusedEditor();
-        if (editor) {
-          const model = editor.getModel();
-          if (model) {
-            editor.setSelection(model.getFullModelRange());
-          }
-        }
-      });
-    }
-
-    public componentWillUnmount() {
-      this.stopListening();
-    }
-
-    private stopListening() {
-      window.ElectronFiddle.removeAllListeners('execute-monaco-command');
-      window.ElectronFiddle.removeAllListeners('new-fiddle');
-      window.ElectronFiddle.removeAllListeners('new-test');
-      window.ElectronFiddle.removeAllListeners('toggle-monaco-option');
-      window.ElectronFiddle.removeAllListeners('select-all-in-editor');
-      window.ElectronFiddle.removeAllListeners('undo-in-editor');
-      window.ElectronFiddle.removeAllListeners('redo-in-editor');
-    }
-
-    /**
-     * Attempt to execute a given commandId on the currently focused editor
-     *
-     * @param {string} commandId
-     * @memberof Editors
-     */
-    public executeCommand(commandId: string) {
+    window.ElectronFiddle.addEventListener('redo-in-editor', () => {
       const editor = this.props.appState.editorMosaic.focusedEditor();
-
       if (editor) {
-        const command = editor.getAction(commandId);
+        const model = editor.getModel();
+        if (model) (model as any).redo();
+      }
+    });
 
-        if (!command) return;
+    window.ElectronFiddle.addEventListener('undo-in-editor', () => {
+      const editor = this.props.appState.editorMosaic.focusedEditor();
+      if (editor) {
+        const model = editor.getModel();
+        if (model) (model as any).undo();
+      }
+    });
 
-        console.log(
-          `Editors: Trying to run ${
-            command.id
-          }. Supported: ${command.isSupported()}`,
-        );
-
-        if (command.isSupported()) {
-          command.run();
+    window.ElectronFiddle.addEventListener('select-all-in-editor', () => {
+      const editor = this.props.appState.editorMosaic.focusedEditor();
+      if (editor) {
+        const model = editor.getModel();
+        if (model) {
+          editor.setSelection(model.getFullModelRange());
         }
       }
-    }
+    });
+  }
 
-    public toggleEditorOption(path: string): boolean {
-      try {
-        const { monacoOptions } = this.state;
-        const newOptions = { ...monacoOptions };
-        const currentSetting = getAtPath(path, newOptions);
+  public componentWillUnmount() {
+    this.stopListening();
+  }
 
-        setAtPath(path, newOptions, toggleMonaco(currentSetting));
-        this.props.appState.editorMosaic.updateOptions(newOptions);
-        this.setState({ monacoOptions: newOptions });
+  private stopListening() {
+    window.ElectronFiddle.removeAllListeners('execute-monaco-command');
+    window.ElectronFiddle.removeAllListeners('new-fiddle');
+    window.ElectronFiddle.removeAllListeners('new-test');
+    window.ElectronFiddle.removeAllListeners('toggle-monaco-option');
+    window.ElectronFiddle.removeAllListeners('select-all-in-editor');
+    window.ElectronFiddle.removeAllListeners('undo-in-editor');
+    window.ElectronFiddle.removeAllListeners('redo-in-editor');
+  }
 
-        return true;
-      } catch (error) {
-        console.warn(`Editors: Could not toggle property ${path}`, error);
+  /**
+   * Attempt to execute a given commandId on the currently focused editor
+   *
+   * @param {string} commandId
+   * @memberof Editors
+   */
+  public executeCommand(commandId: string) {
+    const editor = this.props.appState.editorMosaic.focusedEditor();
 
-        return false;
+    if (editor) {
+      const command = editor.getAction(commandId);
+
+      if (!command) return;
+
+      console.log(
+        `Editors: Trying to run ${
+          command.id
+        }. Supported: ${command.isSupported()}`,
+      );
+
+      if (command.isSupported()) {
+        command.run();
       }
     }
+  }
 
-    /**
-     * Renders the little tool bar on top of each panel
-     *
-     * @param {MosaicWindowProps<EditorId>} { title }
-     * @param {EditorId} id
-     * @returns {JSX.Element}
-     */
-    public renderToolbar(
-      { title }: MosaicWindowProps<EditorId>,
-      id: EditorId,
-    ): JSX.Element {
-      const { appState } = this.props;
+  public toggleEditorOption(path: string): boolean {
+    try {
+      const { monacoOptions } = this.state;
+      const newOptions = { ...monacoOptions };
+      const currentSetting = getAtPath(path, newOptions);
 
-      return (
+      setAtPath(path, newOptions, toggleMonaco(currentSetting));
+      this.props.appState.editorMosaic.updateOptions(newOptions);
+      this.setState({ monacoOptions: newOptions });
+
+      return true;
+    } catch (error) {
+      console.warn(`Editors: Could not toggle property ${path}`, error);
+
+      return false;
+    }
+  }
+
+  /**
+   * Renders the little tool bar on top of each panel
+   *
+   * @param {MosaicWindowProps<EditorId>} { title }
+   * @param {EditorId} id
+   * @returns {JSX.Element}
+   */
+  public renderToolbar(
+    { title }: MosaicWindowProps<EditorId>,
+    id: EditorId,
+  ): JSX.Element {
+    const { appState } = this.props;
+
+    return (
+      <div>
+        {/* Left */}
         <div>
-          {/* Left */}
-          <div>
-            <h5>{title}</h5>
-          </div>
-          {/* Middle */}
-          <div />
-          {/* Right */}
-          <div className="mosaic-controls">
-            <MaximizeButton id={id} appState={appState} />
-            <RemoveButton id={id} appState={appState} />
-          </div>
+          <h5>{title}</h5>
         </div>
-      );
-    }
+        {/* Middle */}
+        <div />
+        {/* Right */}
+        <div className="mosaic-controls">
+          <MaximizeButton id={id} appState={appState} />
+          <RemoveButton id={id} appState={appState} />
+        </div>
+      </div>
+    );
+  }
 
-    /**
-     * Renders a Mosaic tile
-     *
-     * @param {EditorId} id
-     * @param {Array<MosaicBranch>} path
-     * @returns {JSX.Element}
-     */
-    public renderTile(id: EditorId, path: Array<MosaicBranch>): JSX.Element {
-      const content = this.renderEditor(id);
-      const title = getEditorTitle(id as EditorId);
+  /**
+   * Renders a Mosaic tile
+   *
+   * @param {EditorId} id
+   * @param {Array<MosaicBranch>} path
+   * @returns {JSX.Element}
+   */
+  public renderTile(id: EditorId, path: Array<MosaicBranch>): JSX.Element {
+    const content = this.renderEditor(id);
+    const title = getEditorTitle(id as EditorId);
 
-      return (
-        <MosaicWindow<EditorId>
-          className={id}
-          path={path}
-          title={title}
-          renderToolbar={(props: MosaicWindowProps<EditorId>) =>
-            this.renderToolbar(props, id)
-          }
-        >
-          {content}
-        </MosaicWindow>
-      );
-    }
+    return (
+      <MosaicWindow<EditorId>
+        className={id}
+        path={path}
+        title={title}
+        renderToolbar={(props: MosaicWindowProps<EditorId>) =>
+          this.renderToolbar(props, id)
+        }
+      >
+        {content}
+      </MosaicWindow>
+    );
+  }
 
-    /**
-     * Render an editor
-     *
-     * @param {EditorId} id
-     * @returns {(JSX.Element | null)}
-     * @memberof Editors
-     */
-    public renderEditor(id: EditorId): JSX.Element | null {
-      const { appState } = this.props;
-      const { monaco } = this.state;
+  /**
+   * Render an editor
+   *
+   * @param {EditorId} id
+   * @returns {(JSX.Element | null)}
+   * @memberof Editors
+   */
+  public renderEditor(id: EditorId): JSX.Element | null {
+    const { appState } = this.props;
+    const { monaco } = this.state;
 
-      return (
-        <Editor
-          id={id}
-          monaco={monaco}
-          appState={appState}
-          monacoOptions={defaultMonacoOptions}
-          setFocused={this.setFocused}
-        />
-      );
-    }
+    return (
+      <Editor
+        id={id}
+        monaco={monaco}
+        appState={appState}
+        monacoOptions={defaultMonacoOptions}
+        setFocused={this.setFocused}
+      />
+    );
+  }
 
-    public render() {
-      const { editorMosaic } = this.props.appState;
+  public render() {
+    const { editorMosaic } = this.props.appState;
 
-      return (
-        <Mosaic<EditorId>
-          className={`focused__${this.state.focused}`}
-          onChange={this.onChange}
-          value={editorMosaic.mosaic}
-          zeroStateView={renderNonIdealState(editorMosaic)}
-          renderTile={this.renderTile}
-        />
-      );
-    }
+    return (
+      <Mosaic<EditorId>
+        className={`focused__${this.state.focused}`}
+        onChange={this.onChange}
+        value={editorMosaic.mosaic}
+        zeroStateView={renderNonIdealState(editorMosaic)}
+        renderTile={this.renderTile}
+      />
+    );
+  }
 
-    /**
-     * Handles a change in the visible nodes
-     *
-     * @param {(MosaicNode<EditorId> | null)} currentNode
-     */
-    public onChange(currentNode: MosaicNode<EditorId> | null) {
-      this.props.appState.editorMosaic.mosaic = currentNode;
-    }
+  /**
+   * Handles a change in the visible nodes
+   *
+   * @param {(MosaicNode<EditorId> | null)} currentNode
+   */
+  public onChange(currentNode: MosaicNode<EditorId> | null) {
+    this.props.appState.editorMosaic.mosaic = currentNode;
+  }
 
-    /**
-     * Sets the currently-focused editor. This will impact the editor's
-     * z-index, ensuring that its intellisense menus don't get clipped
-     * by the other editor windows.
-     * @param {EditorId} id
-     */
-    public setFocused(id: EditorId): void {
-      this.props.appState.editorMosaic.setFocusedFile(id);
-      this.setState({ focused: id });
-    }
-  },
-);
+  /**
+   * Sets the currently-focused editor. This will impact the editor's
+   * z-index, ensuring that its intellisense menus don't get clipped
+   * by the other editor windows.
+   * @param {EditorId} id
+   */
+  public setFocused(id: EditorId): void {
+    this.props.appState.editorMosaic.setFocusedFile(id);
+    this.setState({ focused: id });
+  }
+}

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -28,181 +28,180 @@ interface CommandsProps {
  * @class Output
  * @extends {React.Component<CommandsProps>}
  */
-export const Output = observer(
-  class Output extends React.Component<CommandsProps> {
-    public static contextType = MosaicContext;
-    public context: MosaicContext<WrapperEditorId>;
-    public editor?: MonacoType.editor.IStandaloneCodeEditor;
-    public language = 'consoleOutputLanguage';
+@observer
+export class Output extends React.Component<CommandsProps> {
+  public static contextType = MosaicContext;
+  declare context: MosaicContext<WrapperEditorId>;
+  public editor?: MonacoType.editor.IStandaloneCodeEditor;
+  public language = 'consoleOutputLanguage';
 
-    private outputRef = React.createRef<HTMLDivElement>();
-    private readonly model: MonacoType.editor.ITextModel;
+  private outputRef = React.createRef<HTMLDivElement>();
+  private readonly model: MonacoType.editor.ITextModel;
 
-    // make it wide enough to fit all of OutputEntry's timestamps
-    private readonly lineNumbersMinChars =
-      new Date('2021-12-31T23:59:59').toLocaleTimeString().length + 1;
+  // make it wide enough to fit all of OutputEntry's timestamps
+  private readonly lineNumbersMinChars =
+    new Date('2021-12-31T23:59:59').toLocaleTimeString().length + 1;
 
-    constructor(props: CommandsProps) {
-      super(props);
+  constructor(props: CommandsProps) {
+    super(props);
 
-      const { monaco } = this.props;
-      this.language = 'consoleOutputLanguage';
-      this.model = monaco.editor.createModel('', this.language);
-      this.updateModel();
-      reaction(
-        () => props.appState.output.length,
-        () => this.updateModel(),
-      );
-    }
+    const { monaco } = this.props;
+    this.language = 'consoleOutputLanguage';
+    this.model = monaco.editor.createModel('', this.language);
+    this.updateModel();
+    reaction(
+      () => props.appState.output.length,
+      () => this.updateModel(),
+    );
+  }
 
-    public async componentDidMount() {
-      autorun(async () => {
-        await this.initMonaco();
-        this.toggleConsole();
-      });
-    }
-
-    public componentWillUnmount() {
-      this.destroyMonacoEditor();
-    }
-
-    public componentDidUpdate() {
+  public async componentDidMount() {
+    autorun(async () => {
+      await this.initMonaco();
       this.toggleConsole();
-    }
+    });
+  }
 
-    /**
-     * Initialize Monaco.
-     */
-    public async initMonaco() {
-      const { monaco, monacoOptions: monacoOptions } = this.props;
-      const ref = this.outputRef.current;
-      if (ref) {
-        this.setupCustomOutputEditorLanguage(monaco);
-        this.editor = monaco.editor.create(ref, {
-          language: this.language,
-          theme: 'main',
-          readOnly: true,
-          contextmenu: false,
-          automaticLayout: true,
-          model: this.model,
-          ...monacoOptions,
-          wordWrap: 'on',
-        });
-      }
-    }
+  public componentWillUnmount() {
+    this.destroyMonacoEditor();
+  }
 
-    /**
-     * Destroy Monaco.
-     */
-    public destroyMonacoEditor() {
-      if (typeof this.editor !== 'undefined') {
-        console.log('Editor: Disposing');
-        this.editor.dispose();
-        delete this.editor;
-      }
-    }
+  public componentDidUpdate() {
+    this.toggleConsole();
+  }
 
-    public toggleConsole() {
-      /**
-       * Type guard to check whether a react-mosaic node is a parent in the tree
-       * or a leaf. Leaf nodes are represented by the string value of their ID,
-       * whereas parent nodes are objects containing information about the nested
-       * binary tree.
-       * @param node A react-mosaic node
-       * @returns Whether that node is a MosaicParent or not
-       */
-      const isParentNode = (
-        node: MosaicNode<WrapperEditorId> | null,
-      ): node is MosaicParent<WrapperEditorId> => {
-        return (node as MosaicParent<WrapperEditorId>)?.direction !== undefined;
-      };
-
-      const { isConsoleShowing } = this.props.appState;
-
-      if (this.context.mosaicActions) {
-        const mosaicTree = this.context.mosaicActions.getRoot();
-        if (isParentNode(mosaicTree)) {
-          // splitPercentage defines the percentage of space the first panel takes
-          // e.g. 25 would mean the two children panels are split 25%/75%
-          if (!isConsoleShowing) {
-            mosaicTree.splitPercentage = 0;
-          } else if (mosaicTree.splitPercentage === 0) {
-            mosaicTree.splitPercentage = 25;
-          }
-          this.context.mosaicActions.replaceWith([], mosaicTree);
-        }
-      }
-    }
-
-    /**
-     * Set up Monaco Language to catch custom regex expressions
-     *
-     * tokenizes timestamps so`main` theme can render them with a custom colour.
-     */
-    private setupCustomOutputEditorLanguage(monaco: typeof MonacoType) {
-      // register a new language
-      monaco.languages.register({ id: 'consoleOutputLanguage' });
-      // Register a tokens provider for the language
-      monaco.languages.setMonarchTokensProvider('consoleOutputLanguage', {
-        tokenizer: {
-          root: [[/\d{1,2}:\d{2}:\d{2}\s(A|P)M/, 'custom-date']],
-        },
+  /**
+   * Initialize Monaco.
+   */
+  public async initMonaco() {
+    const { monaco, monacoOptions: monacoOptions } = this.props;
+    const ref = this.outputRef.current;
+    if (ref) {
+      this.setupCustomOutputEditorLanguage(monaco);
+      this.editor = monaco.editor.create(ref, {
+        language: this.language,
+        theme: 'main',
+        readOnly: true,
+        contextmenu: false,
+        automaticLayout: true,
+        model: this.model,
+        ...monacoOptions,
+        wordWrap: 'on',
       });
     }
+  }
 
-    /**
-     * Sets the model and content on the editor
-     *
-     * @private
-     * @memberof Output
-     */
-    private async updateModel() {
-      // set the lines
-      const lines = Output.getLines(this.props.appState.output);
-      this.model.setValue(lines.map(({ text }) => text).join('\n'));
-
-      // if we have an editor, tell it the line numbers and scroll to newest
-      const { editor, lineNumbersMinChars } = this;
-      if (!editor) return;
-      const timestrs = lines.map(({ timeString }) => timeString);
-      // adjust `i` here because the value passed in by monaco starts at 1, not 0
-      const lineNumbers = (i: number) => timestrs[i - 1] || '';
-      editor.updateOptions({ lineNumbers, lineNumbersMinChars });
-      editor.revealLine(editor.getScrollHeight());
+  /**
+   * Destroy Monaco.
+   */
+  public destroyMonacoEditor() {
+    if (typeof this.editor !== 'undefined') {
+      console.log('Editor: Disposing');
+      this.editor.dispose();
+      delete this.editor;
     }
+  }
 
+  public toggleConsole() {
     /**
-     * An OutputEntry might span multiple lines.
-     * Split it into individual lines to ensure each one has a timestamp.
-     *
-     * @param {OutputEntry} entries that may include paragraphs
-     * @returns {OutputEntry} single-line entries
-     * @memberof Output
+     * Type guard to check whether a react-mosaic node is a parent in the tree
+     * or a leaf. Leaf nodes are represented by the string value of their ID,
+     * whereas parent nodes are objects containing information about the nested
+     * binary tree.
+     * @param node A react-mosaic node
+     * @returns Whether that node is a MosaicParent or not
      */
-    private static getLines(paragraphs: OutputEntry[]): OutputEntry[] {
-      const lines: OutputEntry[] = [];
+    const isParentNode = (
+      node: MosaicNode<WrapperEditorId> | null,
+    ): node is MosaicParent<WrapperEditorId> => {
+      return (node as MosaicParent<WrapperEditorId>)?.direction !== undefined;
+    };
 
-      paragraphs = paragraphs.slice(-1000);
+    const { isConsoleShowing } = this.props.appState;
 
-      for (const { text, timeString } of paragraphs) {
-        for (const line of text.split(/\r?\n/)) {
-          lines.push({ text: line, timeString });
+    if (this.context.mosaicActions) {
+      const mosaicTree = this.context.mosaicActions.getRoot();
+      if (isParentNode(mosaicTree)) {
+        // splitPercentage defines the percentage of space the first panel takes
+        // e.g. 25 would mean the two children panels are split 25%/75%
+        if (!isConsoleShowing) {
+          mosaicTree.splitPercentage = 0;
+        } else if (mosaicTree.splitPercentage === 0) {
+          mosaicTree.splitPercentage = 25;
         }
+        this.context.mosaicActions.replaceWith([], mosaicTree);
       }
+    }
+  }
 
-      return lines;
+  /**
+   * Set up Monaco Language to catch custom regex expressions
+   *
+   * tokenizes timestamps so`main` theme can render them with a custom colour.
+   */
+  private setupCustomOutputEditorLanguage(monaco: typeof MonacoType) {
+    // register a new language
+    monaco.languages.register({ id: 'consoleOutputLanguage' });
+    // Register a tokens provider for the language
+    monaco.languages.setMonarchTokensProvider('consoleOutputLanguage', {
+      tokenizer: {
+        root: [[/\d{1,2}:\d{2}:\d{2}\s(A|P)M/, 'custom-date']],
+      },
+    });
+  }
+
+  /**
+   * Sets the model and content on the editor
+   *
+   * @private
+   * @memberof Output
+   */
+  private async updateModel() {
+    // set the lines
+    const lines = Output.getLines(this.props.appState.output);
+    this.model.setValue(lines.map(({ text }) => text).join('\n'));
+
+    // if we have an editor, tell it the line numbers and scroll to newest
+    const { editor, lineNumbersMinChars } = this;
+    if (!editor) return;
+    const timestrs = lines.map(({ timeString }) => timeString);
+    // adjust `i` here because the value passed in by monaco starts at 1, not 0
+    const lineNumbers = (i: number) => timestrs[i - 1] || '';
+    editor.updateOptions({ lineNumbers, lineNumbersMinChars });
+    editor.revealLine(editor.getScrollHeight());
+  }
+
+  /**
+   * An OutputEntry might span multiple lines.
+   * Split it into individual lines to ensure each one has a timestamp.
+   *
+   * @param {OutputEntry} entries that may include paragraphs
+   * @returns {OutputEntry} single-line entries
+   * @memberof Output
+   */
+  private static getLines(paragraphs: OutputEntry[]): OutputEntry[] {
+    const lines: OutputEntry[] = [];
+
+    paragraphs = paragraphs.slice(-1000);
+
+    for (const { text, timeString } of paragraphs) {
+      for (const line of text.split(/\r?\n/)) {
+        lines.push({ text: line, timeString });
+      }
     }
 
-    public render(): JSX.Element | null {
-      const { isConsoleShowing } = this.props.appState;
+    return lines;
+  }
 
-      return (
-        <div
-          className="output"
-          ref={this.outputRef}
-          style={{ display: isConsoleShowing ? 'inline-block' : 'none' }}
-        />
-      );
-    }
-  },
-);
+  public render(): JSX.Element | null {
+    const { isConsoleShowing } = this.props.appState;
+
+    return (
+      <div
+        className="output"
+        ref={this.outputRef}
+        style={{ display: isConsoleShowing ? 'inline-block' : 'none' }}
+      />
+    );
+  }
+}

--- a/src/renderer/components/outputs.tsx
+++ b/src/renderer/components/outputs.tsx
@@ -22,28 +22,27 @@ interface OutputsState {
   monacoOptions: MonacoType.editor.IEditorOptions;
 }
 
-export const Outputs = observer(
-  class Outputs extends React.Component<OutputsProps, OutputsState> {
-    constructor(props: OutputsProps) {
-      super(props);
+@observer
+export class Outputs extends React.Component<OutputsProps, OutputsState> {
+  constructor(props: OutputsProps) {
+    super(props);
 
-      this.state = {
-        monaco: window.ElectronFiddle.monaco,
-        monacoOptions: defaultMonacoOptions,
-      };
-    }
+    this.state = {
+      monaco: window.ElectronFiddle.monaco,
+      monacoOptions: defaultMonacoOptions,
+    };
+  }
 
-    public render() {
-      const { appState } = this.props;
-      const { monaco } = this.state;
+  public render() {
+    const { appState } = this.props;
+    const { monaco } = this.state;
 
-      return (
-        <Output
-          monaco={monaco}
-          appState={appState}
-          monacoOptions={defaultMonacoOptions}
-        />
-      );
-    }
-  },
-);
+    return (
+      <Output
+        monaco={monaco}
+        appState={appState}
+        monacoOptions={defaultMonacoOptions}
+      />
+    );
+  }
+}

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -41,388 +41,385 @@ interface ElectronSettingsState {
  * @class ElectronSettings
  * @extends {React.Component<ElectronSettingsProps, ElectronSettingsState>}
  */
-export const ElectronSettings = observer(
-  class ElectronSettings extends React.Component<
-    ElectronSettingsProps,
-    ElectronSettingsState
-  > {
-    constructor(props: ElectronSettingsProps) {
-      super(props);
+@observer
+export class ElectronSettings extends React.Component<
+  ElectronSettingsProps,
+  ElectronSettingsState
+> {
+  constructor(props: ElectronSettingsProps) {
+    super(props);
 
-      this.handleAddVersion = this.handleAddVersion.bind(this);
-      this.handleChannelChange = this.handleChannelChange.bind(this);
-      this.handleDeleteAll = this.handleDeleteAll.bind(this);
-      this.handleDownloadAll = this.handleDownloadAll.bind(this);
-      this.handleUpdateElectronVersions = this.handleUpdateElectronVersions.bind(
-        this,
-      );
-      this.handleShowObsoleteChange = this.handleShowObsoleteChange.bind(this);
-      this.handleStateChange = this.handleStateChange.bind(this);
+    this.handleAddVersion = this.handleAddVersion.bind(this);
+    this.handleChannelChange = this.handleChannelChange.bind(this);
+    this.handleDeleteAll = this.handleDeleteAll.bind(this);
+    this.handleDownloadAll = this.handleDownloadAll.bind(this);
+    this.handleUpdateElectronVersions = this.handleUpdateElectronVersions.bind(
+      this,
+    );
+    this.handleShowObsoleteChange = this.handleShowObsoleteChange.bind(this);
+    this.handleStateChange = this.handleStateChange.bind(this);
 
-      this.state = {
-        isDownloadingAll: false,
-        isDeletingAll: false,
-      };
+    this.state = {
+      isDownloadingAll: false,
+      isDeletingAll: false,
+    };
+  }
+
+  public handleUpdateElectronVersions() {
+    this.props.appState.updateElectronVersions();
+  }
+
+  /**
+   * Toggles visibility of non-downloaded versions
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleStateChange(event: React.FormEvent<HTMLInputElement>) {
+    const { appState } = this.props;
+    const { checked } = event.currentTarget;
+    appState.showUndownloadedVersions = checked;
+  }
+
+  /**
+   * Toggles visibility of obsolete versions
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleShowObsoleteChange(event: React.FormEvent<HTMLInputElement>) {
+    const { appState } = this.props;
+    const { checked } = event.currentTarget;
+    appState.showObsoleteVersions = checked;
+  }
+
+  /**
+   * Handles a change in which channels should be displayed.
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleChannelChange(event: React.FormEvent<HTMLInputElement>) {
+    const { id, checked } = event.currentTarget;
+    const { appState } = this.props;
+
+    if (!checked) {
+      appState.hideChannels([id as ElectronReleaseChannel]);
+    } else {
+      appState.showChannels([id as ElectronReleaseChannel]);
+    }
+  }
+
+  /**
+   * Download all visible versions of Electron.
+   *
+   * @returns {Promise<void>}
+   */
+  public async handleDownloadAll(): Promise<void> {
+    this.setState({ isDownloadingAll: true });
+
+    const { downloadVersion, versionsToShow } = this.props.appState;
+
+    for (const ver of versionsToShow) {
+      await downloadVersion(ver);
     }
 
-    public handleUpdateElectronVersions() {
-      this.props.appState.updateElectronVersions();
+    this.setState({ isDownloadingAll: false });
+  }
+
+  /**
+   * Delete all downloaded versions of Electron.
+   *
+   * @returns {Promise<void>}
+   */
+  public async handleDeleteAll(): Promise<void> {
+    this.setState({ isDeletingAll: true });
+
+    const { versions, removeVersion } = this.props.appState;
+
+    for (const ver of Object.values(versions)) {
+      await removeVersion(ver);
     }
 
-    /**
-     * Toggles visibility of non-downloaded versions
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleStateChange(event: React.FormEvent<HTMLInputElement>) {
-      const { appState } = this.props;
-      const { checked } = event.currentTarget;
-      appState.showUndownloadedVersions = checked;
-    }
+    this.setState({ isDeletingAll: false });
+  }
 
-    /**
-     * Toggles visibility of obsolete versions
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleShowObsoleteChange(event: React.FormEvent<HTMLInputElement>) {
-      const { appState } = this.props;
-      const { checked } = event.currentTarget;
-      appState.showObsoleteVersions = checked;
-    }
+  /**
+   * Opens the "add local version" dialog
+   */
+  public handleAddVersion(): void {
+    this.props.appState.toggleAddVersionDialog();
+  }
 
-    /**
-     * Handles a change in which channels should be displayed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleChannelChange(event: React.FormEvent<HTMLInputElement>) {
-      const { id, checked } = event.currentTarget;
-      const { appState } = this.props;
+  public render() {
+    return (
+      <div className="settings-electron">
+        <h1>Electron Settings</h1>
+        <Callout>{this.renderVersionShowOptions()}</Callout>
+        <br />
+        <Callout>{this.filterSection()}</Callout>
+        <br />
+        <Callout>
+          {this.renderAdvancedButtons()}
+          {this.renderTable()}
+        </Callout>
+      </div>
+    );
+  }
 
-      if (!checked) {
-        appState.hideChannels([id as ElectronReleaseChannel]);
-      } else {
-        appState.showChannels([id as ElectronReleaseChannel]);
-      }
-    }
+  /**
+   * Renders the various buttons for advanced operations
+   *
+   * @private
+   * @returns {JSX.Element}
+   */
+  private renderAdvancedButtons(): JSX.Element {
+    const { isDownloadingAll, isDeletingAll } = this.state;
+    const { isUpdatingElectronVersions } = this.props.appState;
+    const isWorking = isDownloadingAll || isDeletingAll;
 
-    /**
-     * Download all visible versions of Electron.
-     *
-     * @returns {Promise<void>}
-     */
-    public async handleDownloadAll(): Promise<void> {
-      this.setState({ isDownloadingAll: true });
+    return (
+      <ButtonGroup fill={true}>
+        <Button
+          disabled={isUpdatingElectronVersions}
+          onClick={this.handleUpdateElectronVersions}
+          loading={isUpdatingElectronVersions}
+          icon="numbered-list"
+          text="Update Electron Release List"
+        />
+        <Button
+          disabled={isWorking}
+          icon="download"
+          onClick={this.handleDownloadAll}
+          text="Download All Versions"
+        />
+        <Button
+          disabled={isWorking}
+          icon="trash"
+          onClick={this.handleDeleteAll}
+          text="Delete All Downloads"
+        />
+        <Button
+          icon="document-open"
+          onClick={this.handleAddVersion}
+          text="Add Local Electron Build"
+        />
+      </ButtonGroup>
+    );
+  }
+  private filterSection(): JSX.Element {
+    const { appState } = this.props;
+    return (
+      <FormGroup label="Filters:">
+        <Checkbox
+          checked={appState.showUndownloadedVersions}
+          id="showUndownloadedVersions"
+          label="Not downloaded"
+          onChange={this.handleStateChange}
+        />
+      </FormGroup>
+    );
+  }
 
-      const { downloadVersion, versionsToShow } = this.props.appState;
+  /**
+   * Renders the various options for which versions should be displayed
+   *
+   * @private
+   * @returns {JSX.Element}
+   */
+  private renderVersionShowOptions(): JSX.Element {
+    const { appState } = this.props;
 
-      for (const ver of versionsToShow) {
-        await downloadVersion(ver);
-      }
+    const getIsChecked = (channel: ElectronReleaseChannel) => {
+      return appState.channelsToShow.includes(channel);
+    };
 
-      this.setState({ isDownloadingAll: false });
-    }
+    const getIsCurrentVersionReleaseChannel = (
+      channel: ElectronReleaseChannel,
+    ) => {
+      return getReleaseChannel(appState.version) === channel;
+    };
 
-    /**
-     * Delete all downloaded versions of Electron.
-     *
-     * @returns {Promise<void>}
-     */
-    public async handleDeleteAll(): Promise<void> {
-      this.setState({ isDeletingAll: true });
+    const channels = {
+      stable: ElectronReleaseChannel.stable,
+      beta: ElectronReleaseChannel.beta,
+      nightly: ElectronReleaseChannel.nightly,
+    };
 
-      const { versions, removeVersion } = this.props.appState;
-
-      for (const ver of Object.values(versions)) {
-        await removeVersion(ver);
-      }
-
-      this.setState({ isDeletingAll: false });
-    }
-
-    /**
-     * Opens the "add local version" dialog
-     */
-    public handleAddVersion(): void {
-      this.props.appState.toggleAddVersionDialog();
-    }
-
-    public render() {
-      return (
-        <div className="settings-electron">
-          <h1>Electron Settings</h1>
-          <Callout>{this.renderVersionShowOptions()}</Callout>
-          <br />
-          <Callout>{this.filterSection()}</Callout>
-          <br />
-          <Callout>
-            {this.renderAdvancedButtons()}
-            {this.renderTable()}
-          </Callout>
-        </div>
-      );
-    }
-
-    /**
-     * Renders the various buttons for advanced operations
-     *
-     * @private
-     * @returns {JSX.Element}
-     */
-    private renderAdvancedButtons(): JSX.Element {
-      const { isDownloadingAll, isDeletingAll } = this.state;
-      const { isUpdatingElectronVersions } = this.props.appState;
-      const isWorking = isDownloadingAll || isDeletingAll;
-
-      return (
-        <ButtonGroup fill={true}>
-          <Button
-            disabled={isUpdatingElectronVersions}
-            onClick={this.handleUpdateElectronVersions}
-            loading={isUpdatingElectronVersions}
-            icon="numbered-list"
-            text="Update Electron Release List"
-          />
-          <Button
-            disabled={isWorking}
-            icon="download"
-            onClick={this.handleDownloadAll}
-            text="Download All Versions"
-          />
-          <Button
-            disabled={isWorking}
-            icon="trash"
-            onClick={this.handleDeleteAll}
-            text="Delete All Downloads"
-          />
-          <Button
-            icon="document-open"
-            onClick={this.handleAddVersion}
-            text="Add Local Electron Build"
-          />
-        </ButtonGroup>
-      );
-    }
-    private filterSection(): JSX.Element {
-      const { appState } = this.props;
-      return (
-        <FormGroup label="Filters:">
-          <Checkbox
-            checked={appState.showUndownloadedVersions}
-            id="showUndownloadedVersions"
-            label="Not downloaded"
-            onChange={this.handleStateChange}
-          />
-        </FormGroup>
-      );
-    }
-
-    /**
-     * Renders the various options for which versions should be displayed
-     *
-     * @private
-     * @returns {JSX.Element}
-     */
-    private renderVersionShowOptions(): JSX.Element {
-      const { appState } = this.props;
-
-      const getIsChecked = (channel: ElectronReleaseChannel) => {
-        return appState.channelsToShow.includes(channel);
-      };
-
-      const getIsCurrentVersionReleaseChannel = (
-        channel: ElectronReleaseChannel,
-      ) => {
-        return getReleaseChannel(appState.version) === channel;
-      };
-
-      const channels = {
-        stable: ElectronReleaseChannel.stable,
-        beta: ElectronReleaseChannel.beta,
-        nightly: ElectronReleaseChannel.nightly,
-      };
-
-      return (
-        <FormGroup label="Channels:">
-          {Object.values(channels).map((channel) => (
-            <Tooltip
-              content={`Can't disable channel of selected version (${appState.version})`}
-              disabled={!getIsCurrentVersionReleaseChannel(channel)}
-              position="bottom"
-              intent="primary"
-              key={channel}
-            >
-              <Checkbox
-                checked={getIsChecked(channel)}
-                label={channel}
-                id={channel}
-                onChange={this.handleChannelChange}
-                disabled={getIsCurrentVersionReleaseChannel(channel)}
-                inline={true}
-              />
-            </Tooltip>
-          ))}
+    return (
+      <FormGroup label="Channels:">
+        {Object.values(channels).map((channel) => (
           <Tooltip
-            content={`Include versions that have reached end-of-life (older than ${window.ElectronFiddle.getOldestSupportedMajor()}.0.0)`}
+            content={`Can't disable channel of selected version (${appState.version})`}
+            disabled={!getIsCurrentVersionReleaseChannel(channel)}
             position="bottom"
             intent="primary"
+            key={channel}
           >
             <Checkbox
-              checked={appState.showObsoleteVersions}
-              id="showObsoleteVersions"
+              checked={getIsChecked(channel)}
+              label={channel}
+              id={channel}
+              onChange={this.handleChannelChange}
+              disabled={getIsCurrentVersionReleaseChannel(channel)}
               inline={true}
-              label="Obsolete"
-              onChange={this.handleShowObsoleteChange}
             />
           </Tooltip>
-        </FormGroup>
-      );
+        ))}
+        <Tooltip
+          content={`Include versions that have reached end-of-life (older than ${window.ElectronFiddle.getOldestSupportedMajor()}.0.0)`}
+          position="bottom"
+          intent="primary"
+        >
+          <Checkbox
+            checked={appState.showObsoleteVersions}
+            id="showObsoleteVersions"
+            inline={true}
+            label="Obsolete"
+            onChange={this.handleShowObsoleteChange}
+          />
+        </Tooltip>
+      </FormGroup>
+    );
+  }
+
+  /**
+   * Renders the table with Electron versions.
+   *
+   * @private
+   * @returns {JSX.Element}
+   */
+  private renderTable(): JSX.Element {
+    return (
+      <HTMLTable className="electron-versions-table" striped={true}>
+        <thead>
+          <tr>
+            <th>Version</th>
+            <th>Status</th>
+            <th className="action">Action</th>
+          </tr>
+        </thead>
+        <tbody>{this.renderTableRows()}</tbody>
+      </HTMLTable>
+    );
+  }
+
+  /**
+   * Renders the rows with Electron version, returning an Array.
+   *
+   * @private
+   * @returns {Array<JSX.Element>}
+   */
+  private renderTableRows(): Array<JSX.Element | null> {
+    return this.props.appState.versionsToShow.map((item) => (
+      <tr key={item.version}>
+        <td>{item.version}</td>
+        <td>{this.renderHumanState(item)}</td>
+        <td className="action">{this.renderAction(item)}</td>
+      </tr>
+    ));
+  }
+
+  /**
+   * Returns a human-readable state indicator for an Electron version.
+   *
+   * @param {RunnableVersion} item
+   * @returns {JSX.Element}
+   */
+  private renderHumanState(item: RunnableVersion): JSX.Element {
+    const { state, source } = item;
+    const isLocal = source === VersionSource.local;
+    let icon: IconName = 'box';
+    let humanState = 'Downloaded';
+
+    if (state === InstallState.downloading) {
+      icon = 'cloud-download';
+      humanState = 'Downloading';
+    } else if (state === InstallState.missing) {
+      // The only way for a local version to be missing
+      // is for it to have been deleted. Mark as unavailable.
+      icon = isLocal ? 'issue' : 'cloud';
+      humanState = isLocal ? 'Not available' : 'Not downloaded';
     }
 
-    /**
-     * Renders the table with Electron versions.
-     *
-     * @private
-     * @returns {JSX.Element}
-     */
-    private renderTable(): JSX.Element {
+    return (
+      <span>
+        <Icon icon={icon} /> {humanState}
+      </span>
+    );
+  }
+
+  /**
+   * Renders the action for a single Electron version.
+   *
+   * @private
+   * @param {RunnableVersion} ver
+   * @returns {JSX.Element}
+   */
+  private renderAction(ver: RunnableVersion): JSX.Element {
+    const { state, source, version } = ver;
+    const { appState } = this.props;
+    const isLocal = source === VersionSource.local;
+    const buttonProps: ButtonProps = {
+      fill: true,
+      small: true,
+    };
+
+    switch (state) {
+      case InstallState.installed:
+      case InstallState.downloaded:
+        buttonProps.icon = 'trash';
+        buttonProps.onClick = () => appState.removeVersion(ver);
+        buttonProps.text = isLocal ? 'Remove' : 'Delete';
+        break;
+
+      case InstallState.installing:
+      case InstallState.downloading:
+        buttonProps.disabled = true;
+        buttonProps.icon = <Spinner size={16} value={ver.downloadProgress} />;
+        buttonProps.text = 'Downloading';
+        break;
+
+      case InstallState.missing:
+        buttonProps.disabled = false;
+        buttonProps.loading = false;
+        buttonProps.icon = isLocal ? 'trash' : 'cloud-download';
+        buttonProps.text = isLocal ? 'Remove' : 'Download';
+        buttonProps.onClick = () => {
+          isLocal ? appState.removeVersion(ver) : appState.downloadVersion(ver);
+        };
+        break;
+    }
+
+    if (version === appState.currentElectronVersion.version) {
       return (
-        <HTMLTable className="electron-versions-table" striped={true}>
-          <thead>
-            <tr>
-              <th>Version</th>
-              <th>Status</th>
-              <th className="action">Action</th>
-            </tr>
-          </thead>
-          <tbody>{this.renderTableRows()}</tbody>
-        </HTMLTable>
+        <Tooltip
+          position="auto"
+          intent="primary"
+          content={`Can't remove currently active Electron version (${version})`}
+        >
+          <AnchorButton
+            className={'disabled-version'}
+            disabled={true}
+            text={buttonProps.text}
+            icon={buttonProps.icon}
+          />
+        </Tooltip>
       );
-    }
-
-    /**
-     * Renders the rows with Electron version, returning an Array.
-     *
-     * @private
-     * @returns {Array<JSX.Element>}
-     */
-    private renderTableRows(): Array<JSX.Element | null> {
-      return this.props.appState.versionsToShow.map((item) => (
-        <tr key={item.version}>
-          <td>{item.version}</td>
-          <td>{this.renderHumanState(item)}</td>
-          <td className="action">{this.renderAction(item)}</td>
-        </tr>
-      ));
-    }
-
-    /**
-     * Returns a human-readable state indicator for an Electron version.
-     *
-     * @param {RunnableVersion} item
-     * @returns {JSX.Element}
-     */
-    private renderHumanState(item: RunnableVersion): JSX.Element {
-      const { state, source } = item;
-      const isLocal = source === VersionSource.local;
-      let icon: IconName = 'box';
-      let humanState = 'Downloaded';
-
-      if (state === InstallState.downloading) {
-        icon = 'cloud-download';
-        humanState = 'Downloading';
-      } else if (state === InstallState.missing) {
-        // The only way for a local version to be missing
-        // is for it to have been deleted. Mark as unavailable.
-        icon = isLocal ? 'issue' : 'cloud';
-        humanState = isLocal ? 'Not available' : 'Not downloaded';
-      }
-
+    } else if (disableDownload(version)) {
       return (
-        <span>
-          <Icon icon={icon} /> {humanState}
-        </span>
+        <Tooltip
+          position="auto"
+          intent="primary"
+          content={`Version is not available on your current OS`}
+        >
+          <AnchorButton
+            className={'disabled-version'}
+            disabled={true}
+            text={buttonProps.text}
+            icon={buttonProps.icon}
+          />
+        </Tooltip>
       );
     }
 
-    /**
-     * Renders the action for a single Electron version.
-     *
-     * @private
-     * @param {RunnableVersion} ver
-     * @returns {JSX.Element}
-     */
-    private renderAction(ver: RunnableVersion): JSX.Element {
-      const { state, source, version } = ver;
-      const { appState } = this.props;
-      const isLocal = source === VersionSource.local;
-      const buttonProps: ButtonProps = {
-        fill: true,
-        small: true,
-      };
-
-      switch (state) {
-        case InstallState.installed:
-        case InstallState.downloaded:
-          buttonProps.icon = 'trash';
-          buttonProps.onClick = () => appState.removeVersion(ver);
-          buttonProps.text = isLocal ? 'Remove' : 'Delete';
-          break;
-
-        case InstallState.installing:
-        case InstallState.downloading:
-          buttonProps.disabled = true;
-          buttonProps.icon = <Spinner size={16} value={ver.downloadProgress} />;
-          buttonProps.text = 'Downloading';
-          break;
-
-        case InstallState.missing:
-          buttonProps.disabled = false;
-          buttonProps.loading = false;
-          buttonProps.icon = isLocal ? 'trash' : 'cloud-download';
-          buttonProps.text = isLocal ? 'Remove' : 'Download';
-          buttonProps.onClick = () => {
-            isLocal
-              ? appState.removeVersion(ver)
-              : appState.downloadVersion(ver);
-          };
-          break;
-      }
-
-      if (version === appState.currentElectronVersion.version) {
-        return (
-          <Tooltip
-            position="auto"
-            intent="primary"
-            content={`Can't remove currently active Electron version (${version})`}
-          >
-            <AnchorButton
-              className={'disabled-version'}
-              disabled={true}
-              text={buttonProps.text}
-              icon={buttonProps.icon}
-            />
-          </Tooltip>
-        );
-      } else if (disableDownload(version)) {
-        return (
-          <Tooltip
-            position="auto"
-            intent="primary"
-            content={`Version is not available on your current OS`}
-          >
-            <AnchorButton
-              className={'disabled-version'}
-              disabled={true}
-              text={buttonProps.text}
-              icon={buttonProps.icon}
-            />
-          </Tooltip>
-        );
-      }
-
-      return <Button {...buttonProps} type={undefined} />;
-    }
-  },
-);
+    return <Button {...buttonProps} type={undefined} />;
+  }
+}

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -34,339 +34,331 @@ interface ExecutionSettingsState {
  * @class ExecutionSettings
  * @extends {React.Component<ExecutionSettingsProps, ExecutionSettingsState>}
  */
-export const ExecutionSettings = observer(
-  class ExecutionSettings extends React.Component<
-    ExecutionSettingsProps,
-    ExecutionSettingsState
-  > {
-    constructor(props: ExecutionSettingsProps) {
-      super(props);
+@observer
+export class ExecutionSettings extends React.Component<
+  ExecutionSettingsProps,
+  ExecutionSettingsState
+> {
+  constructor(props: ExecutionSettingsProps) {
+    super(props);
 
-      this.state = {
-        executionFlags: Object.assign(
-          {},
-          ...props.appState.executionFlags.map((flag, idx) => {
-            return { [idx]: flag };
-          }),
-        ),
-        environmentVariables: Object.assign(
-          {},
-          ...props.appState.environmentVariables.map((envVar, idx) => {
-            return { [idx]: envVar };
-          }),
-        ),
-      };
-
-      this.handleDeleteDataChange = this.handleDeleteDataChange.bind(this);
-      this.handleElectronLoggingChange = this.handleElectronLoggingChange.bind(
-        this,
-      );
-
-      this.handleSettingsItemChange = this.handleSettingsItemChange.bind(this);
-      this.addNewSettingsItem = this.addNewSettingsItem.bind(this);
-    }
-
-    public componentDidMount() {
-      const { environmentVariables, executionFlags } = this.state;
-
-      if (Object.keys(executionFlags).length === 0) {
-        this.addNewSettingsItem(SettingItemType.Flags);
-      }
-
-      if (Object.keys(environmentVariables).length === 0) {
-        this.addNewSettingsItem(SettingItemType.EnvVars);
-      }
-    }
-
-    public componentDidUpdate() {
-      const { appState } = this.props;
-
-      for (const type of Object.values(SettingItemType)) {
-        const values = Object.values(this.state[type]);
-        appState[type] = values.filter((v) => v !== '');
-      }
-    }
-
-    /**
-     * Handles a change on whether or not the user data dir should be deleted
-     * after a run.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleDeleteDataChange(event: React.FormEvent<HTMLInputElement>) {
-      const { checked } = event.currentTarget;
-      this.props.appState.isKeepingUserDataDirs = checked;
-    }
-
-    /**
-     * Handles a change on whether or not electron should log more things
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleElectronLoggingChange(
-      event: React.FormEvent<HTMLInputElement>,
-    ) {
-      const { checked } = event.currentTarget;
-      this.props.appState.isEnablingElectronLogging = checked;
-    }
-
-    /**
-     * Handles a change in the execution flags or environment variables
-     * run with the Electron executable.
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     * @param {SettingItemType} type
-     */
-    public handleSettingsItemChange(
-      event: React.ChangeEvent<HTMLInputElement>,
-      type: SettingItemType,
-    ) {
-      const { name, value } = event.currentTarget;
-
-      this.setState((prevState) => ({
-        [type]: {
-          ...prevState[type],
-          [name]: value,
-        },
-      }));
-    }
-
-    /**
-     * Adds a new settings item input field.
-     *
-     * @param {SettingItemType} type
-     */
-    private addNewSettingsItem(type: SettingItemType) {
-      const array = Object.entries(this.state[type]);
-
-      this.setState((prevState) => ({
-        [type as any]: {
-          ...prevState[type],
-          [array.length]: '',
-        },
-      }));
-    }
-
-    /**
-     * Handle a change to the package manager used to install modules when running
-     * Fiddles;
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    private handlePMChange = (event: React.FormEvent<HTMLInputElement>) => {
-      const { appState } = this.props;
-      const { value } = event.currentTarget;
-
-      appState.packageManager = value as IPackageManager;
+    this.state = {
+      executionFlags: Object.assign(
+        {},
+        ...props.appState.executionFlags.map((flag, idx) => {
+          return { [idx]: flag };
+        }),
+      ),
+      environmentVariables: Object.assign(
+        {},
+        ...props.appState.environmentVariables.map((envVar, idx) => {
+          return { [idx]: envVar };
+        }),
+      ),
     };
 
-    public renderDeleteItem(idx: string, type: SettingItemType): JSX.Element {
-      const updated = this.state[type];
+    this.handleDeleteDataChange = this.handleDeleteDataChange.bind(this);
+    this.handleElectronLoggingChange = this.handleElectronLoggingChange.bind(
+      this,
+    );
 
-      const removeFn = () => {
-        if (Object.keys(updated).length === 1) {
-          updated[idx] = '';
-        } else {
-          delete updated[idx];
-        }
+    this.handleSettingsItemChange = this.handleSettingsItemChange.bind(this);
+    this.addNewSettingsItem = this.addNewSettingsItem.bind(this);
+  }
 
-        this.setState({ [type]: updated });
-      };
+  public componentDidMount() {
+    const { environmentVariables, executionFlags } = this.state;
 
-      return (
-        <Button
-          icon="cross"
-          disabled={Object.keys(updated).length === 1}
-          onClick={removeFn}
-        />
-      );
+    if (Object.keys(executionFlags).length === 0) {
+      this.addNewSettingsItem(SettingItemType.Flags);
     }
 
-    private renderEnvironmentVariables() {
-      const { environmentVariables } = this.state;
-
-      const varsArray = Object.entries(environmentVariables);
-      const type = SettingItemType.EnvVars;
-
-      return (
-        <FormGroup>
-          <p>
-            Electron allows starting the executable with{' '}
-            <a href="https://www.electronjs.org/docs/api/environment-variables">
-              user-provided environment variables
-            </a>
-            , such as{' '}
-            <code>
-              NODE_OPTIONS=&quot;--no-warnings --max-old-space-size=2048&quot;
-            </code>
-            . Those can be added here to run when you start your Fiddles.
-          </p>
-          <br />
-          {varsArray.map(([idx, envVar]) => {
-            return (
-              <InputGroup
-                aria-label={'Set user-provided environment variables'}
-                placeholder='NODE_OPTIONS="--no-warnings --max-old-space-size=2048"'
-                value={envVar}
-                name={idx}
-                key={idx}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  this.handleSettingsItemChange(e, type)
-                }
-                rightElement={this.renderDeleteItem(idx, type)}
-              />
-            );
-          })}
-        </FormGroup>
-      );
+    if (Object.keys(environmentVariables).length === 0) {
+      this.addNewSettingsItem(SettingItemType.EnvVars);
     }
+  }
 
-    private renderExecutionFlags() {
-      const { executionFlags } = this.state;
+  public componentDidUpdate() {
+    const { appState } = this.props;
 
-      const flagsArray = Object.entries(executionFlags);
-      const type = SettingItemType.Flags;
-
-      return (
-        <FormGroup>
-          <p>
-            Electron allows starting the executable with{' '}
-            <a href="https://www.electronjs.org/docs/api/command-line-switches">
-              user-provided flags
-            </a>
-            , such as <code>--js-flags=--expose-gc</code>. Those can be added to
-            run when you start your Fiddles.
-          </p>
-          <br />
-          {flagsArray.map(([idx, flag]) => {
-            return (
-              <InputGroup
-                aria-label={'Set user-provided flags'}
-                placeholder="--js-flags=--expose-gc"
-                value={flag}
-                name={idx}
-                key={idx}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  this.handleSettingsItemChange(e, type)
-                }
-                rightElement={this.renderDeleteItem(idx, type)}
-              />
-            );
-          })}
-        </FormGroup>
-      );
+    for (const type of Object.values(SettingItemType)) {
+      const values = Object.values(this.state[type]);
+      appState[type] = values.filter((v) => v !== '');
     }
+  }
 
-    public render() {
-      const {
-        isKeepingUserDataDirs,
-        isEnablingElectronLogging,
-      } = this.props.appState;
+  /**
+   * Handles a change on whether or not the user data dir should be deleted
+   * after a run.
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleDeleteDataChange(event: React.FormEvent<HTMLInputElement>) {
+    const { checked } = event.currentTarget;
+    this.props.appState.isKeepingUserDataDirs = checked;
+  }
 
-      return (
-        <div>
-          <h1>Execution</h1>
-          <Callout>
-            These advanced settings control how Electron Fiddle executes your
-            fiddles.
-          </Callout>
-          <br />
-          <Callout>
-            <FormGroup>
-              <p>
-                Whenever Electron runs, it creates a user data directory for
-                cookies, the cache, and various other things that it needs to
-                keep around. Since fiddles are usually just run once, we delete
-                this directory after your fiddle exits. Enable this setting to
-                keep the user data directories around.
-              </p>
-              <Checkbox
-                checked={isKeepingUserDataDirs}
-                label="Do not delete user data directories."
-                onChange={this.handleDeleteDataChange}
-              />
-            </FormGroup>
-          </Callout>
-          <br />
-          <Callout>
-            <FormGroup>
-              <p>
-                There are some flags that Electron uses to log extra information
-                both internally and through Chromium. Enable this option to make
-                Fiddle produce those logs. Enabling advanced Electron logging
-                will set the <code>ELECTRON_ENABLE_LOGGING</code>,{' '}
-                <code>ELECTRON_DEBUG_NOTIFICATION</code>, and{' '}
-                <code>ELECTRON_ENABLE_STACK_DUMPING</code> environment variables
-                to true. See{' '}
-                <a href="https://www.electronjs.org/docs/api/environment-variables">
-                  documentation
-                </a>{' '}
-                for more information about what they do.
-              </p>
-              <Checkbox
-                checked={isEnablingElectronLogging}
-                label="Enable advanced Electron logging."
-                onChange={this.handleElectronLoggingChange}
-              />
-            </FormGroup>
-          </Callout>
-          <br />
-          <Callout>
-            {this.renderExecutionFlags()}
-            <ButtonGroup>
-              <Button
-                onClick={() => this.addNewSettingsItem(SettingItemType.Flags)}
+  /**
+   * Handles a change on whether or not electron should log more things
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleElectronLoggingChange(event: React.FormEvent<HTMLInputElement>) {
+    const { checked } = event.currentTarget;
+    this.props.appState.isEnablingElectronLogging = checked;
+  }
+
+  /**
+   * Handles a change in the execution flags or environment variables
+   * run with the Electron executable.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   * @param {SettingItemType} type
+   */
+  public handleSettingsItemChange(
+    event: React.ChangeEvent<HTMLInputElement>,
+    type: SettingItemType,
+  ) {
+    const { name, value } = event.currentTarget;
+
+    this.setState((prevState) => ({
+      [type]: {
+        ...prevState[type],
+        [name]: value,
+      },
+    }));
+  }
+
+  /**
+   * Adds a new settings item input field.
+   *
+   * @param {SettingItemType} type
+   */
+  private addNewSettingsItem(type: SettingItemType) {
+    const array = Object.entries(this.state[type]);
+
+    this.setState((prevState) => ({
+      [type as any]: {
+        ...prevState[type],
+        [array.length]: '',
+      },
+    }));
+  }
+
+  /**
+   * Handle a change to the package manager used to install modules when running
+   * Fiddles;
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  private handlePMChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const { appState } = this.props;
+    const { value } = event.currentTarget;
+
+    appState.packageManager = value as IPackageManager;
+  };
+
+  public renderDeleteItem(idx: string, type: SettingItemType): JSX.Element {
+    const updated = this.state[type];
+
+    const removeFn = () => {
+      if (Object.keys(updated).length === 1) {
+        updated[idx] = '';
+      } else {
+        delete updated[idx];
+      }
+
+      this.setState({ [type]: updated });
+    };
+
+    return (
+      <Button
+        icon="cross"
+        disabled={Object.keys(updated).length === 1}
+        onClick={removeFn}
+      />
+    );
+  }
+
+  private renderEnvironmentVariables() {
+    const { environmentVariables } = this.state;
+
+    const varsArray = Object.entries(environmentVariables);
+    const type = SettingItemType.EnvVars;
+
+    return (
+      <FormGroup>
+        <p>
+          Electron allows starting the executable with{' '}
+          <a href="https://www.electronjs.org/docs/api/environment-variables">
+            user-provided environment variables
+          </a>
+          , such as{' '}
+          <code>
+            NODE_OPTIONS=&quot;--no-warnings --max-old-space-size=2048&quot;
+          </code>
+          . Those can be added here to run when you start your Fiddles.
+        </p>
+        <br />
+        {varsArray.map(([idx, envVar]) => {
+          return (
+            <InputGroup
+              aria-label={'Set user-provided environment variables'}
+              placeholder='NODE_OPTIONS="--no-warnings --max-old-space-size=2048"'
+              value={envVar}
+              name={idx}
+              key={idx}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                this.handleSettingsItemChange(e, type)
+              }
+              rightElement={this.renderDeleteItem(idx, type)}
+            />
+          );
+        })}
+      </FormGroup>
+    );
+  }
+
+  private renderExecutionFlags() {
+    const { executionFlags } = this.state;
+
+    const flagsArray = Object.entries(executionFlags);
+    const type = SettingItemType.Flags;
+
+    return (
+      <FormGroup>
+        <p>
+          Electron allows starting the executable with{' '}
+          <a href="https://www.electronjs.org/docs/api/command-line-switches">
+            user-provided flags
+          </a>
+          , such as <code>--js-flags=--expose-gc</code>. Those can be added to
+          run when you start your Fiddles.
+        </p>
+        <br />
+        {flagsArray.map(([idx, flag]) => {
+          return (
+            <InputGroup
+              aria-label={'Set user-provided flags'}
+              placeholder="--js-flags=--expose-gc"
+              value={flag}
+              name={idx}
+              key={idx}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                this.handleSettingsItemChange(e, type)
+              }
+              rightElement={this.renderDeleteItem(idx, type)}
+            />
+          );
+        })}
+      </FormGroup>
+    );
+  }
+
+  public render() {
+    const {
+      isKeepingUserDataDirs,
+      isEnablingElectronLogging,
+    } = this.props.appState;
+
+    return (
+      <div>
+        <h1>Execution</h1>
+        <Callout>
+          These advanced settings control how Electron Fiddle executes your
+          fiddles.
+        </Callout>
+        <br />
+        <Callout>
+          <FormGroup>
+            <p>
+              Whenever Electron runs, it creates a user data directory for
+              cookies, the cache, and various other things that it needs to keep
+              around. Since fiddles are usually just run once, we delete this
+              directory after your fiddle exits. Enable this setting to keep the
+              user data directories around.
+            </p>
+            <Checkbox
+              checked={isKeepingUserDataDirs}
+              label="Do not delete user data directories."
+              onChange={this.handleDeleteDataChange}
+            />
+          </FormGroup>
+        </Callout>
+        <br />
+        <Callout>
+          <FormGroup>
+            <p>
+              There are some flags that Electron uses to log extra information
+              both internally and through Chromium. Enable this option to make
+              Fiddle produce those logs. Enabling advanced Electron logging will
+              set the <code>ELECTRON_ENABLE_LOGGING</code>,{' '}
+              <code>ELECTRON_DEBUG_NOTIFICATION</code>, and{' '}
+              <code>ELECTRON_ENABLE_STACK_DUMPING</code> environment variables
+              to true. See{' '}
+              <a href="https://www.electronjs.org/docs/api/environment-variables">
+                documentation
+              </a>{' '}
+              for more information about what they do.
+            </p>
+            <Checkbox
+              checked={isEnablingElectronLogging}
+              label="Enable advanced Electron logging."
+              onChange={this.handleElectronLoggingChange}
+            />
+          </FormGroup>
+        </Callout>
+        <br />
+        <Callout>
+          {this.renderExecutionFlags()}
+          <ButtonGroup>
+            <Button
+              onClick={() => this.addNewSettingsItem(SettingItemType.Flags)}
+            >
+              Add New Flag
+            </Button>
+          </ButtonGroup>
+        </Callout>
+        <br />
+        <Callout>
+          {this.renderEnvironmentVariables()}
+          <ButtonGroup>
+            <Button
+              onClick={() => this.addNewSettingsItem(SettingItemType.EnvVars)}
+            >
+              Add New Variable
+            </Button>
+          </ButtonGroup>
+        </Callout>
+        <br />
+        <Callout>
+          <FormGroup>
+            <span style={{ marginRight: 4 }}>
+              Electron Fiddle will install packages if you specify them. It uses{' '}
+              <a href="https://www.npmjs.com/" target="_blank" rel="noreferrer">
+                npm
+              </a>{' '}
+              as its package manager by default, but{' '}
+              <a
+                href="https://classic.yarnpkg.com/lang/en/"
+                target="_blank"
+                rel="noreferrer"
               >
-                Add New Flag
-              </Button>
-            </ButtonGroup>
-          </Callout>
-          <br />
-          <Callout>
-            {this.renderEnvironmentVariables()}
-            <ButtonGroup>
-              <Button
-                onClick={() => this.addNewSettingsItem(SettingItemType.EnvVars)}
-              >
-                Add New Variable
-              </Button>
-            </ButtonGroup>
-          </Callout>
-          <br />
-          <Callout>
-            <FormGroup>
-              <span style={{ marginRight: 4 }}>
-                Electron Fiddle will install packages if you specify them. It
-                uses{' '}
-                <a
-                  href="https://www.npmjs.com/"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  npm
-                </a>{' '}
-                as its package manager by default, but{' '}
-                <a
-                  href="https://classic.yarnpkg.com/lang/en/"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Yarn
-                </a>{' '}
-                is also available.
-              </span>
-              <RadioGroup
-                onChange={this.handlePMChange}
-                selectedValue={this.props.appState.packageManager}
-                inline={true}
-              >
-                <Radio label="npm" value="npm" />
-                <Radio label="yarn" value="yarn" />
-              </RadioGroup>
-            </FormGroup>
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+                Yarn
+              </a>{' '}
+              is also available.
+            </span>
+            <RadioGroup
+              onChange={this.handlePMChange}
+              selectedValue={this.props.appState.packageManager}
+              inline={true}
+            >
+              <Radio label="npm" value="npm" />
+              <Radio label="yarn" value="yarn" />
+            </RadioGroup>
+          </FormGroup>
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -77,185 +77,182 @@ interface AppearanceSettingsState {
  * @class AppearanceSettings
  * @extends {React.Component<AppearanceSettingsProps, AppearanceSettingsState>}
  */
-export const AppearanceSettings = observer(
-  class AppearanceSettings extends React.Component<
-    AppearanceSettingsProps,
-    AppearanceSettingsState
-  > {
-    public constructor(props: AppearanceSettingsProps) {
-      super(props);
+@observer
+export class AppearanceSettings extends React.Component<
+  AppearanceSettingsProps,
+  AppearanceSettingsState
+> {
+  public constructor(props: AppearanceSettingsProps) {
+    super(props);
 
-      this.handleChange = this.handleChange.bind(this);
-      this.openThemeFolder = this.openThemeFolder.bind(this);
-      this.handleAddTheme = this.handleAddTheme.bind(this);
-      this.handleThemeSource = this.handleThemeSource.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.openThemeFolder = this.openThemeFolder.bind(this);
+    this.handleAddTheme = this.handleAddTheme.bind(this);
+    this.handleThemeSource = this.handleThemeSource.bind(this);
 
-      this.state = {
-        themes: [],
-      };
+    this.state = {
+      themes: [],
+    };
 
-      window.ElectronFiddle.getAvailableThemes().then((themes) => {
-        const { theme } = this.props.appState;
-        const selectedTheme =
-          (theme && themes.find(({ file }) => file === theme)) || themes[0];
+    window.ElectronFiddle.getAvailableThemes().then((themes) => {
+      const { theme } = this.props.appState;
+      const selectedTheme =
+        (theme && themes.find(({ file }) => file === theme)) || themes[0];
 
-        this.setState({ themes, selectedTheme });
+      this.setState({ themes, selectedTheme });
 
-        // set up mobx so that changes from system sync are reflected in picker
-        reaction(
-          () => this.props.appState.theme,
-          async () => {
-            const selectedTheme = await getTheme(this.props.appState.theme);
-            this.setState({ selectedTheme });
-          },
-        );
-      });
-
-      this.createNewThemeFromCurrent = this.createNewThemeFromCurrent.bind(
-        this,
+      // set up mobx so that changes from system sync are reflected in picker
+      reaction(
+        () => this.props.appState.theme,
+        async () => {
+          const selectedTheme = await getTheme(this.props.appState.theme);
+          this.setState({ selectedTheme });
+        },
       );
-      this.openThemeFolder = this.openThemeFolder.bind(this);
-    }
+    });
 
-    /**
-     * Handle change, which usually means that we'd like update
-     * the current theme.
-     *
-     * @param {LoadedFiddleTheme} theme
-     */
-    public handleChange(theme: LoadedFiddleTheme) {
-      this.setState({ selectedTheme: theme });
-      this.props.appState.setTheme(theme.file);
-    }
+    this.createNewThemeFromCurrent = this.createNewThemeFromCurrent.bind(this);
+    this.openThemeFolder = this.openThemeFolder.bind(this);
+  }
 
-    /**
-     * Creates a new theme from the current template.
-     *
-     * @returns {Promise<boolean>}
-     * @memberof AppearanceSettings
-     */
-    public async createNewThemeFromCurrent(): Promise<boolean> {
-      const { appState } = this.props;
-      const theme = await getTheme(appState.theme);
+  /**
+   * Handle change, which usually means that we'd like update
+   * the current theme.
+   *
+   * @param {LoadedFiddleTheme} theme
+   */
+  public handleChange(theme: LoadedFiddleTheme) {
+    this.setState({ selectedTheme: theme });
+    this.props.appState.setTheme(theme.file);
+  }
 
-      try {
-        await window.ElectronFiddle.createThemeFile(theme);
-        this.setState({
-          themes: await window.ElectronFiddle.getAvailableThemes(),
-        });
+  /**
+   * Creates a new theme from the current template.
+   *
+   * @returns {Promise<boolean>}
+   * @memberof AppearanceSettings
+   */
+  public async createNewThemeFromCurrent(): Promise<boolean> {
+    const { appState } = this.props;
+    const theme = await getTheme(appState.theme);
 
-        return true;
-      } catch (error) {
-        console.warn(`Themes: Failed to create new theme from current`, error);
-
-        return false;
-      }
-    }
-
-    /**
-     * Creates the themes folder in .electron-fiddle if one does not
-     * exist yet, then shows that folder in the Finder/Explorer.
-     *
-     * @returns {Promise<boolean>}
-     */
-    public async openThemeFolder(): Promise<boolean> {
-      try {
-        await window.ElectronFiddle.openThemeFolder();
-        return true;
-      } catch (error) {
-        console.warn(`Appearance Settings: Could not open themes folder`);
-        return false;
-      }
-    }
-
-    /**
-     * Opens the "add monaco theme" dialog
-     */
-    public async handleAddTheme(): Promise<void> {
-      this.props.appState.toggleAddMonacoThemeDialog();
-
-      // Wait for the dialog to be closed again
-      await when(() => !this.props.appState.isTokenDialogShowing);
-
+    try {
+      await window.ElectronFiddle.createThemeFile(theme);
       this.setState({
         themes: await window.ElectronFiddle.getAvailableThemes(),
       });
+
+      return true;
+    } catch (error) {
+      console.warn(`Themes: Failed to create new theme from current`, error);
+
+      return false;
     }
+  }
 
-    public handleThemeSource(event: React.FormEvent<HTMLInputElement>): void {
-      const { appState } = this.props;
-      const { checked } = event.currentTarget;
-      appState.isUsingSystemTheme = checked;
+  /**
+   * Creates the themes folder in .electron-fiddle if one does not
+   * exist yet, then shows that folder in the Finder/Explorer.
+   *
+   * @returns {Promise<boolean>}
+   */
+  public async openThemeFolder(): Promise<boolean> {
+    try {
+      await window.ElectronFiddle.openThemeFolder();
+      return true;
+    } catch (error) {
+      console.warn(`Appearance Settings: Could not open themes folder`);
+      return false;
     }
+  }
 
-    public render() {
-      const { selectedTheme } = this.state;
-      const { isUsingSystemTheme } = this.props.appState;
-      const selectedName =
-        (selectedTheme && selectedTheme.name) || 'Select a theme';
+  /**
+   * Opens the "add monaco theme" dialog
+   */
+  public async handleAddTheme(): Promise<void> {
+    this.props.appState.toggleAddMonacoThemeDialog();
 
-      return (
-        <div className="settings-appearance">
-          <h3>Appearance</h3>
-          <Checkbox
-            label="Sync theme with system setting"
-            checked={isUsingSystemTheme}
-            onChange={this.handleThemeSource}
-          />
-          <FormGroup
-            label="Choose your theme"
-            labelFor="open-theme-selector"
+    // Wait for the dialog to be closed again
+    await when(() => !this.props.appState.isTokenDialogShowing);
+
+    this.setState({
+      themes: await window.ElectronFiddle.getAvailableThemes(),
+    });
+  }
+
+  public handleThemeSource(event: React.FormEvent<HTMLInputElement>): void {
+    const { appState } = this.props;
+    const { checked } = event.currentTarget;
+    appState.isUsingSystemTheme = checked;
+  }
+
+  public render() {
+    const { selectedTheme } = this.state;
+    const { isUsingSystemTheme } = this.props.appState;
+    const selectedName =
+      (selectedTheme && selectedTheme.name) || 'Select a theme';
+
+    return (
+      <div className="settings-appearance">
+        <h3>Appearance</h3>
+        <Checkbox
+          label="Sync theme with system setting"
+          checked={isUsingSystemTheme}
+          onChange={this.handleThemeSource}
+        />
+        <FormGroup
+          label="Choose your theme"
+          labelFor="open-theme-selector"
+          disabled={isUsingSystemTheme}
+          inline={true}
+        >
+          <ThemeSelect
+            filterable={true}
             disabled={isUsingSystemTheme}
-            inline={true}
+            items={this.state.themes}
+            activeItem={selectedTheme}
+            itemRenderer={renderItem}
+            itemPredicate={filterItem}
+            onItemSelect={this.handleChange}
+            popoverProps={{
+              onClosed: () => this.props.toggleHasPopoverOpen(),
+            }}
+            noResults={<MenuItem disabled={true} text="No results." />}
           >
-            <ThemeSelect
-              filterable={true}
+            <Button
+              id="open-theme-selector"
+              text={selectedName}
+              icon="tint"
+              onClick={() => this.props.toggleHasPopoverOpen()}
               disabled={isUsingSystemTheme}
-              items={this.state.themes}
-              activeItem={selectedTheme}
-              itemRenderer={renderItem}
-              itemPredicate={filterItem}
-              onItemSelect={this.handleChange}
-              popoverProps={{
-                onClosed: () => this.props.toggleHasPopoverOpen(),
-              }}
-              noResults={<MenuItem disabled={true} text="No results." />}
-            >
-              <Button
-                id="open-theme-selector"
-                text={selectedName}
-                icon="tint"
-                onClick={() => this.props.toggleHasPopoverOpen()}
-                disabled={isUsingSystemTheme}
-              />
-            </ThemeSelect>
-          </FormGroup>
-          <Callout hidden={isUsingSystemTheme}>
-            <p>
-              To add themes, add JSON theme files to{' '}
-              <a id="open-theme-folder" onClick={this.openThemeFolder}>
-                <code>{window.ElectronFiddle.themePath}</code>
-              </a>
-              . The easiest way to get started is to clone one of the two
-              existing themes and to add your own colors.
-            </p>
-            <p>
-              Additionally, if you wish to import a Monaco Editor theme, pick
-              your JSON file and Fiddle will attempt to import it.
-            </p>
-            <Button
-              onClick={this.createNewThemeFromCurrent}
-              text="Create theme from current selection"
-              icon="duplicate"
             />
-            <Button
-              icon="document-open"
-              onClick={this.handleAddTheme}
-              text="Add a Monaco Editor theme"
-            />
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+          </ThemeSelect>
+        </FormGroup>
+        <Callout hidden={isUsingSystemTheme}>
+          <p>
+            To add themes, add JSON theme files to{' '}
+            <a id="open-theme-folder" onClick={this.openThemeFolder}>
+              <code>{window.ElectronFiddle.themePath}</code>
+            </a>
+            . The easiest way to get started is to clone one of the two existing
+            themes and to add your own colors.
+          </p>
+          <p>
+            Additionally, if you wish to import a Monaco Editor theme, pick your
+            JSON file and Fiddle will attempt to import it.
+          </p>
+          <Button
+            onClick={this.createNewThemeFromCurrent}
+            text="Create theme from current selection"
+            icon="duplicate"
+          />
+          <Button
+            icon="document-open"
+            onClick={this.handleAddTheme}
+            text="Add a Monaco Editor theme"
+          />
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general-block-accelerators.tsx
+++ b/src/renderer/components/settings-general-block-accelerators.tsx
@@ -16,69 +16,64 @@ interface BlockAcceleratorsSettingsProps {
  * @class BlockAcceleratorsSettings
  * @extends {React.Component<BlockAcceleratorsSettingsProps>}
  */
-export const BlockAcceleratorsSettings = observer(
-  class BlockAcceleratorsSettings extends React.Component<BlockAcceleratorsSettingsProps> {
-    constructor(props: BlockAcceleratorsSettingsProps) {
-      super(props);
+@observer
+export class BlockAcceleratorsSettings extends React.Component<BlockAcceleratorsSettingsProps> {
+  constructor(props: BlockAcceleratorsSettingsProps) {
+    super(props);
 
-      this.handleBlockAcceleratorChange = this.handleBlockAcceleratorChange.bind(
-        this,
+    this.handleBlockAcceleratorChange = this.handleBlockAcceleratorChange.bind(
+      this,
+    );
+  }
+
+  /**
+   * Handles a change on whether a keyboard shortcut should be blocked
+   * before fiddle is executed.
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleBlockAcceleratorChange(
+    event: React.FormEvent<HTMLInputElement>,
+  ) {
+    const { checked, value } = event.currentTarget;
+    if (checked) {
+      this.props.appState.addAcceleratorToBlock(value as BlockableAccelerator);
+    } else {
+      this.props.appState.removeAcceleratorToBlock(
+        value as BlockableAccelerator,
       );
     }
+  }
 
-    /**
-     * Handles a change on whether a keyboard shortcut should be blocked
-     * before fiddle is executed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleBlockAcceleratorChange(
-      event: React.FormEvent<HTMLInputElement>,
-    ) {
-      const { checked, value } = event.currentTarget;
-      if (checked) {
-        this.props.appState.addAcceleratorToBlock(
-          value as BlockableAccelerator,
-        );
-      } else {
-        this.props.appState.removeAcceleratorToBlock(
-          value as BlockableAccelerator,
-        );
-      }
-    }
+  public render() {
+    const { acceleratorsToBlock } = this.props.appState;
 
-    public render() {
-      const { acceleratorsToBlock } = this.props.appState;
-
-      const blockAcceleratorsInstructions = `
+    const blockAcceleratorsInstructions = `
         Any keyboard shortcuts checked below will be disabled.`.trim();
 
-      return (
-        <div>
-          <h4>Block Keyboard Shortcuts</h4>
-          <Callout>
-            <FormGroup>
-              <p>{blockAcceleratorsInstructions}</p>
-              <Checkbox
-                checked={acceleratorsToBlock.includes(
-                  BlockableAccelerator.save,
-                )}
-                label="Save"
-                value={BlockableAccelerator.save}
-                onChange={this.handleBlockAcceleratorChange}
-              />
-              <Checkbox
-                checked={acceleratorsToBlock.includes(
-                  BlockableAccelerator.saveAs,
-                )}
-                label="Save as"
-                value={BlockableAccelerator.saveAs}
-                onChange={this.handleBlockAcceleratorChange}
-              />
-            </FormGroup>
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+    return (
+      <div>
+        <h4>Block Keyboard Shortcuts</h4>
+        <Callout>
+          <FormGroup>
+            <p>{blockAcceleratorsInstructions}</p>
+            <Checkbox
+              checked={acceleratorsToBlock.includes(BlockableAccelerator.save)}
+              label="Save"
+              value={BlockableAccelerator.save}
+              onChange={this.handleBlockAcceleratorChange}
+            />
+            <Checkbox
+              checked={acceleratorsToBlock.includes(
+                BlockableAccelerator.saveAs,
+              )}
+              label="Save as"
+              value={BlockableAccelerator.saveAs}
+              onChange={this.handleBlockAcceleratorChange}
+            />
+          </FormGroup>
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general-console.tsx
+++ b/src/renderer/components/settings-general-console.tsx
@@ -15,47 +15,46 @@ interface ConsoleSettingsProps {
  * @class ConsoleSettings
  * @extends {React.Component<ConsoleSettingsProps>}
  */
-export const ConsoleSettings = observer(
-  class ConsoleSettings extends React.Component<ConsoleSettingsProps> {
-    constructor(props: ConsoleSettingsProps) {
-      super(props);
+@observer
+export class ConsoleSettings extends React.Component<ConsoleSettingsProps> {
+  constructor(props: ConsoleSettingsProps) {
+    super(props);
 
-      this.handleClearOnRunChange = this.handleClearOnRunChange.bind(this);
-    }
+    this.handleClearOnRunChange = this.handleClearOnRunChange.bind(this);
+  }
 
-    /**
-     * Handles a change on whether or not the console should be cleared
-     * before fiddle is executed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handleClearOnRunChange(event: React.FormEvent<HTMLInputElement>) {
-      const { checked } = event.currentTarget;
-      this.props.appState.isClearingConsoleOnRun = checked;
-    }
+  /**
+   * Handles a change on whether or not the console should be cleared
+   * before fiddle is executed.
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handleClearOnRunChange(event: React.FormEvent<HTMLInputElement>) {
+    const { checked } = event.currentTarget;
+    this.props.appState.isClearingConsoleOnRun = checked;
+  }
 
-    public render() {
-      const { isClearingConsoleOnRun } = this.props.appState;
+  public render() {
+    const { isClearingConsoleOnRun } = this.props.appState;
 
-      const clearOnRunInstructions = `
+    const clearOnRunInstructions = `
       Enable this option to automatically clear the console whenever you run your
       fiddle.`.trim();
 
-      return (
-        <div>
-          <h1>Console</h1>
-          <Callout>
-            <FormGroup>
-              <p>{clearOnRunInstructions}</p>
-              <Checkbox
-                checked={isClearingConsoleOnRun}
-                label="Clear on run."
-                onChange={this.handleClearOnRunChange}
-              />
-            </FormGroup>
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+    return (
+      <div>
+        <h1>Console</h1>
+        <Callout>
+          <FormGroup>
+            <p>{clearOnRunInstructions}</p>
+            <Checkbox
+              checked={isClearingConsoleOnRun}
+              label="Clear on run."
+              onChange={this.handleClearOnRunChange}
+            />
+          </FormGroup>
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -15,103 +15,102 @@ interface GitHubSettingsProps {
  * @class GitHubSettings
  * @extends {React.Component<GitHubSettingsProps, {}>}
  */
-export const GitHubSettings = observer(
-  class GitHubSettings extends React.Component<GitHubSettingsProps> {
-    constructor(props: GitHubSettingsProps) {
-      super(props);
+@observer
+export class GitHubSettings extends React.Component<GitHubSettingsProps> {
+  constructor(props: GitHubSettingsProps) {
+    super(props);
 
-      this.signIn = this.signIn.bind(this);
-      this.handlePublishGistAsRevisionChange = this.handlePublishGistAsRevisionChange.bind(
-        this,
-      );
-    }
+    this.signIn = this.signIn.bind(this);
+    this.handlePublishGistAsRevisionChange = this.handlePublishGistAsRevisionChange.bind(
+      this,
+    );
+  }
 
-    private static publishGistAsRevisionInstructions = `
+  private static publishGistAsRevisionInstructions = `
     Enable this option to always publish your fiddle as a revision of the
     default fiddle gist values.`.trim();
 
-    /**
-     * Render the "logged out" settings experience.
-     *
-     * @returns {JSX.Element}
-     */
-    public renderNotSignedIn(): JSX.Element {
-      return (
+  /**
+   * Render the "logged out" settings experience.
+   *
+   * @returns {JSX.Element}
+   */
+  public renderNotSignedIn(): JSX.Element {
+    return (
+      <Callout>
+        <p>
+          Your fiddles can be published as GitHub Gists - that way you can share
+          your fiddles with the world!
+        </p>
+        <Button onClick={this.signIn} icon="log-in" text="Sign in" />
+      </Callout>
+    );
+  }
+
+  /**
+   * Render the "logged in" settings experience.
+   *
+   * @returns {JSX.Element}
+   */
+  public renderSignedIn(): JSX.Element {
+    const { gitHubLogin } = this.props.appState;
+    const signOut = this.props.appState.signOutGitHub;
+
+    return (
+      <Callout>
+        <p>
+          Your fiddles can be published as public GitHub Gists. Using the
+          personal access token you gave us, we logged you into GitHub as{' '}
+          <code>{gitHubLogin}</code>.
+        </p>
+        <Button onClick={signOut} icon="log-out" text="Sign out" />
+      </Callout>
+    );
+  }
+
+  /**
+   * Handles a change on whether or not the gist should be published
+   * as a revision on top of the default fiddle gist.
+   *
+   * @param {React.FormEvent<HTMLInputElement>} event
+   */
+  public handlePublishGistAsRevisionChange(
+    event: React.FormEvent<HTMLInputElement>,
+  ) {
+    const { checked } = event.currentTarget;
+    this.props.appState.isPublishingGistAsRevision = checked;
+  }
+
+  public render() {
+    const { gitHubToken } = this.props.appState;
+    const { isPublishingGistAsRevision } = this.props.appState;
+
+    const maybeSignedIn = !!gitHubToken
+      ? this.renderSignedIn()
+      : this.renderNotSignedIn();
+
+    return (
+      <div>
+        <h4>GitHub</h4>
+        {maybeSignedIn}
         <Callout>
-          <p>
-            Your fiddles can be published as GitHub Gists - that way you can
-            share your fiddles with the world!
-          </p>
-          <Button onClick={this.signIn} icon="log-in" text="Sign in" />
+          <FormGroup>
+            <p>{GitHubSettings.publishGistAsRevisionInstructions}</p>
+            <Checkbox
+              checked={isPublishingGistAsRevision}
+              label="Publish as revision."
+              onChange={this.handlePublishGistAsRevisionChange}
+            />
+          </FormGroup>
         </Callout>
-      );
-    }
+      </div>
+    );
+  }
 
-    /**
-     * Render the "logged in" settings experience.
-     *
-     * @returns {JSX.Element}
-     */
-    public renderSignedIn(): JSX.Element {
-      const { gitHubLogin } = this.props.appState;
-      const signOut = this.props.appState.signOutGitHub;
-
-      return (
-        <Callout>
-          <p>
-            Your fiddles can be published as public GitHub Gists. Using the
-            personal access token you gave us, we logged you into GitHub as{' '}
-            <code>{gitHubLogin}</code>.
-          </p>
-          <Button onClick={signOut} icon="log-out" text="Sign out" />
-        </Callout>
-      );
-    }
-
-    /**
-     * Handles a change on whether or not the gist should be published
-     * as a revision on top of the default fiddle gist.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
-     */
-    public handlePublishGistAsRevisionChange(
-      event: React.FormEvent<HTMLInputElement>,
-    ) {
-      const { checked } = event.currentTarget;
-      this.props.appState.isPublishingGistAsRevision = checked;
-    }
-
-    public render() {
-      const { gitHubToken } = this.props.appState;
-      const { isPublishingGistAsRevision } = this.props.appState;
-
-      const maybeSignedIn = !!gitHubToken
-        ? this.renderSignedIn()
-        : this.renderNotSignedIn();
-
-      return (
-        <div>
-          <h4>GitHub</h4>
-          {maybeSignedIn}
-          <Callout>
-            <FormGroup>
-              <p>{GitHubSettings.publishGistAsRevisionInstructions}</p>
-              <Checkbox
-                checked={isPublishingGistAsRevision}
-                label="Publish as revision."
-                onChange={this.handlePublishGistAsRevisionChange}
-              />
-            </FormGroup>
-          </Callout>
-        </div>
-      );
-    }
-
-    /**
-     * Simply shows the GitHub Token dialog.``
-     */
-    private signIn() {
-      this.props.appState.isTokenDialogShowing = true;
-    }
-  },
-);
+  /**
+   * Simply shows the GitHub Token dialog.``
+   */
+  private signIn() {
+    this.props.appState.isTokenDialogShowing = true;
+  }
+}

--- a/src/renderer/components/settings-general-mirror.tsx
+++ b/src/renderer/components/settings-general-mirror.tsx
@@ -19,67 +19,66 @@ type IMirrorSettingsState = Mirrors;
  * @class MirrorSettings
  * @extends {React.Component<MirrorSettingsProps, IMirrorSettingsState>}
  */
-export const MirrorSettings = observer(
-  class MirrorSettings extends React.Component<
-    MirrorSettingsProps,
-    IMirrorSettingsState
-  > {
-    constructor(props: MirrorSettingsProps) {
-      super(props);
+@observer
+export class MirrorSettings extends React.Component<
+  MirrorSettingsProps,
+  IMirrorSettingsState
+> {
+  constructor(props: MirrorSettingsProps) {
+    super(props);
 
-      this.changeSourceType = this.changeSourceType.bind(this);
-    }
+    this.changeSourceType = this.changeSourceType.bind(this);
+  }
 
-    private modifyMirror(isNightly: boolean, value: string) {
-      this.props.appState.electronMirror.sources.CUSTOM[
-        isNightly ? 'electronNightlyMirror' : 'electronMirror'
-      ] = value;
-    }
+  private modifyMirror(isNightly: boolean, value: string) {
+    this.props.appState.electronMirror.sources.CUSTOM[
+      isNightly ? 'electronNightlyMirror' : 'electronMirror'
+    ] = value;
+  }
 
-    private changeSourceType(e: FormEvent<HTMLInputElement>) {
-      this.props.appState.electronMirror.sourceType = (e.target as HTMLInputElement)
-        .value as Sources;
-    }
+  private changeSourceType(e: FormEvent<HTMLInputElement>) {
+    this.props.appState.electronMirror.sourceType = (e.target as HTMLInputElement)
+      .value as Sources;
+  }
 
-    private get notCustomSource() {
-      return this.props.appState.electronMirror.sourceType !== 'CUSTOM';
-    }
+  private get notCustomSource() {
+    return this.props.appState.electronMirror.sourceType !== 'CUSTOM';
+  }
 
-    public render() {
-      const { sourceType, sources } = this.props.appState.electronMirror;
-      const electronMirrorLabel = `If you don't have access to Electron's GitHub releases, you can tell Fiddle to download Electron binaries from an alternate source.`;
+  public render() {
+    const { sourceType, sources } = this.props.appState.electronMirror;
+    const electronMirrorLabel = `If you don't have access to Electron's GitHub releases, you can tell Fiddle to download Electron binaries from an alternate source.`;
 
-      return (
-        <div>
-          <h4>Electron Mirrors</h4>
-          <Callout>
-            <RadioGroup
-              label={electronMirrorLabel}
-              inline={true}
-              onChange={this.changeSourceType}
-              selectedValue={sourceType}
-            >
-              <Radio label="Default" value="DEFAULT" />
-              <Radio label="China" value="CHINA" />
-              <Radio label="Custom" value="CUSTOM" />
-            </RadioGroup>
-            <InputGroup
-              value={sources[sourceType].electronMirror}
-              disabled={this.notCustomSource}
-              onChange={(e) => {
-                this.modifyMirror(false, e.target.value);
-              }}
-            />
-            <InputGroup
-              value={sources[sourceType].electronNightlyMirror}
-              disabled={this.notCustomSource}
-              onChange={(e) => {
-                this.modifyMirror(true, e.target.value);
-              }}
-            />
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+    return (
+      <div>
+        <h4>Electron Mirrors</h4>
+        <Callout>
+          <RadioGroup
+            label={electronMirrorLabel}
+            inline={true}
+            onChange={this.changeSourceType}
+            selectedValue={sourceType}
+          >
+            <Radio label="Default" value="DEFAULT" />
+            <Radio label="China" value="CHINA" />
+            <Radio label="Custom" value="CUSTOM" />
+          </RadioGroup>
+          <InputGroup
+            value={sources[sourceType].electronMirror}
+            disabled={this.notCustomSource}
+            onChange={(e) => {
+              this.modifyMirror(false, e.target.value);
+            }}
+          />
+          <InputGroup
+            value={sources[sourceType].electronNightlyMirror}
+            disabled={this.notCustomSource}
+            onChange={(e) => {
+              this.modifyMirror(true, e.target.value);
+            }}
+          />
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general-package-author.tsx
+++ b/src/renderer/components/settings-general-package-author.tsx
@@ -19,58 +19,55 @@ interface IPackageAuthorSettingsState {
  * @class PackageAuthorSettings
  * @extends {React.Component<PackageAuthorSettingsProps, IPackageAuthorSettingsState>}
  */
-export const PackageAuthorSettings = observer(
-  class PackageAuthorSettings extends React.Component<
-    PackageAuthorSettingsProps,
-    IPackageAuthorSettingsState
-  > {
-    constructor(props: PackageAuthorSettingsProps) {
-      super(props);
+@observer
+export class PackageAuthorSettings extends React.Component<
+  PackageAuthorSettingsProps,
+  IPackageAuthorSettingsState
+> {
+  constructor(props: PackageAuthorSettingsProps) {
+    super(props);
 
-      this.state = {
-        value: this.props.appState.packageAuthor,
-      };
+    this.state = {
+      value: this.props.appState.packageAuthor,
+    };
 
-      this.handlePackageAuthorChange = this.handlePackageAuthorChange.bind(
-        this,
-      );
-    }
+    this.handlePackageAuthorChange = this.handlePackageAuthorChange.bind(this);
+  }
 
-    /**
-     * Set the author information in package.json when processing uploads to gist
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     */
-    public handlePackageAuthorChange(event: React.FormEvent<HTMLInputElement>) {
-      const { value } = event.currentTarget;
+  /**
+   * Set the author information in package.json when processing uploads to gist
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event
+   */
+  public handlePackageAuthorChange(event: React.FormEvent<HTMLInputElement>) {
+    const { value } = event.currentTarget;
 
-      this.setState({
-        value,
-      });
+    this.setState({
+      value,
+    });
 
-      this.props.appState.packageAuthor = value;
-    }
+    this.props.appState.packageAuthor = value;
+  }
 
-    public render() {
-      const packageAuthorLabel =
-        'Set the package.json author field for your exported Fiddle projects.';
+  public render() {
+    const packageAuthorLabel =
+      'Set the package.json author field for your exported Fiddle projects.';
 
-      return (
-        <div>
-          <h4>Package Author</h4>
-          <Callout>
-            <FormGroup label={packageAuthorLabel} labelFor="package-author">
-              <InputGroup
-                id="package-author"
-                value={this.state.value}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  this.handlePackageAuthorChange(e)
-                }
-              />
-            </FormGroup>
-          </Callout>
-        </div>
-      );
-    }
-  },
-);
+    return (
+      <div>
+        <h4>Package Author</h4>
+        <Callout>
+          <FormGroup label={packageAuthorLabel} labelFor="package-author">
+            <InputGroup
+              id="package-author"
+              value={this.state.value}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                this.handlePackageAuthorChange(e)
+              }
+            />
+          </FormGroup>
+        </Callout>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings-general.tsx
+++ b/src/renderer/components/settings-general.tsx
@@ -23,30 +23,29 @@ interface GeneralSettingsProps {
  * @class GitHubSettings
  * @extends {React.Component<GeneralSettingsProps>}
  */
-export const GeneralSettings = observer(
-  class GeneralSettings extends React.Component<GeneralSettingsProps> {
-    public render() {
-      return (
-        <div>
-          <h1>General Settings</h1>
-          <AppearanceSettings
-            appState={this.props.appState}
-            toggleHasPopoverOpen={() => this.props.toggleHasPopoverOpen()}
-          />
-          <Divider />
-          <FontSettings appState={this.props.appState} />
-          <Divider />
-          <ConsoleSettings appState={this.props.appState} />
-          <Divider />
-          <GitHubSettings appState={this.props.appState} />
-          <Divider />
-          <BlockAcceleratorsSettings appState={this.props.appState} />
-          <Divider />
-          <PackageAuthorSettings appState={this.props.appState} />
-          <Divider />
-          <MirrorSettings appState={this.props.appState} />
-        </div>
-      );
-    }
-  },
-);
+@observer
+export class GeneralSettings extends React.Component<GeneralSettingsProps> {
+  public render() {
+    return (
+      <div>
+        <h1>General Settings</h1>
+        <AppearanceSettings
+          appState={this.props.appState}
+          toggleHasPopoverOpen={() => this.props.toggleHasPopoverOpen()}
+        />
+        <Divider />
+        <FontSettings appState={this.props.appState} />
+        <Divider />
+        <ConsoleSettings appState={this.props.appState} />
+        <Divider />
+        <GitHubSettings appState={this.props.appState} />
+        <Divider />
+        <BlockAcceleratorsSettings appState={this.props.appState} />
+        <Divider />
+        <PackageAuthorSettings appState={this.props.appState} />
+        <Divider />
+        <MirrorSettings appState={this.props.appState} />
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -38,160 +38,156 @@ interface SettingsState {
  * @class Settings
  * @extends {React.Component<SettingsProps, SettingsState>}
  */
-export const Settings = observer(
-  class Settings extends React.Component<SettingsProps, SettingsState> {
-    constructor(props: SettingsProps) {
-      super(props);
+@observer
+export class Settings extends React.Component<SettingsProps, SettingsState> {
+  constructor(props: SettingsProps) {
+    super(props);
 
-      this.state = {
-        section: SettingsSections.General,
-        hasPopoverOpen: false,
-      };
+    this.state = {
+      section: SettingsSections.General,
+      hasPopoverOpen: false,
+    };
 
-      this.closeSettingsPanel = this.closeSettingsPanel.bind(this);
-      this.disableContextMenu = this.disableContextMenu.bind(this);
-    }
+    this.closeSettingsPanel = this.closeSettingsPanel.bind(this);
+    this.disableContextMenu = this.disableContextMenu.bind(this);
+  }
 
-    public componentDidMount() {
-      window.addEventListener('keyup', this.closeSettingsPanel, true);
-      window.addEventListener('contextmenu', this.disableContextMenu, true);
-    }
+  public componentDidMount() {
+    window.addEventListener('keyup', this.closeSettingsPanel, true);
+    window.addEventListener('contextmenu', this.disableContextMenu, true);
+  }
 
-    public componentWillUnmount() {
-      window.removeEventListener('keyup', this.closeSettingsPanel, true);
-      window.removeEventListener('contextmenu', this.disableContextMenu, true);
-    }
+  public componentWillUnmount() {
+    window.removeEventListener('keyup', this.closeSettingsPanel, true);
+    window.removeEventListener('contextmenu', this.disableContextMenu, true);
+  }
 
-    /**
-     * Renders the content of the settings, usually by simply
-     * return the appropriate component.
-     *
-     * @returns {(JSX.Element | null)}
-     */
-    public renderContent(): JSX.Element | null {
-      const { section } = this.state;
-      const { appState } = this.props;
+  /**
+   * Renders the content of the settings, usually by simply
+   * return the appropriate component.
+   *
+   * @returns {(JSX.Element | null)}
+   */
+  public renderContent(): JSX.Element | null {
+    const { section } = this.state;
+    const { appState } = this.props;
 
-      if (section === SettingsSections.General) {
-        return (
-          <GeneralSettings
-            appState={appState}
-            toggleHasPopoverOpen={() => this.toggleHasPopoverOpen()}
-          />
-        );
-      }
-
-      if (section === SettingsSections.Electron) {
-        return <ElectronSettings appState={appState} />;
-      }
-
-      if (section === SettingsSections.Execution) {
-        return <ExecutionSettings appState={appState} />;
-      }
-
-      if (section === SettingsSections.Credits) {
-        return <CreditsSettings appState={appState} />;
-      }
-
-      return null;
-    }
-
-    /**
-     * Renders the individual menu items
-     *
-     * @returns {Array<JSX.Element>}
-     */
-    public renderOptions(): Array<JSX.Element> {
-      const { section } = this.state;
-
-      return settingsSections.map((name) => {
-        const isSelected = section === name;
-        const onClick = () => this.setState({ section: name });
-
-        return (
-          <MenuItem
-            onClick={onClick}
-            active={isSelected}
-            key={name}
-            id={`settings-link-${name}`}
-            text={name}
-            icon={this.getIconForSection(name)}
-          />
-        );
-      });
-    }
-
-    public render() {
-      const { appState } = this.props;
-      const { isSettingsShowing } = appState;
-
-      if (!isSettingsShowing) return null;
-
+    if (section === SettingsSections.General) {
       return (
-        <div className="settings">
-          <div className="settings-menu">
-            <ul>{this.renderOptions()}</ul>
-          </div>
-          <div className="settings-content">
-            <button
-              className="settings-close"
-              onClick={appState.toggleSettings}
-            >
-              <Icon icon="cross" iconSize={25} />
-            </button>
-            {this.renderContent()}
-          </div>
-        </div>
+        <GeneralSettings
+          appState={appState}
+          toggleHasPopoverOpen={() => this.toggleHasPopoverOpen()}
+        />
       );
     }
 
-    /**
-     * Get the settings icons
-     *
-     * @param {SettingsSections} section
-     * @returns {IconName}
-     * @memberof Settings
-     */
-    private getIconForSection(section: SettingsSections): IconName {
-      if (section === SettingsSections.Credits) {
-        return 'heart';
-      } else if (section === SettingsSections.Electron) {
-        return 'floppy-disk';
-      } else if (section === SettingsSections.Execution) {
-        return 'play';
-      }
-
-      return 'cog';
+    if (section === SettingsSections.Electron) {
+      return <ElectronSettings appState={appState} />;
     }
 
-    /**
-     * Trigger closing of the settings panel upon Esc
-     * If hasPopoverOpen is set to true, settings will not close as only the popover should close
-     *
-     * @param {KeyboardEvent} event
-     */
-    private closeSettingsPanel(event: KeyboardEvent) {
-      const { appState } = this.props;
-      if (event.code === 'Escape' && !this.state.hasPopoverOpen) {
-        appState.isSettingsShowing = false;
-      }
+    if (section === SettingsSections.Execution) {
+      return <ExecutionSettings appState={appState} />;
     }
 
-    /**
-     * Disable the right-click contextmenu when the settings page is mounted.
-     */
-    private disableContextMenu(event: MouseEvent) {
-      event.preventDefault();
+    if (section === SettingsSections.Credits) {
+      return <CreditsSettings appState={appState} />;
     }
 
-    /**
-     * Toggles whether there is a popover open
-     */
-    public toggleHasPopoverOpen(): void {
-      this.setState({
-        ...this.state,
-        hasPopoverOpen: !this.state.hasPopoverOpen,
-      });
+    return null;
+  }
+
+  /**
+   * Renders the individual menu items
+   *
+   * @returns {Array<JSX.Element>}
+   */
+  public renderOptions(): Array<JSX.Element> {
+    const { section } = this.state;
+
+    return settingsSections.map((name) => {
+      const isSelected = section === name;
+      const onClick = () => this.setState({ section: name });
+
+      return (
+        <MenuItem
+          onClick={onClick}
+          active={isSelected}
+          key={name}
+          id={`settings-link-${name}`}
+          text={name}
+          icon={this.getIconForSection(name)}
+        />
+      );
+    });
+  }
+
+  public render() {
+    const { appState } = this.props;
+    const { isSettingsShowing } = appState;
+
+    if (!isSettingsShowing) return null;
+
+    return (
+      <div className="settings">
+        <div className="settings-menu">
+          <ul>{this.renderOptions()}</ul>
+        </div>
+        <div className="settings-content">
+          <button className="settings-close" onClick={appState.toggleSettings}>
+            <Icon icon="cross" iconSize={25} />
+          </button>
+          {this.renderContent()}
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Get the settings icons
+   *
+   * @param {SettingsSections} section
+   * @returns {IconName}
+   * @memberof Settings
+   */
+  private getIconForSection(section: SettingsSections): IconName {
+    if (section === SettingsSections.Credits) {
+      return 'heart';
+    } else if (section === SettingsSections.Electron) {
+      return 'floppy-disk';
+    } else if (section === SettingsSections.Execution) {
+      return 'play';
     }
-  },
-);
+
+    return 'cog';
+  }
+
+  /**
+   * Trigger closing of the settings panel upon Esc
+   * If hasPopoverOpen is set to true, settings will not close as only the popover should close
+   *
+   * @param {KeyboardEvent} event
+   */
+  private closeSettingsPanel(event: KeyboardEvent) {
+    const { appState } = this.props;
+    if (event.code === 'Escape' && !this.state.hasPopoverOpen) {
+      appState.isSettingsShowing = false;
+    }
+  }
+
+  /**
+   * Disable the right-click contextmenu when the settings page is mounted.
+   */
+  private disableContextMenu(event: MouseEvent) {
+    event.preventDefault();
+  }
+
+  /**
+   * Toggles whether there is a popover open
+   */
+  public toggleHasPopoverOpen(): void {
+    this.setState({
+      ...this.state,
+      hasPopoverOpen: !this.state.hasPopoverOpen,
+    });
+  }
+}

--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -30,197 +30,196 @@ interface FileTreeState {
 // crazy idea: maybe save state should be tied to the editors
 // and not to the filesystem
 
-export const SidebarFileTree = observer(
-  class SidebarFileTree extends React.Component<FileTreeProps, FileTreeState> {
-    constructor(props: FileTreeProps) {
-      super(props);
+@observer
+export class SidebarFileTree extends React.Component<
+  FileTreeProps,
+  FileTreeState
+> {
+  constructor(props: FileTreeProps) {
+    super(props);
 
-      this.state = {
-        action: 'default',
-      };
-    }
+    this.state = {
+      action: 'default',
+    };
+  }
 
-    public render() {
-      const { editorMosaic } = this.props.appState;
-      const { files, focusedFile } = editorMosaic;
+  public render() {
+    const { editorMosaic } = this.props.appState;
+    const { files, focusedFile } = editorMosaic;
 
-      const fileList: TreeNodeInfo[] = Array.from(files)
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([editorId, presence], index) => {
-          const visibilityIcon =
-            presence !== EditorPresence.Hidden ? 'eye-open' : 'eye-off';
+    const fileList: TreeNodeInfo[] = Array.from(files)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([editorId, presence], index) => {
+        const visibilityIcon =
+          presence !== EditorPresence.Hidden ? 'eye-open' : 'eye-off';
 
-          return {
-            isSelected: focusedFile === editorId,
-            id: index,
-            hasCaret: false,
-            icon: 'document',
-            label: (
-              <ContextMenu2
-                className="pointer"
-                onClick={() => this.setFocusedFile(editorId)}
-                content={
-                  <Menu>
-                    <MenuItem
-                      icon="redo"
-                      text="Rename"
-                      intent="primary"
-                      onClick={() => this.renameEditor(editorId)}
-                    />
-                    <MenuItem
-                      disabled={isRequiredFile(editorId)}
-                      icon="remove"
-                      text="Delete"
-                      intent="danger"
-                      onClick={() => this.removeEditor(editorId)}
-                    />
-                  </Menu>
-                }
-              >
-                {String(editorId)}
-              </ContextMenu2>
-            ),
-            secondaryLabel: (
-              <ButtonGroup>
-                <Tooltip2
-                  content="Toggle Visibility"
-                  minimal={true}
-                  hoverOpenDelay={1000}
-                >
-                  <Button
-                    minimal
-                    onClick={() => this.toggleVisibility(editorId)}
-                  >
-                    <Icon icon={visibilityIcon} />
-                  </Button>
-                </Tooltip2>
-              </ButtonGroup>
-            ),
-          };
-        });
-
-      if (this.state.action === 'add') {
-        fileList.push({
-          id: 'add',
-          className: 'add-file-input',
+        return {
+          isSelected: focusedFile === editorId,
+          id: index,
+          hasCaret: false,
           icon: 'document',
           label: (
-            <input
-              className={classNames(Classes.INPUT, Classes.FILL, Classes.SMALL)}
-              style={{ width: `100%`, padding: 0 }}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  e.currentTarget.blur();
-                } else if (e.key === 'Enter') {
-                  this.createEditor(e.currentTarget.value as EditorId);
-                  e.currentTarget.blur();
-                }
-              }}
-              id="new-file-input"
-              autoFocus
-              onBlur={() => {
-                this.setState({ action: 'default' });
-              }}
-            />
+            <ContextMenu2
+              className="pointer"
+              onClick={() => this.setFocusedFile(editorId)}
+              content={
+                <Menu>
+                  <MenuItem
+                    icon="redo"
+                    text="Rename"
+                    intent="primary"
+                    onClick={() => this.renameEditor(editorId)}
+                  />
+                  <MenuItem
+                    disabled={isRequiredFile(editorId)}
+                    icon="remove"
+                    text="Delete"
+                    intent="danger"
+                    onClick={() => this.removeEditor(editorId)}
+                  />
+                </Menu>
+              }
+            >
+              {String(editorId)}
+            </ContextMenu2>
           ),
-        });
-      }
-
-      const editorsTree: TreeNodeInfo[] = [
-        {
-          childNodes: fileList,
-          id: 'files',
-          hasCaret: false,
-          icon: 'folder-open',
-          isExpanded: true,
-          label: 'Editors',
           secondaryLabel: (
-            <ButtonGroup minimal>
+            <ButtonGroup>
               <Tooltip2
-                content="Add New File"
+                content="Toggle Visibility"
                 minimal={true}
                 hoverOpenDelay={1000}
               >
-                <Button
-                  small
-                  icon="add"
-                  onClick={() => this.setState({ action: 'add' })}
-                />
-              </Tooltip2>
-              <Tooltip2
-                content="Reset Layout"
-                minimal={true}
-                hoverOpenDelay={1000}
-              >
-                <Button small icon="grid-view" onClick={this.resetLayout} />
+                <Button minimal onClick={() => this.toggleVisibility(editorId)}>
+                  <Icon icon={visibilityIcon} />
+                </Button>
               </Tooltip2>
             </ButtonGroup>
           ),
-        },
-      ];
+        };
+      });
 
-      return (
-        <div className="fiddle-scrollbar">
-          <Tree contents={editorsTree} />
-        </div>
-      );
+    if (this.state.action === 'add') {
+      fileList.push({
+        id: 'add',
+        className: 'add-file-input',
+        icon: 'document',
+        label: (
+          <input
+            className={classNames(Classes.INPUT, Classes.FILL, Classes.SMALL)}
+            style={{ width: `100%`, padding: 0 }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.currentTarget.blur();
+              } else if (e.key === 'Enter') {
+                this.createEditor(e.currentTarget.value as EditorId);
+                e.currentTarget.blur();
+              }
+            }}
+            id="new-file-input"
+            autoFocus
+            onBlur={() => {
+              this.setState({ action: 'default' });
+            }}
+          />
+        ),
+      });
     }
 
-    public toggleVisibility = (editorId: EditorId) => {
-      const { editorMosaic } = this.props.appState;
-      editorMosaic.toggle(editorId);
-    };
+    const editorsTree: TreeNodeInfo[] = [
+      {
+        childNodes: fileList,
+        id: 'files',
+        hasCaret: false,
+        icon: 'folder-open',
+        isExpanded: true,
+        label: 'Editors',
+        secondaryLabel: (
+          <ButtonGroup minimal>
+            <Tooltip2
+              content="Add New File"
+              minimal={true}
+              hoverOpenDelay={1000}
+            >
+              <Button
+                small
+                icon="add"
+                onClick={() => this.setState({ action: 'add' })}
+              />
+            </Tooltip2>
+            <Tooltip2
+              content="Reset Layout"
+              minimal={true}
+              hoverOpenDelay={1000}
+            >
+              <Button small icon="grid-view" onClick={this.resetLayout} />
+            </Tooltip2>
+          </ButtonGroup>
+        ),
+      },
+    ];
 
-    public setFocusedFile = (editorId: EditorId) => {
-      const { editorMosaic } = this.props.appState;
-      editorMosaic.setFocusedFile(editorId);
-    };
+    return (
+      <div className="fiddle-scrollbar">
+        <Tree contents={editorsTree} />
+      </div>
+    );
+  }
 
-    public renameEditor = async (editorId: EditorId) => {
-      const { appState } = this.props;
+  public toggleVisibility = (editorId: EditorId) => {
+    const { editorMosaic } = this.props.appState;
+    editorMosaic.toggle(editorId);
+  };
 
-      const visible =
-        appState.editorMosaic.files.get(editorId) === EditorPresence.Visible;
-      const id = (await appState.showInputDialog({
-        label: 'Enter New Filename',
-        ok: 'Rename',
-        placeholder: 'New Name',
-      })) as EditorId;
+  public setFocusedFile = (editorId: EditorId) => {
+    const { editorMosaic } = this.props.appState;
+    editorMosaic.setFocusedFile(editorId);
+  };
 
-      if (!id) return;
+  public renameEditor = async (editorId: EditorId) => {
+    const { appState } = this.props;
 
-      if (!isSupportedFile(id)) {
-        await appState.showErrorDialog(
-          `Invalid filename "${id}": Must be a file ending in .js, .html, or .css`,
-        );
-        return;
-      }
+    const visible =
+      appState.editorMosaic.files.get(editorId) === EditorPresence.Visible;
+    const id = (await appState.showInputDialog({
+      label: 'Enter New Filename',
+      ok: 'Rename',
+      placeholder: 'New Name',
+    })) as EditorId;
 
-      const contents = appState.editorMosaic.value(editorId).trim();
-      appState.editorMosaic.remove(editorId);
-      appState.editorMosaic.addNewFile(id, contents);
+    if (!id) return;
 
-      if (visible) appState.editorMosaic.show(id);
-    };
+    if (!isSupportedFile(id)) {
+      await appState.showErrorDialog(
+        `Invalid filename "${id}": Must be a file ending in .js, .html, or .css`,
+      );
+      return;
+    }
 
-    public removeEditor = (editorId: EditorId) => {
-      const { editorMosaic } = this.props.appState;
-      editorMosaic.remove(editorId);
-    };
+    const contents = appState.editorMosaic.value(editorId).trim();
+    appState.editorMosaic.remove(editorId);
+    appState.editorMosaic.addNewFile(id, contents);
 
-    public createEditor = (editorId: EditorId) => {
-      const { appState } = this.props;
-      try {
-        appState.editorMosaic.addNewFile(editorId);
-        appState.editorMosaic.show(editorId);
-      } catch (err) {
-        appState.showErrorDialog(err.message);
-      }
-    };
+    if (visible) appState.editorMosaic.show(id);
+  };
 
-    public resetLayout = () => {
-      const { editorMosaic } = this.props.appState;
-      editorMosaic.resetLayout();
-    };
-  },
-);
+  public removeEditor = (editorId: EditorId) => {
+    const { editorMosaic } = this.props.appState;
+    editorMosaic.remove(editorId);
+  };
+
+  public createEditor = (editorId: EditorId) => {
+    const { appState } = this.props;
+    try {
+      appState.editorMosaic.addNewFile(editorId);
+      appState.editorMosaic.show(editorId);
+    } catch (err) {
+      appState.showErrorDialog(err.message);
+    }
+  };
+
+  public resetLayout = () => {
+    const { editorMosaic } = this.props.appState;
+    editorMosaic.resetLayout();
+  };
+}

--- a/src/renderer/components/sidebar-package-manager.tsx
+++ b/src/renderer/components/sidebar-package-manager.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Hit } from '@algolia/client-search';
 import { Button, MenuItem, Tree, TreeNodeInfo } from '@blueprintjs/core';
 import { Suggest } from '@blueprintjs/select';
 import { autorun } from 'mobx';
@@ -7,27 +8,16 @@ import { observer } from 'mobx-react';
 import pDebounce from 'p-debounce';
 import semver from 'semver';
 
-import { npmSearch } from '../npm-search';
+import { NPMSearchResult, npmSearch } from '../npm-search';
 import { AppState } from '../state';
+
 interface IState {
-  suggestions: Array<AlgoliaHit>;
+  suggestions: Array<Hit<NPMSearchResult>>;
   versionsCache: Map<string, string[]>;
 }
 
 interface IProps {
   appState: AppState;
-}
-
-// See full schema: https://github.com/algolia/npm-search#schema
-interface AlgoliaHit {
-  name: string;
-  version: string;
-  versions: Record<string, string>;
-  _highlightResult: {
-    name: {
-      value: string;
-    };
-  };
 }
 
 @observer
@@ -47,7 +37,7 @@ export class SidebarPackageManager extends React.Component<IProps, IState> {
     });
   }
 
-  public addModuleToFiddle = (item: AlgoliaHit) => {
+  public addModuleToFiddle = (item: Hit<NPMSearchResult>) => {
     const { appState } = this.props;
     appState.modules.set(item.name, item.version);
     // copy state so react can re-render
@@ -72,7 +62,7 @@ export class SidebarPackageManager extends React.Component<IProps, IState> {
                 <span
                   className="package-manager-result"
                   dangerouslySetInnerHTML={{
-                    __html: item._highlightResult.name.value,
+                    __html: item._highlightResult?.name?.value ?? '',
                   }}
                 />
               }

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -180,87 +180,84 @@ export function getWelcomeTour(): Set<TourScriptStep> {
  * @class WelcomeTour
  * @extends {React.Component<WelcomeTourProps, WelcomeTourState>}
  */
-export const WelcomeTour = observer(
-  class WelcomeTour extends React.Component<
-    WelcomeTourProps,
-    WelcomeTourState
-  > {
-    constructor(props: WelcomeTourProps) {
-      super(props);
+@observer
+export class WelcomeTour extends React.Component<
+  WelcomeTourProps,
+  WelcomeTourState
+> {
+  constructor(props: WelcomeTourProps) {
+    super(props);
 
-      this.stopTour = this.stopTour.bind(this);
-      this.startTour = this.startTour.bind(this);
+    this.stopTour = this.stopTour.bind(this);
+    this.startTour = this.startTour.bind(this);
 
-      this.state = {
-        isTourStarted: false,
-      };
-    }
+    this.state = {
+      isTourStarted: false,
+    };
+  }
 
-    /**
-     * Stops the tour, closing it.
-     */
-    public stopTour() {
-      this.props.appState.disableTour();
-    }
+  /**
+   * Stops the tour, closing it.
+   */
+  public stopTour() {
+    this.props.appState.disableTour();
+  }
 
-    /**
-     * Starts the tour.
-     */
-    public startTour() {
-      this.setState({ isTourStarted: true });
-    }
+  /**
+   * Starts the tour.
+   */
+  public startTour() {
+    this.setState({ isTourStarted: true });
+  }
 
-    get buttons() {
+  get buttons() {
+    return (
+      <>
+        <Button
+          key="cancel"
+          onClick={this.stopTour}
+          icon="cross"
+          text={`I'll figure it out`}
+        />
+        <Button
+          key="ok"
+          onClick={this.startTour}
+          icon="presentation"
+          text="Show me around"
+        />
+      </>
+    );
+  }
+
+  public render() {
+    const { isTourShowing } = this.props.appState;
+    const { isTourStarted } = this.state;
+
+    if (!isTourShowing) return null;
+
+    if (!isTourStarted) {
       return (
-        <>
-          <Button
-            key="cancel"
-            onClick={this.stopTour}
-            icon="cross"
-            text={`I'll figure it out`}
-          />
-          <Button
-            key="ok"
-            onClick={this.startTour}
-            icon="presentation"
-            text="Show me around"
-          />
-        </>
+        <Dialog key="welcome-tour-dialog" isOpen={true}>
+          <div className={Classes.DIALOG_HEADER}>
+            <h4 className={Classes.HEADING}>🙋‍ Hey There!</h4>
+          </div>
+          <div className={Classes.DIALOG_BODY}>
+            <p>
+              Welcome to Electron Fiddle! If you&apos;re new to the app,
+              we&apos;d like to give you a brief tour of its features.
+            </p>
+            <p>
+              We won&apos;t show this dialog again, but you can always find the
+              tour in the Help menu.
+            </p>
+          </div>
+          <div className={Classes.DIALOG_FOOTER}>
+            <div className={Classes.DIALOG_FOOTER_ACTIONS}>{this.buttons}</div>
+          </div>
+        </Dialog>
       );
+    } else {
+      return <Tour tour={getWelcomeTour()} onStop={this.stopTour} />;
     }
-
-    public render() {
-      const { isTourShowing } = this.props.appState;
-      const { isTourStarted } = this.state;
-
-      if (!isTourShowing) return null;
-
-      if (!isTourStarted) {
-        return (
-          <Dialog key="welcome-tour-dialog" isOpen={true}>
-            <div className={Classes.DIALOG_HEADER}>
-              <h4 className={Classes.HEADING}>🙋‍ Hey There!</h4>
-            </div>
-            <div className={Classes.DIALOG_BODY}>
-              <p>
-                Welcome to Electron Fiddle! If you&apos;re new to the app,
-                we&apos;d like to give you a brief tour of its features.
-              </p>
-              <p>
-                We won&apos;t show this dialog again, but you can always find
-                the tour in the Help menu.
-              </p>
-            </div>
-            <div className={Classes.DIALOG_FOOTER}>
-              <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                {this.buttons}
-              </div>
-            </div>
-          </Dialog>
-        );
-      } else {
-        return <Tour tour={getWelcomeTour()} onStop={this.stopTour} />;
-      }
-    }
-  },
-);
+  }
+}

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -244,38 +244,37 @@ interface VersionSelectProps {
  * @class VersionSelect
  * @extends {React.Component<VersionSelectProps, VersionSelectState>}
  */
-export const VersionSelect = observer(
-  class VersionSelect extends React.Component<
-    VersionSelectProps,
-    VersionSelectState
-  > {
-    public render() {
-      const { currentVersion, itemDisabled } = this.props;
-      const { version } = currentVersion;
+@observer
+export class VersionSelect extends React.Component<
+  VersionSelectProps,
+  VersionSelectState
+> {
+  public render() {
+    const { currentVersion, itemDisabled } = this.props;
+    const { version } = currentVersion;
 
-      return (
-        <ElectronVersionSelect
-          filterable={true}
-          items={this.props.appState.versionsToShow}
-          itemRenderer={renderItem}
-          itemListPredicate={filterItems}
-          itemListRenderer={itemListRenderer}
-          itemDisabled={itemDisabled}
-          onItemSelect={this.props.onVersionSelect}
-          noResults={<MenuItem disabled={true} text="No results." />}
+    return (
+      <ElectronVersionSelect
+        filterable={true}
+        items={this.props.appState.versionsToShow}
+        itemRenderer={renderItem}
+        itemListPredicate={filterItems}
+        itemListRenderer={itemListRenderer}
+        itemDisabled={itemDisabled}
+        onItemSelect={this.props.onVersionSelect}
+        noResults={<MenuItem disabled={true} text="No results." />}
+        disabled={!!this.props.disabled}
+      >
+        <Button
+          className="version-chooser"
+          text={`Electron v${version}`}
+          icon={getItemIcon(currentVersion)}
+          onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) => {
+            renderVersionContextMenu(e, version);
+          }}
           disabled={!!this.props.disabled}
-        >
-          <Button
-            className="version-chooser"
-            text={`Electron v${version}`}
-            icon={getItemIcon(currentVersion)}
-            onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) => {
-              renderVersionContextMenu(e, version);
-            }}
-            disabled={!!this.props.disabled}
-          />
-        </ElectronVersionSelect>
-      );
-    }
-  },
-);
+        />
+      </ElectronVersionSelect>
+    );
+  }
+}

--- a/src/renderer/npm-search.tsx
+++ b/src/renderer/npm-search.tsx
@@ -2,20 +2,15 @@ import { SearchResponse } from '@algolia/client-search';
 import algoliasearch, { SearchIndex } from 'algoliasearch/lite';
 
 // See full schema: https://github.com/algolia/npm-search#schema
-interface AlgoliaHit {
+export interface NPMSearchResult {
   name: string;
   version: string;
   versions: Record<string, string>;
-  _highlightResult: {
-    name: {
-      value: string;
-    };
-  };
 }
 
 class NPMSearch {
   private index: SearchIndex;
-  private searchCache: Map<string, SearchResponse<AlgoliaHit>>;
+  private searchCache: Map<string, SearchResponse<NPMSearchResult>>;
   constructor() {
     const client = algoliasearch(
       'OFCNCOG2CU',
@@ -34,7 +29,7 @@ class NPMSearch {
     if (this.searchCache.has(query)) {
       return this.searchCache.get(query)!;
     } else {
-      const result = await this.index.search<AlgoliaHit>(query, {
+      const result = await this.index.search<NPMSearchResult>(query, {
         hitsPerPage: 5,
         optionalFilters: [`objectID:${query}`],
       });

--- a/tests/main/dialogs-spec.ts
+++ b/tests/main/dialogs-spec.ts
@@ -31,7 +31,7 @@ describe('dialogs', () => {
   describe('warning dialog', () => {
     it('shows dialog when triggering IPC event', () => {
       ipcMainManager.emit(IpcEvents.SHOW_WARNING_DIALOG, {}, { hi: 'hello' });
-      expect(dialog.showMessageBox).toHaveBeenCalledWith<any>(undefined, {
+      expect(dialog.showMessageBox).toHaveBeenCalledWith(undefined, {
         type: 'warning',
         hi: 'hello',
       });
@@ -55,7 +55,7 @@ describe('dialogs', () => {
       });
 
       await ipcHandler();
-      expect(dialog.showOpenDialog).toHaveBeenCalledWith<any>(
+      expect(dialog.showOpenDialog).toHaveBeenCalledWith(
         expect.objectContaining({
           properties: ['openDirectory'],
         }),

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -22,10 +22,10 @@ jest.mock('fs-extra', () => ({
 }));
 
 const mockTarget = {
-  webContents: {
+  webContents: ({
     send: jest.fn(),
     isDestroyed: () => false,
-  },
+  } as unknown) as Electron.WebContents,
 };
 
 describe('files', () => {
@@ -35,7 +35,7 @@ describe('files', () => {
     });
     (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
 
-    ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
+    ipcMainManager.readyWebContents.add(mockTarget.webContents);
   });
 
   describe('setupFileListeners()', () => {
@@ -108,7 +108,7 @@ describe('files', () => {
       (dialog.showMessageBox as jest.Mock).mockResolvedValue(consent);
       (fs.pathExists as jest.Mock).mockReturnValue(true);
       (fs.readdir as jest.Mock).mockReturnValue([MAIN_JS]);
-      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents);
 
       await showSaveDialog();
 

--- a/tests/main/first-run-spec.ts
+++ b/tests/main/first-run-spec.ts
@@ -22,9 +22,7 @@ describe('first-run', () => {
   beforeEach(() => {
     overridePlatform('darwin');
 
-    (dialog.showMessageBox as jest.Mock<any>).mockResolvedValue(
-      mockDialogResponse,
-    );
+    (dialog.showMessageBox as jest.Mock).mockResolvedValue(mockDialogResponse);
   });
 
   afterEach(() => {

--- a/tests/main/ipc-spec.ts
+++ b/tests/main/ipc-spec.ts
@@ -28,44 +28,44 @@ describe('IpcMainManager', () => {
   describe('send()', () => {
     it('sends an event and finds the main window', () => {
       const mockTarget = {
-        webContents: {
+        webContents: ({
           send: jest.fn(),
           isDestroyed: () => false,
-        },
+        } as unknown) as Electron.WebContents,
       };
 
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(mockTarget);
-      ipcMainManager.readyWebContents.add(mockTarget.webContents as any);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+      ipcMainManager.readyWebContents.add(mockTarget.webContents);
 
       ipcMainManager.send(IpcEvents.FIDDLE_RUN);
 
-      expect(mockTarget.webContents.send).toHaveBeenCalledWith<any>(
+      expect(mockTarget.webContents.send).toHaveBeenCalledWith(
         IpcEvents.FIDDLE_RUN,
       );
     });
 
     it('sends an event to a target window', () => {
-      const mockTarget = {
+      const mockTarget = ({
         send: jest.fn(),
         isDestroyed: () => false,
-      };
+      } as unknown) as Electron.WebContents;
 
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(null);
-      ipcMainManager.readyWebContents.add(mockTarget as any);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(null);
+      ipcMainManager.readyWebContents.add(mockTarget);
 
-      ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget as any);
+      ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget);
 
-      expect(mockTarget.send).toHaveBeenCalledWith<any>(IpcEvents.FIDDLE_RUN);
+      expect(mockTarget.send).toHaveBeenCalledWith(IpcEvents.FIDDLE_RUN);
     });
 
     it('does not send an event to a target window if it is not ready', () => {
-      const mockTarget = {
+      const mockTarget = ({
         send: jest.fn(),
-      };
+      } as unknown) as Electron.WebContents;
 
-      (getOrCreateMainWindow as jest.Mock<any>).mockReturnValue(null);
+      (getOrCreateMainWindow as jest.Mock).mockReturnValue(null);
 
-      ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget as any);
+      ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget);
 
       expect(mockTarget.send).toHaveBeenCalledTimes(0);
     });

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -76,10 +76,8 @@ describe('main', () => {
   describe('onBeforeQuit()', () => {
     it('sets up IPC so app can quit if dialog confirmed', () => {
       onBeforeQuit();
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.BEFORE_QUIT,
-      );
-      expect(ipcMainManager.on).toHaveBeenCalledWith<any>(
+      expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.BEFORE_QUIT);
+      expect(ipcMainManager.on).toHaveBeenCalledWith(
         IpcEvents.CONFIRM_QUIT,
         app.quit,
       );
@@ -115,7 +113,7 @@ describe('main', () => {
     it('check if listening on BLOCK_ACCELERATORS', () => {
       setupMenuHandler();
 
-      expect(ipcMainManager.on).toHaveBeenCalledWith<any>(
+      expect(ipcMainManager.on).toHaveBeenCalledWith(
         IpcEvents.BLOCK_ACCELERATORS,
         expect.anything(),
       );

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -113,7 +113,7 @@ describe('menu', () => {
         ({ label }) => label === 'Toggle Bisect Helper',
       );
       (toggleSoftWrap as any).click();
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+      expect(ipcMainManager.send).toHaveBeenCalledWith(
         IpcEvents.BISECT_COMMANDS_TOGGLE,
       );
     });
@@ -129,7 +129,7 @@ describe('menu', () => {
 
       const selectAll = submenu.find(({ label }) => label === 'Select All');
       (selectAll as any).click();
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+      expect(ipcMainManager.send).toHaveBeenCalledWith(
         IpcEvents.SELECT_ALL_IN_EDITOR,
       );
     });
@@ -181,7 +181,7 @@ describe('menu', () => {
 
       it('shows the welcome tour', () => {
         help.submenu[1].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.SHOW_WELCOME_TOUR,
         );
       });
@@ -202,21 +202,21 @@ describe('menu', () => {
 
       it('opens the Fiddle repo', () => {
         help.submenu[5].click();
-        expect(electron.shell.openExternal).toHaveBeenCalledWith<any>(
+        expect(electron.shell.openExternal).toHaveBeenCalledWith(
           'https://github.com/electron/fiddle',
         );
       });
 
       it('opens the Electron repo', () => {
         help.submenu[6].click();
-        expect(electron.shell.openExternal).toHaveBeenCalledWith<any>(
+        expect(electron.shell.openExternal).toHaveBeenCalledWith(
           'https://github.com/electron/electron',
         );
       });
 
       it('opens the Electron issues', () => {
         help.submenu[7].click();
-        expect(electron.shell.openExternal).toHaveBeenCalledWith<any>(
+        expect(electron.shell.openExternal).toHaveBeenCalledWith(
           'https://github.com/electron/electron/issues',
         );
       });
@@ -233,7 +233,7 @@ describe('menu', () => {
 
       it('shows the preferences', () => {
         preferences.submenu[3].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.OPEN_SETTINGS,
         );
       });
@@ -265,10 +265,9 @@ describe('menu', () => {
 
       it('attempts to open a template on click', () => {
         showMe.submenu[0].submenu[0].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-          IpcEvents.FS_OPEN_TEMPLATE,
-          ['App'],
-        );
+        expect(
+          ipcMainManager.send,
+        ).toHaveBeenCalledWith(IpcEvents.FS_OPEN_TEMPLATE, ['App']);
       });
     });
 
@@ -283,23 +282,19 @@ describe('menu', () => {
 
       it('runs the fiddle', () => {
         tasks.submenu[0].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-          IpcEvents.FIDDLE_RUN,
-        );
+        expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.FIDDLE_RUN);
       });
 
       it('packages the fiddle', () => {
         tasks.submenu[1].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.FIDDLE_PACKAGE,
         );
       });
 
       it('makes the fiddle', () => {
         tasks.submenu[2].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-          IpcEvents.FIDDLE_MAKE,
-        );
+        expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.FIDDLE_MAKE);
       });
     });
 
@@ -325,16 +320,14 @@ describe('menu', () => {
 
       it('creates a new fiddle', () => {
         file.submenu[Idx.NEW_FIDDLE].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.FS_NEW_FIDDLE,
         );
       });
 
       it('creates a new test fiddle', () => {
         file.submenu[Idx.NEW_TEST].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-          IpcEvents.FS_NEW_TEST,
-        );
+        expect(ipcMainManager.send).toHaveBeenCalledWith(IpcEvents.FS_NEW_TEST);
       });
 
       it('creates a new window', () => {
@@ -350,7 +343,7 @@ describe('menu', () => {
 
       it('saves a Fiddle', () => {
         file.submenu[Idx.SAVE].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.FS_SAVE_FIDDLE,
         );
       });
@@ -362,7 +355,7 @@ describe('menu', () => {
 
       it('saves a Fiddle as a gist', () => {
         file.submenu[Idx.PUBLISH].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.FS_SAVE_FIDDLE_GIST,
         );
       });
@@ -375,7 +368,7 @@ describe('menu', () => {
       it('saves a Fiddle with blocked accelerator', () => {
         setupMenu({ acceleratorsToBlock: [BlockableAccelerator.save] });
         file.submenu[Idx.SAVE].click();
-        expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+        expect(ipcMainManager.send).toHaveBeenCalledWith(
           IpcEvents.FS_SAVE_FIDDLE,
         );
       });

--- a/tests/main/npm-spec.ts
+++ b/tests/main/npm-spec.ts
@@ -125,7 +125,7 @@ describe('npm', () => {
           'thing',
         );
 
-        expect(exec).toHaveBeenCalledWith<any>(
+        expect(exec).toHaveBeenCalledWith(
           '/my/directory',
           'npm install -S say thing',
         );
@@ -134,7 +134,7 @@ describe('npm', () => {
       it('attempts to installs all modules', async () => {
         addModules({ dir: '/my/directory', packageManager: 'npm' });
 
-        expect(exec).toHaveBeenCalledWith<any>(
+        expect(exec).toHaveBeenCalledWith(
           '/my/directory',
           'npm install --also=dev --prod',
         );
@@ -149,7 +149,7 @@ describe('npm', () => {
           'thing',
         );
 
-        expect(exec).toHaveBeenCalledWith<any>(
+        expect(exec).toHaveBeenCalledWith(
           '/my/directory',
           'yarn add say thing',
         );
@@ -158,7 +158,7 @@ describe('npm', () => {
       it('attempts to installs all modules', async () => {
         addModules({ dir: '/my/directory', packageManager: 'yarn' });
 
-        expect(exec).toHaveBeenCalledWith<any>('/my/directory', 'yarn install');
+        expect(exec).toHaveBeenCalledWith('/my/directory', 'yarn install');
       });
     });
   });
@@ -167,19 +167,13 @@ describe('npm', () => {
     it('attempts to run a command via npm', async () => {
       packageRun({ dir: '/my/directory', packageManager: 'npm' }, 'package');
 
-      expect(exec).toHaveBeenCalledWith<any>(
-        '/my/directory',
-        'npm run package',
-      );
+      expect(exec).toHaveBeenCalledWith('/my/directory', 'npm run package');
     });
 
     it('attempts to run a command via yarn', async () => {
       packageRun({ dir: '/my/directory', packageManager: 'yarn' }, 'package');
 
-      expect(exec).toHaveBeenCalledWith<any>(
-        '/my/directory',
-        'yarn run package',
-      );
+      expect(exec).toHaveBeenCalledWith('/my/directory', 'yarn run package');
     });
   });
 });

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -51,10 +51,9 @@ describe('protocol', () => {
       const handler = (app.on as jest.Mock).mock.calls[1][1];
 
       handler({}, ['electron-fiddle://gist/hi']);
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.LOAD_GIST_REQUEST,
-        [{ id: 'hi' }],
-      );
+      expect(
+        ipcMainManager.send,
+      ).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi' }]);
     });
 
     it('handles a Fiddle url (open-url)', () => {
@@ -65,10 +64,9 @@ describe('protocol', () => {
       const handler = (app.on as jest.Mock).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/hi');
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.LOAD_GIST_REQUEST,
-        [{ id: 'hi' }],
-      );
+      expect(
+        ipcMainManager.send,
+      ).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi' }]);
     });
 
     it('handles a Fiddle url with a username (open-url)', () => {
@@ -79,10 +77,9 @@ describe('protocol', () => {
       const handler = (app.on as jest.Mock).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/username/gistID');
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.LOAD_GIST_REQUEST,
-        [{ id: 'gistID' }],
-      );
+      expect(
+        ipcMainManager.send,
+      ).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'gistID' }]);
     });
 
     it('handles a non-fiddle url (open-url)', () => {
@@ -104,10 +101,9 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.LOAD_GIST_REQUEST,
-        [{ id: 'hi-arg' }],
-      );
+      expect(
+        ipcMainManager.send,
+      ).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi-arg' }]);
     });
 
     it('waits for the app to be ready', () => {
@@ -127,10 +123,9 @@ describe('protocol', () => {
 
       cb();
 
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
-        IpcEvents.LOAD_GIST_REQUEST,
-        [{ id: 'hi-ready' }],
-      );
+      expect(
+        ipcMainManager.send,
+      ).toHaveBeenCalledWith(IpcEvents.LOAD_GIST_REQUEST, [{ id: 'hi-ready' }]);
     });
 
     it('handles an electron path url', () => {
@@ -141,7 +136,7 @@ describe('protocol', () => {
 
       handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 
-      expect(ipcMainManager.send).toHaveBeenCalledWith<any>(
+      expect(ipcMainManager.send).toHaveBeenCalledWith(
         IpcEvents.LOAD_ELECTRON_EXAMPLE_REQUEST,
         [
           {

--- a/tests/main/utils/exec-spec.ts
+++ b/tests/main/utils/exec-spec.ts
@@ -58,8 +58,8 @@ describe('exec', () => {
     it('handles errors', async () => {
       let errored = false;
       const cpExec = require('node:child_process').exec;
-      (cpExec as jest.Mock<any>).mockImplementation(
-        (_a: any, _b: any, c: any) => c(new Error('Poop!')),
+      (cpExec as jest.Mock).mockImplementation((_a: any, _b: any, c: any) =>
+        c(new Error('Poop!')),
       );
 
       try {

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -89,14 +89,14 @@ describe('windows', () => {
     it('updates "browserWindows" on "close"', () => {
       getOrCreateMainWindow();
       expect(browserWindows[0]).toBeTruthy();
-      (getOrCreateMainWindow() as any).emit('closed');
+      getOrCreateMainWindow().emit('closed');
       expect(browserWindows.length).toBe(0);
     });
 
     it('creates the context menu on "dom-ready"', () => {
       getOrCreateMainWindow();
       expect(browserWindows[0]).toBeTruthy();
-      (getOrCreateMainWindow().webContents as any).emit('dom-ready');
+      getOrCreateMainWindow().webContents.emit('dom-ready');
       expect(createContextMenu).toHaveBeenCalled();
     });
 
@@ -108,7 +108,7 @@ describe('windows', () => {
 
       getOrCreateMainWindow();
       expect(browserWindows[0]).toBeTruthy();
-      (getOrCreateMainWindow().webContents as any).emit('new-window', e);
+      getOrCreateMainWindow().webContents.emit('new-window', e);
       expect(e.preventDefault).toHaveBeenCalled();
     });
 
@@ -119,7 +119,7 @@ describe('windows', () => {
 
       getOrCreateMainWindow();
       expect(browserWindows[0]).toBeTruthy();
-      (getOrCreateMainWindow().webContents as any).emit('will-navigate', e);
+      getOrCreateMainWindow().webContents.emit('will-navigate', e);
       expect(e.preventDefault).toHaveBeenCalled();
     });
 

--- a/tests/mocks/monaco.ts
+++ b/tests/mocks/monaco.ts
@@ -69,7 +69,6 @@ export class MonacoEditorMock {
   public restoreViewState = jest.fn();
   public revealLine = jest.fn();
   public saveViewState = jest.fn();
-  public setContent = jest.fn();
   public setModel = jest.fn((model) => (this.model = model));
   public setMonarchTokensProvider = jest.fn();
   public setSelection = jest.fn();

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -23,7 +23,7 @@ export class StateMock {
   public executionFlags: string[] = [];
   public genericDialogLastInput: string | null = null;
   public genericDialogLastResult: boolean | null = null;
-  public genericDialogOptions: GenericDialogOptions = {} as any;
+  public genericDialogOptions = {} as GenericDialogOptions;
   public gistId = '';
   public gitHubAvatarUrl: string | null = null;
   public gitHubLogin: string | null = null;

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -382,7 +382,7 @@ describe('App component', () => {
     let editorMosaic: EditorMosaic;
 
     beforeEach(() => {
-      ({ editorMosaic } = app.state as any);
+      ({ editorMosaic } = app.state);
     });
 
     async function testDialog(confirm: boolean) {

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { shallow } from 'enzyme';
+import { ShallowWrapper, shallow } from 'enzyme';
 
 import {
   EditorValues,
@@ -76,8 +76,10 @@ describe('Action button component', () => {
   });
 
   function createActionButton() {
-    const wrapper = shallow(<GistActionButton appState={state} />);
-    const instance = wrapper.instance() as any;
+    const wrapper = shallow<GistActionButton>(
+      <GistActionButton appState={state} />,
+    );
+    const instance = wrapper.instance();
     return { wrapper, instance };
   }
 
@@ -143,7 +145,7 @@ describe('Action button component', () => {
   });
 
   describe('publish mode', () => {
-    let instance: any;
+    let instance: GistActionButton;
 
     beforeEach(() => {
       // create a button that's primed to publish a new gist
@@ -265,8 +267,8 @@ describe('Action button component', () => {
 
   describe('update mode', () => {
     const gistId = '123';
-    let wrapper: any;
-    let instance: any;
+    let wrapper: ShallowWrapper;
+    let instance: GistActionButton;
 
     beforeEach(() => {
       // create a button that's primed to update gistId
@@ -311,8 +313,8 @@ describe('Action button component', () => {
 
   describe('delete mode', () => {
     const gistId = '123';
-    let wrapper: any;
-    let instance: any;
+    let wrapper: ShallowWrapper;
+    let instance: GistActionButton;
 
     beforeEach(() => {
       state.gistId = gistId;

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -56,11 +56,11 @@ describe('Commands component', () => {
   });
 
   it('handleDoubleClick()', () => {
-    const wrapper = shallow(<Commands appState={store} />);
-    const instance = wrapper.instance() as any;
+    const wrapper = shallow<Commands>(<Commands appState={store} />);
+    const instance = wrapper.instance();
 
     const tag = { tagName: 'DIV' };
-    instance.handleDoubleClick({ target: tag, currentTarget: tag });
+    (instance as any).handleDoubleClick({ target: tag, currentTarget: tag });
 
     expect(
       window.ElectronFiddle.macTitlebarClicked as jest.Mock,
@@ -68,10 +68,10 @@ describe('Commands component', () => {
   });
 
   it('handleDoubleClick() should not handle input tag', () => {
-    const wrapper = shallow(<Commands appState={store} />);
-    const instance = wrapper.instance() as any;
+    const wrapper = shallow<Commands>(<Commands appState={store} />);
+    const instance = wrapper.instance();
 
-    instance.handleDoubleClick({
+    (instance as any).handleDoubleClick({
       target: { tagName: 'INPUT' },
       currentTarget: { tagName: 'DIV' },
     });

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -66,13 +66,15 @@ describe('AddVersionDialog component', () => {
 
   describe('selectLocalVersion()', () => {
     it('updates state', async () => {
-      const wrapper = shallow(<AddVersionDialog appState={store} />);
+      const wrapper = shallow<AddVersionDialog>(
+        <AddVersionDialog appState={store} />,
+      );
       (window.ElectronFiddle.selectLocalVersion as jest.Mock).mockReturnValue({
         folderPath: '/test/',
         isValidElectron: true,
         localName: 'Test',
       });
-      await (wrapper.instance() as any).selectLocalVersion();
+      await wrapper.instance().selectLocalVersion();
 
       expect(wrapper.state('isValidElectron')).toBe(true);
       expect(wrapper.state('folderPath')).toBe('/test/');
@@ -82,23 +84,31 @@ describe('AddVersionDialog component', () => {
 
   describe('onChangeVersion()', () => {
     it('handles valid input', () => {
-      const wrapper = shallow(<AddVersionDialog appState={store} />);
+      const wrapper = shallow<AddVersionDialog>(
+        <AddVersionDialog appState={store} />,
+      );
 
-      (wrapper.instance() as any).onChangeVersion({
+      wrapper.instance().onChangeVersion({
         target: { value: '3.3.3' },
-      });
+      } as React.ChangeEvent<HTMLInputElement>);
       expect(wrapper.state('isValidVersion')).toBe(true);
       expect(wrapper.state('version')).toBe('3.3.3');
     });
 
     it('handles invalid input', () => {
-      const wrapper = shallow(<AddVersionDialog appState={store} />);
+      const wrapper = shallow<AddVersionDialog>(
+        <AddVersionDialog appState={store} />,
+      );
 
-      (wrapper.instance() as any).onChangeVersion({ target: { value: 'foo' } });
+      wrapper.instance().onChangeVersion({
+        target: { value: 'foo' },
+      } as React.ChangeEvent<HTMLInputElement>);
       expect(wrapper.state('isValidVersion')).toBe(false);
       expect(wrapper.state('version')).toBe('foo');
 
-      (wrapper.instance() as any).onChangeVersion({ target: {} });
+      wrapper
+        .instance()
+        .onChangeVersion({ target: {} } as React.ChangeEvent<HTMLInputElement>);
       expect(wrapper.state('isValidVersion')).toBe(false);
       expect(wrapper.state('version')).toBe('');
     });
@@ -106,22 +116,26 @@ describe('AddVersionDialog component', () => {
 
   describe('onSubmit', () => {
     it('does not do anything without a file', async () => {
-      const wrapper = shallow(<AddVersionDialog appState={store} />);
+      const wrapper = shallow<AddVersionDialog>(
+        <AddVersionDialog appState={store} />,
+      );
 
-      await (wrapper.instance() as any).onSubmit();
+      await wrapper.instance().onSubmit();
 
       expect(store.addLocalVersion).toHaveBeenCalledTimes(0);
     });
 
     it('adds a local version using the given data', async () => {
-      const wrapper = shallow(<AddVersionDialog appState={store} />);
+      const wrapper = shallow<AddVersionDialog>(
+        <AddVersionDialog appState={store} />,
+      );
 
       wrapper.setState({
         version: '3.3.3',
         folderPath: '/test/path',
       });
 
-      await (wrapper.instance() as any).onSubmit();
+      await wrapper.instance().onSubmit();
 
       expect(store.addLocalVersion).toHaveBeenCalledTimes(1);
       expect(store.addLocalVersion).toHaveBeenCalledWith(

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -42,7 +42,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<BisectDialog appState={store} />);
+    const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
     // start and end selected
     wrapper.setState({
       startIndex: 3,
@@ -53,8 +53,8 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
 
     // no selection
     wrapper.setState({
-      startIndex: undefined,
-      endIndex: undefined,
+      startIndex: (undefined as unknown) as number,
+      endIndex: (undefined as unknown) as number,
       allVersions: generateVersionRange(numVersions),
     });
     expect(wrapper).toMatchSnapshot();
@@ -62,7 +62,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
     // only start selected
     wrapper.setState({
       startIndex: 3,
-      endIndex: undefined,
+      endIndex: (undefined as unknown) as number,
       allVersions: generateVersionRange(numVersions),
     });
     expect(wrapper).toMatchSnapshot();
@@ -76,14 +76,14 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
     expect(wrapper).toMatchSnapshot();
 
     // Help displayed
-    (wrapper.instance() as any).showHelp();
+    wrapper.instance().showHelp();
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('onBeginSelect()', () => {
     it('sets the begin version', () => {
-      const wrapper = shallow(<BisectDialog appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
+      const instance = wrapper.instance();
 
       expect(instance.state.startIndex).toBe(
         numVersions > 10 ? 10 : numVersions - 1,
@@ -95,8 +95,8 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
 
   describe('onEndSelect()', () => {
     it('sets the end version', () => {
-      const wrapper = shallow(<BisectDialog appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
+      const instance = wrapper.instance();
 
       expect(instance.state.endIndex).toBe(0);
       instance.onEndSelect(store.versionsToShow[2]);
@@ -113,14 +113,14 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
 
       const versions = generateVersionRange(numVersions);
 
-      const wrapper = shallow(<BisectDialog appState={store} />);
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
       wrapper.setState({
         allVersions: versions,
         endIndex: 0,
         startIndex: versions.length - 1,
       });
 
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       await instance.onSubmit();
       expect(Bisector).toHaveBeenCalledWith(versions.reverse());
       expect(store.Bisector).toBeDefined();
@@ -128,22 +128,22 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
     });
 
     it('does nothing if endIndex or startIndex are falsy', async () => {
-      const wrapper = shallow(<BisectDialog appState={store} />);
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
 
       wrapper.setState({
-        startIndex: undefined,
+        startIndex: (undefined as unknown) as number,
         endIndex: 0,
       });
-      const instance1: any = wrapper.instance() as any;
+      const instance1 = wrapper.instance();
       await instance1.onSubmit();
       expect(Bisector).not.toHaveBeenCalled();
 
       wrapper.setState({
         startIndex: 4,
-        endIndex: undefined,
+        endIndex: (undefined as unknown) as number,
       });
 
-      const instance2: any = wrapper.instance() as any;
+      const instance2 = wrapper.instance();
       await instance2.onSubmit();
       expect(Bisector).not.toHaveBeenCalled();
     });
@@ -152,7 +152,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
   describe('onAuto()', () => {
     it('initiates autobisect', async () => {
       // setup: dialog state
-      const wrapper = shallow(<BisectDialog appState={store} />);
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
       wrapper.setState({
         allVersions: generateVersionRange(numVersions),
         endIndex: 0,
@@ -162,7 +162,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
       (runner.autobisect as jest.Mock).mockResolvedValue(RunResult.SUCCESS);
 
       // click the 'auto' button
-      const instance1: any = wrapper.instance() as any;
+      const instance1 = wrapper.instance();
       await instance1.onAuto();
 
       // check the results
@@ -170,33 +170,33 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
     });
 
     it('does nothing if endIndex or startIndex are falsy', async () => {
-      const wrapper = shallow(<BisectDialog appState={store} />);
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
 
       wrapper.setState({
-        startIndex: undefined,
+        startIndex: (undefined as unknown) as number,
         endIndex: 0,
       });
-      const instance1: any = wrapper.instance() as any;
+      const instance1 = wrapper.instance();
       await instance1.onAuto();
       expect(Bisector).not.toHaveBeenCalled();
 
       wrapper.setState({
         startIndex: 4,
-        endIndex: undefined,
+        endIndex: (undefined as unknown) as number,
       });
 
-      const instance2: any = wrapper.instance() as any;
+      const instance2 = wrapper.instance();
       await instance2.onAuto();
       expect(Bisector).not.toHaveBeenCalled();
     });
   });
 
   describe('items disabled', () => {
-    let instance: any;
+    let instance: BisectDialog;
 
     beforeEach(() => {
-      const wrapper = shallow(<BisectDialog appState={store} />);
-      instance = wrapper.instance() as any;
+      const wrapper = shallow<BisectDialog>(<BisectDialog appState={store} />);
+      instance = wrapper.instance();
     });
 
     describe('isEarliestItemDisabled', () => {

--- a/tests/renderer/components/dialog-generic-spec.tsx
+++ b/tests/renderer/components/dialog-generic-spec.tsx
@@ -52,21 +52,21 @@ describe('GenericDialog component', () => {
 
   it('onClose() closes itself', () => {
     store.isGenericDialogShowing = true;
-    const wrapper = shallow(<GenericDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<GenericDialog>(<GenericDialog appState={store} />);
+    const instance = wrapper.instance();
 
     instance.onClose(true);
     expect(store.isGenericDialogShowing).toBe(false);
   });
 
   it('enter submit', () => {
-    const wrapper = shallow(<GenericDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
-    const event = { key: 'Enter' };
+    const wrapper = shallow<GenericDialog>(<GenericDialog appState={store} />);
+    const instance = wrapper.instance();
+    const event = { key: 'Enter' } as React.KeyboardEvent<HTMLInputElement>;
 
     store.isGenericDialogShowing = true;
 
-    instance.enterSubmit(event as any);
+    instance.enterSubmit(event);
 
     expect(store.isGenericDialogShowing).toBe(false);
   });

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -34,8 +34,8 @@ describe('TokenDialog component', () => {
   });
 
   it('tries to read the clipboard on focus and enters it if valid', async () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
+    const instance = wrapper.instance();
 
     (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
       mockValidToken,
@@ -47,8 +47,8 @@ describe('TokenDialog component', () => {
   });
 
   it('tries to read the clipboard on focus and does not enter it if invalid', async () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
+    const instance = wrapper.instance();
 
     (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
       mockInvalidToken,
@@ -60,8 +60,8 @@ describe('TokenDialog component', () => {
   });
 
   it('reset() resets the component', () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
+    const instance = wrapper.instance();
 
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
     instance.reset();
@@ -74,8 +74,8 @@ describe('TokenDialog component', () => {
   });
 
   it('onClose() resets the component', () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
+    const instance = wrapper.instance();
 
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
     instance.onClose();
@@ -88,18 +88,20 @@ describe('TokenDialog component', () => {
   });
 
   it('handleChange() handles the change event', () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
 
-    const instance: any = wrapper.instance() as any;
-    instance.handleChange({ target: { value: 'hi' } } as any);
+    const instance = wrapper.instance();
+    instance.handleChange({
+      target: { value: 'hi' },
+    } as React.ChangeEvent<HTMLInputElement>);
 
     expect(wrapper.state('tokenInput')).toBe('hi');
   });
 
   it('openGenerateTokenExternal() tries to open the link', () => {
-    const wrapper = shallow(<TokenDialog appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
+    const instance = wrapper.instance();
 
     wrapper.setState({ verifying: true, tokenInput: 'hello' });
     instance.openGenerateTokenExternal();
@@ -123,13 +125,13 @@ describe('TokenDialog component', () => {
         },
       };
 
-      (getOctokit as jest.Mock).mockReturnValue(mockOctokit);
+      (getOctokit as jest.Mock).mockResolvedValue(mockOctokit);
     });
 
     it('handles missing input', async () => {
-      const wrapper = shallow(<TokenDialog appState={store} />);
+      const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
       wrapper.setState({ tokenInput: '' });
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
 
       await instance.onSubmitToken();
 
@@ -137,9 +139,9 @@ describe('TokenDialog component', () => {
     });
 
     it('tries to sign the user in', async () => {
-      const wrapper = shallow(<TokenDialog appState={store} />);
+      const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
       wrapper.setState({ tokenInput: mockValidToken });
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
 
       await instance.onSubmitToken();
 
@@ -152,9 +154,9 @@ describe('TokenDialog component', () => {
     it('handles an error', async () => {
       mockOctokit.users.getAuthenticated.mockReturnValue({ data: null });
 
-      const wrapper = shallow(<TokenDialog appState={store} />);
+      const wrapper = shallow<TokenDialog>(<TokenDialog appState={store} />);
       wrapper.setState({ tokenInput: mockValidToken });
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
 
       await instance.onSubmitToken();
 

--- a/tests/renderer/components/editor-spec.tsx
+++ b/tests/renderer/components/editor-spec.tsx
@@ -18,7 +18,7 @@ describe('Editor component', () => {
   });
 
   function createEditor(id: EditorId, didMount: DidMount = jest.fn()) {
-    const wrapper = shallow(
+    const wrapper = shallow<Editor>(
       <Editor
         appState={store}
         editorDidMount={didMount}
@@ -28,7 +28,7 @@ describe('Editor component', () => {
         setFocused={() => undefined}
       />,
     );
-    const instance: any = wrapper.instance();
+    const instance = wrapper.instance();
     return { wrapper, instance };
   }
 
@@ -50,7 +50,7 @@ describe('Editor component', () => {
 
   it('denies updates', () => {
     const { instance } = createEditor(MAIN_JS);
-    expect(instance.shouldComponentUpdate(null, null, null)).toBe(false);
+    expect(instance.shouldComponentUpdate()).toBe(false);
   });
 
   describe('initMonaco()', () => {
@@ -63,7 +63,7 @@ describe('Editor component', () => {
       const didMount = jest.fn();
       const { instance } = createEditor(id, didMount);
 
-      instance.containerRef.current = 'ref';
+      (instance as any).containerRef.current = 'ref';
       await instance.initMonaco();
 
       expect(didMount).toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('Editor component', () => {
       store.editorMosaic.set({ [id]: '// content' });
       const { instance } = createEditor(id);
 
-      instance.containerRef.current = 'ref';
+      (instance as any).containerRef.current = 'ref';
       await instance.initMonaco();
       expect(monaco.latestEditor.onDidFocusEditorText).toHaveBeenCalled();
     });
@@ -87,7 +87,7 @@ describe('Editor component', () => {
     const didMount = jest.fn();
     const { instance } = createEditor(id, didMount);
 
-    instance.containerRef.current = 'ref';
+    (instance as any).containerRef.current = 'ref';
     await instance.initMonaco();
     instance.componentWillUnmount();
 
@@ -100,7 +100,7 @@ describe('Editor component', () => {
     const didMount = jest.fn();
     const { instance } = createEditor(id, didMount);
 
-    instance.containerRef.current = 'ref';
+    (instance as any).containerRef.current = 'ref';
     await instance.initMonaco();
     instance.componentWillUnmount();
     expect(instance.props.id).toBe(id);

--- a/tests/renderer/components/editors-non-ideal-state-spec.tsx
+++ b/tests/renderer/components/editors-non-ideal-state-spec.tsx
@@ -11,12 +11,12 @@ describe('renderNonIdealState()', () => {
   });
 
   it('renders a non-ideal state', () => {
-    expect(renderNonIdealState({} as any)).toMatchSnapshot();
+    expect(renderNonIdealState({} as EditorMosaic)).toMatchSnapshot();
   });
 
   it('handles a click', () => {
     const resetLayoutSpy = jest.spyOn(editorMosaic, 'resetLayout');
-    const wrapper = mount(renderNonIdealState(editorMosaic as any));
+    const wrapper = mount(renderNonIdealState(editorMosaic));
     wrapper.find('button').simulate('click');
     expect(resetLayoutSpy).toHaveBeenCalledTimes(1);
   });

--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
 import { mount, shallow } from 'enzyme';
+import { MosaicWindowProps } from 'react-mosaic-component';
 
-import { EditorValues, MAIN_JS } from '../../../src/interfaces';
+import { EditorId, EditorValues, MAIN_JS } from '../../../src/interfaces';
 import { App } from '../../../src/renderer/app';
 import { Editors } from '../../../src/renderer/components/editors';
-import { EditorMosaic } from '../../../src/renderer/editor-mosaic';
+import { Editor, EditorMosaic } from '../../../src/renderer/editor-mosaic';
 import { AppState } from '../../../src/renderer/state';
 import {
   MonacoEditorMock,
@@ -44,8 +45,8 @@ describe('Editors component', () => {
   });
 
   it('does not execute command if not supported', () => {
-    const wrapper = shallow(<Editors appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<Editors>(<Editors appState={store} />);
+    const instance = wrapper.instance();
 
     const editor = new MonacoEditorMock();
     const action = editor.getAction();
@@ -64,23 +65,23 @@ describe('Editors component', () => {
 
     it('handles an error', () => {
       const editor = new MonacoEditorMock();
-      editorMosaic.addEditor(filename, editor as any);
+      editorMosaic.addEditor(filename, (editor as unknown) as Editor);
       editor.updateOptions.mockImplementationOnce(() => {
         throw new Error('Bwap bwap');
       });
 
-      const wrapper = shallow(<Editors appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<Editors>(<Editors appState={store} />);
+      const instance = wrapper.instance();
 
       expect(instance.toggleEditorOption('wordWrap')).toBe(false);
     });
 
     it('updates a setting', () => {
-      const wrapper = shallow(<Editors appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<Editors>(<Editors appState={store} />);
+      const instance = wrapper.instance();
 
       const editor = new MonacoEditorMock();
-      editorMosaic.addEditor(filename, editor as any);
+      editorMosaic.addEditor(filename, (editor as unknown) as Editor);
       expect(instance.toggleEditorOption('wordWrap')).toBe(true);
       expect(editor.updateOptions).toHaveBeenCalledWith({
         minimap: { enabled: false },
@@ -90,16 +91,19 @@ describe('Editors component', () => {
   });
 
   it('renders a toolbar', () => {
-    const wrapper = shallow(<Editors appState={store} />);
-    const instance: any = wrapper.instance() as any;
-    const toolbar = instance.renderToolbar({ title: MAIN_JS } as any, MAIN_JS);
+    const wrapper = shallow<Editors>(<Editors appState={store} />);
+    const instance = wrapper.instance();
+    const toolbar = instance.renderToolbar(
+      { title: MAIN_JS } as MosaicWindowProps<EditorId>,
+      MAIN_JS,
+    );
 
     expect(toolbar).toMatchSnapshot();
   });
 
   it('onChange() updates the mosaic arrangement in the appState', () => {
-    const wrapper = shallow(<Editors appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<Editors>(<Editors appState={store} />);
+    const instance = wrapper.instance();
 
     const arrangement = { testArrangement: true };
     instance.onChange(arrangement as any);
@@ -127,7 +131,7 @@ describe('Editors component', () => {
     it('handles a "new-fiddle" event', async () => {
       shallow(<Editors appState={store} />);
 
-      let resolve: any;
+      let resolve: (value?: unknown) => void;
       const replacePromise = new Promise((r) => {
         resolve = r;
       });
@@ -138,7 +142,10 @@ describe('Editors component', () => {
         .mockResolvedValue(fakeValues);
       const replaceFiddleSpy = jest
         .spyOn(app, 'replaceFiddle')
-        .mockImplementation(() => resolve());
+        .mockImplementation(async () => {
+          resolve();
+          return true;
+        });
 
       // invoke the call
       emitEvent('new-fiddle');
@@ -197,13 +204,16 @@ describe('Editors component', () => {
       const getTestTemplateSpy = jest
         .spyOn(window.ElectronFiddle, 'getTestTemplate')
         .mockResolvedValue(fakeValues);
-      let replaceResolve: any;
+      let replaceResolve: (value?: unknown) => void;
       const replacePromise = new Promise((r) => {
         replaceResolve = r;
       });
       const replaceFiddleSpy = jest
         .spyOn(app, 'replaceFiddle')
-        .mockImplementation(() => replaceResolve());
+        .mockImplementation(async () => {
+          replaceResolve();
+          return true;
+        });
 
       // invoke the call
       emitEvent('new-test');
@@ -235,7 +245,7 @@ describe('Editors component', () => {
     it('handles the monaco editor option event', () => {
       const id = MAIN_JS;
       const editor = new MonacoEditorMock();
-      editorMosaic.addEditor(id, editor as any);
+      editorMosaic.addEditor(id, (editor as unknown) as Editor);
 
       shallow(<Editors appState={store} />);
       emitEvent('toggle-monaco-option', 'wordWrap');
@@ -245,8 +255,8 @@ describe('Editors component', () => {
 
   describe('setFocused()', () => {
     it('sets the "focused" property', () => {
-      const wrapper = shallow(<Editors appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<Editors>(<Editors appState={store} />);
+      const instance = wrapper.instance();
       const spy = jest.spyOn(instance, 'setState');
 
       const id = MAIN_JS;
@@ -255,8 +265,8 @@ describe('Editors component', () => {
     });
 
     it('focus sidebar file', () => {
-      const wrapper = shallow(<Editors appState={store} />);
-      const instance: any = wrapper.instance() as any;
+      const wrapper = shallow<Editors>(<Editors appState={store} />);
+      const instance = wrapper.instance();
       const spy = jest.spyOn(instance, 'setState');
 
       const id = MAIN_JS;

--- a/tests/renderer/components/header-spec.tsx
+++ b/tests/renderer/components/header-spec.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { Header } from '../../../src/renderer/components/header';
+import { AppState } from '../../../src/renderer/state';
 
 jest.mock('../../../src/renderer/components/commands', () => ({
   Commands: 'commands',
@@ -17,7 +18,7 @@ jest.mock('../../../src/renderer/components/tour-welcome', () => ({
 }));
 
 describe('Header component', () => {
-  const store: any = {};
+  const store = {} as AppState;
 
   it('renders', () => {
     const wrapper = shallow(<Header appState={store} />);

--- a/tests/renderer/components/output-spec.tsx
+++ b/tests/renderer/components/output-spec.tsx
@@ -38,21 +38,21 @@ describe('Output component', () => {
   });
 
   it('correctly sets the language', () => {
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
     );
 
-    expect((wrapper.instance() as any).language).toBe('consoleOutputLanguage');
+    expect(wrapper.instance().language).toBe('consoleOutputLanguage');
   });
 
   describe('initMonaco()', () => {
     it('attempts to create an editor', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<Output>(
         <Output appState={store} monaco={monaco} monacoOptions={{}} />,
       );
-      const instance: any = wrapper.instance();
+      const instance = wrapper.instance();
 
-      instance.outputRef.current = 'ref';
+      (instance as any).outputRef.current = 'ref';
       await instance.initMonaco();
 
       expect(monaco.editor.create).toHaveBeenCalled();
@@ -61,12 +61,12 @@ describe('Output component', () => {
   });
 
   it('componentWillUnmount() attempts to dispose the editor', async () => {
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
     );
-    const instance: any = wrapper.instance();
+    const instance = wrapper.instance();
 
-    instance.outputRef.current = 'ref';
+    (instance as any).outputRef.current = 'ref';
     await instance.initMonaco();
     instance.componentWillUnmount();
 
@@ -78,14 +78,14 @@ describe('Output component', () => {
   it('hides the console with react-mosaic-component', async () => {
     // manually trigger lifecycle methods so that
     // context can be set before mounting method
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
       {
         context: mockContext,
         disableLifecycleMethods: true,
       },
     );
-    const instance: any = wrapper.instance();
+    const instance = wrapper.instance();
 
     // Todo: There's a scary bug here in Jest / Enzyme. At this point in time,
     // the context is {}. That's never the case in production.
@@ -95,10 +95,10 @@ describe('Output component', () => {
       direction: 'row',
     });
 
-    wrapper.instance().context = mockContext;
-    wrapper.instance().componentDidMount!();
+    instance.context = mockContext;
+    await instance.componentDidMount();
 
-    instance.outputRef.current = 'ref';
+    (instance as any).outputRef.current = 'ref';
     await instance.initMonaco();
 
     expect(mockContext.mosaicActions.replaceWith).toHaveBeenCalled();
@@ -122,17 +122,17 @@ describe('Output component', () => {
       },
     ];
 
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
     );
-    const instance: any = wrapper.instance();
+    const instance = wrapper.instance();
 
-    instance.outputRef.current = 'ref';
+    (instance as any).outputRef.current = 'ref';
     await instance.initMonaco();
-    instance.updateModel();
+    (instance as any).updateModel();
 
     expect(monaco.editor.createModel).toHaveBeenCalled();
-    expect(instance.editor.revealLine).toHaveBeenCalled();
+    expect(instance.editor?.revealLine).toHaveBeenCalled();
   });
 
   it('updateModel correctly observes and gets called when output is updated', async () => {
@@ -143,17 +143,17 @@ describe('Output component', () => {
       },
     ];
 
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
     );
 
-    const instance: any = wrapper.instance();
-    const spy = jest.spyOn(instance, 'updateModel');
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance as any, 'updateModel');
 
-    instance.outputRef.current = 'ref';
+    (instance as any).outputRef.current = 'ref';
     await instance.initMonaco();
 
-    instance.updateModel();
+    (instance as any).updateModel();
 
     // new output
     store.output = [
@@ -172,17 +172,16 @@ describe('Output component', () => {
 
   it('handles componentDidUpdate', async () => {
     // set up component
-    const wrapper = shallow(
+    const wrapper = shallow<Output>(
       <Output appState={store} monaco={monaco} monacoOptions={{}} />,
     );
-    const instance: any = wrapper.instance();
+    const instance = wrapper.instance();
     const spy = jest.spyOn(instance, 'toggleConsole');
 
-    instance.outputRef.current = 'ref';
+    (instance as any).outputRef.current = 'ref';
     await instance.initMonaco();
 
-    // setContent will trigger componentDidUpdate()
-    instance.editor.setContent(store.output);
+    await (instance as any).updateModel();
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/tests/renderer/components/settings-credits-spec.tsx
+++ b/tests/renderer/components/settings-credits-spec.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { CreditsSettings } from '../../../src/renderer/components/settings-credits';
+import { AppState } from '../../../src/renderer/state';
 
 describe('CreditsSettings component', () => {
   const mockContributors = [
@@ -29,10 +30,10 @@ describe('CreditsSettings component', () => {
     },
   ];
 
-  let store: any;
+  let store: AppState;
 
   beforeEach(() => {
-    store = {};
+    store = {} as AppState;
   });
 
   it('renders', async () => {

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -139,20 +139,20 @@ describe('ElectronSettings component', () => {
   });
 
   it('handles the deleteAll()', async () => {
-    const wrapper = shallow(
+    const wrapper = shallow<ElectronSettings>(
       <ElectronSettings appState={(store as unknown) as AppState} />,
     );
-    const instance = wrapper.instance() as any;
+    const instance = wrapper.instance();
     await instance.handleDeleteAll();
 
     expect(store.removeVersion).toHaveBeenCalledTimes(mockVersionsArray.length);
   });
 
   it('handles the downloadAll()', async () => {
-    const wrapper = shallow(
+    const wrapper = shallow<ElectronSettings>(
       <ElectronSettings appState={(store as unknown) as AppState} />,
     );
-    const instance = wrapper.instance() as any;
+    const instance = wrapper.instance();
     await instance.handleDownloadAll();
 
     expect(store.downloadVersion).toHaveBeenCalled();
@@ -160,11 +160,11 @@ describe('ElectronSettings component', () => {
 
   describe('handleUpdateElectronVersions()', () => {
     it('kicks off an update of Electron versions', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<ElectronSettings>(
         <ElectronSettings appState={(store as unknown) as AppState} />,
       );
-      const instance = wrapper.instance() as any;
-      await instance.handleUpdateElectronVersions();
+      const instance = wrapper.instance();
+      instance.handleUpdateElectronVersions();
 
       expect(store.updateElectronVersions).toHaveBeenCalled();
     });
@@ -172,10 +172,10 @@ describe('ElectronSettings component', () => {
 
   describe('handleAddVersion()', () => {
     it('toggles the add version dialog', () => {
-      const wrapper = shallow(
+      const wrapper = shallow<ElectronSettings>(
         <ElectronSettings appState={(store as unknown) as AppState} />,
       );
-      const instance = wrapper.instance() as any;
+      const instance = wrapper.instance();
       instance.handleAddVersion();
 
       expect(store.toggleAddVersionDialog).toHaveBeenCalled();
@@ -186,13 +186,13 @@ describe('ElectronSettings component', () => {
     it('toggles remote versions', async () => {
       const id = 'showUndownloadedVersions';
       for (const checked of [true, false]) {
-        const wrapper = shallow(
+        const wrapper = shallow<ElectronSettings>(
           <ElectronSettings appState={(store as unknown) as AppState} />,
         );
-        const instance = wrapper.instance() as any;
-        await instance.handleStateChange({
+        const instance = wrapper.instance();
+        instance.handleStateChange({
           currentTarget: { checked, id },
-        });
+        } as React.FormEvent<HTMLInputElement>);
         expect(store[id]).toBe(checked);
       }
     });
@@ -202,13 +202,13 @@ describe('ElectronSettings component', () => {
     it('toggles obsolete versions', async () => {
       const id = 'showObsoleteVersions';
       for (const checked of [true, false]) {
-        const wrapper = shallow(
+        const wrapper = shallow<ElectronSettings>(
           <ElectronSettings appState={(store as unknown) as AppState} />,
         );
-        const instance = wrapper.instance() as any;
-        await instance.handleShowObsoleteChange({
+        const instance = wrapper.instance();
+        instance.handleShowObsoleteChange({
           currentTarget: { checked, id },
-        });
+        } as React.FormEvent<HTMLInputElement>);
         expect(store[id]).toBe(checked);
       }
     });
@@ -216,7 +216,7 @@ describe('ElectronSettings component', () => {
 
   describe('handleChannelChange()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<ElectronSettings>(
         <ElectronSettings appState={(store as unknown) as AppState} />,
       );
       store.showChannels.mockImplementation((ids: ElectronReleaseChannel[]) =>
@@ -228,20 +228,20 @@ describe('ElectronSettings component', () => {
             (id: ElectronReleaseChannel) => !ids.includes(id),
           )),
       );
-      const instance = wrapper.instance() as any;
-      await instance.handleChannelChange({
+      const instance = wrapper.instance();
+      instance.handleChannelChange({
         currentTarget: {
           id: ElectronReleaseChannel.stable,
           checked: false,
         },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
-      await instance.handleChannelChange({
+      instance.handleChannelChange({
         currentTarget: {
           id: ElectronReleaseChannel.nightly,
           checked: true,
         },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.channelsToShow).toEqual([
         ElectronReleaseChannel.beta,

--- a/tests/renderer/components/settings-execution-spec.tsx
+++ b/tests/renderer/components/settings-execution-spec.tsx
@@ -6,15 +6,16 @@ import {
   ExecutionSettings,
   SettingItemType,
 } from '../../../src/renderer/components/settings-execution';
+import { AppState } from '../../../src/renderer/state';
 
 describe('ExecutionSettings component', () => {
-  let store: any;
+  let store: AppState;
 
   beforeEach(() => {
     store = {
-      executionFlags: [],
-      environmentVariables: [],
-    };
+      executionFlags: [] as string[],
+      environmentVariables: [] as string[],
+    } as AppState;
   });
 
   it('renders', () => {
@@ -24,17 +25,19 @@ describe('ExecutionSettings component', () => {
 
   describe('handleDeleteDataChange()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<ExecutionSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleDeleteDataChange({
+      const wrapper = shallow<ExecutionSettings>(
+        <ExecutionSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
+      instance.handleDeleteDataChange({
         currentTarget: { checked: false },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isKeepingUserDataDirs).toBe(false);
 
-      await instance.handleDeleteDataChange({
+      instance.handleDeleteDataChange({
         currentTarget: { checked: true },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isKeepingUserDataDirs).toBe(true);
     });
@@ -42,17 +45,19 @@ describe('ExecutionSettings component', () => {
 
   describe('handleElectronLoggingChange()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<ExecutionSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleElectronLoggingChange({
+      const wrapper = shallow<ExecutionSettings>(
+        <ExecutionSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
+      instance.handleElectronLoggingChange({
         currentTarget: { checked: false },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isEnablingElectronLogging).toBe(false);
 
-      await instance.handleElectronLoggingChange({
+      instance.handleElectronLoggingChange({
         currentTarget: { checked: true },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isEnablingElectronLogging).toBe(true);
     });
@@ -61,26 +66,28 @@ describe('ExecutionSettings component', () => {
   describe('handleItemSettingsChange()', () => {
     describe('with executionFlags', () => {
       it('updates when new flags are added', async () => {
-        const wrapper = shallow(<ExecutionSettings appState={store} />);
-        const instance = wrapper.instance() as any;
+        const wrapper = shallow<ExecutionSettings>(
+          <ExecutionSettings appState={store} />,
+        );
+        const instance = wrapper.instance();
 
         const lang = '--lang=es';
         const flags = '--js-flags=--expose-gc';
 
-        await instance.handleSettingsItemChange(
+        instance.handleSettingsItemChange(
           {
             currentTarget: { name: '0', value: lang },
-          },
+          } as React.ChangeEvent<HTMLInputElement>,
           SettingItemType.Flags,
         );
 
         expect(instance.state.executionFlags).toEqual({ '0': lang });
         expect(store.executionFlags).toEqual([lang]);
 
-        await instance.handleSettingsItemChange(
+        instance.handleSettingsItemChange(
           {
             currentTarget: { name: '1', value: flags },
-          },
+          } as React.ChangeEvent<HTMLInputElement>,
           SettingItemType.Flags,
         );
 
@@ -94,29 +101,31 @@ describe('ExecutionSettings component', () => {
 
     describe('with environmentVariables', () => {
       it('updates when new flags are added', async () => {
-        const wrapper = shallow(<ExecutionSettings appState={store} />);
-        const instance = wrapper.instance() as any;
+        const wrapper = shallow<ExecutionSettings>(
+          <ExecutionSettings appState={store} />,
+        );
+        const instance = wrapper.instance();
 
         const debug = 'ELECTRON_DEBUG_DRAG_REGIONS=1';
         const trash = 'ELECTRON_TRASH=trash-cli';
 
-        await instance.handleSettingsItemChange(
+        instance.handleSettingsItemChange(
           {
             currentTarget: {
               name: '0',
               value: debug,
             },
-          },
+          } as React.ChangeEvent<HTMLInputElement>,
           SettingItemType.EnvVars,
         );
 
         expect(instance.state.environmentVariables).toEqual({ '0': debug });
         expect(store.environmentVariables).toEqual([debug]);
 
-        await instance.handleSettingsItemChange(
+        instance.handleSettingsItemChange(
           {
             currentTarget: { name: '1', value: trash },
-          },
+          } as React.ChangeEvent<HTMLInputElement>,
           SettingItemType.EnvVars,
         );
 

--- a/tests/renderer/components/settings-general-appearance-spec.tsx
+++ b/tests/renderer/components/settings-general-appearance-spec.tsx
@@ -45,7 +45,7 @@ describe('AppearanceSettings component', () => {
 
   it('renders the correct selected theme', async () => {
     store.theme = 'defaultDark';
-    const wrapper = shallow(
+    const wrapper = shallow<AppearanceSettings>(
       <AppearanceSettings
         appState={store}
         toggleHasPopoverOpen={doNothingFunc}
@@ -53,18 +53,18 @@ describe('AppearanceSettings component', () => {
     );
 
     await process.nextTick;
-    expect((wrapper.state() as any).selectedTheme.name).toBe('defaultDark');
+    expect(wrapper.state().selectedTheme?.name).toBe('defaultDark');
   });
 
   it('handles a theme change', () => {
-    const wrapper = shallow(
+    const wrapper = shallow<AppearanceSettings>(
       <AppearanceSettings
         appState={store}
         toggleHasPopoverOpen={doNothingFunc}
       />,
     );
-    const instance: any = wrapper.instance() as any;
-    instance.handleChange({ file: 'defaultLight' } as any);
+    const instance = wrapper.instance();
+    instance.handleChange({ file: 'defaultLight' } as LoadedFiddleTheme);
 
     expect(store.setTheme).toHaveBeenCalledWith('defaultLight');
   });
@@ -89,26 +89,26 @@ describe('AppearanceSettings component', () => {
 
   describe('openThemeFolder()', () => {
     it('attempts to open the folder', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       await instance.openThemeFolder();
 
       expect(window.ElectronFiddle.openThemeFolder).toHaveBeenCalled();
     });
 
     it('handles an error', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       (window.ElectronFiddle.openThemeFolder as jest.Mock).mockRejectedValue(
         new Error('Bwap'),
       );
@@ -119,13 +119,13 @@ describe('AppearanceSettings component', () => {
 
   describe('createNewThemeFromCurrent()', () => {
     it('creates a new file from the current theme', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       await instance.createNewThemeFromCurrent();
 
       expect(window.ElectronFiddle.createThemeFile).toHaveBeenCalledWith(
@@ -145,26 +145,26 @@ describe('AppearanceSettings component', () => {
           arr.push(theme);
         },
       );
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
       expect(wrapper.state('themes')).toHaveLength(0);
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       await instance.createNewThemeFromCurrent();
       expect(wrapper.state('themes')).toHaveLength(1);
     });
 
     it('handles an error', async () => {
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       (window.ElectronFiddle.createThemeFile as jest.Mock).mockRejectedValue(
         new Error('Bwap'),
       );
@@ -180,14 +180,14 @@ describe('AppearanceSettings component', () => {
       (window.ElectronFiddle.getAvailableThemes as jest.Mock).mockResolvedValue(
         arr,
       );
-      const wrapper = shallow(
+      const wrapper = shallow<AppearanceSettings>(
         <AppearanceSettings
           appState={store}
           toggleHasPopoverOpen={doNothingFunc}
         />,
       );
       expect(window.ElectronFiddle.getAvailableThemes).toHaveBeenCalledTimes(1);
-      const instance: any = wrapper.instance() as any;
+      const instance = wrapper.instance();
       const promise = instance.handleAddTheme();
       store.isTokenDialogShowing = false;
       await promise;
@@ -197,10 +197,10 @@ describe('AppearanceSettings component', () => {
 
   describe('filterItem()', () => {
     it('filters', () => {
-      const foo = filterItem('foo', { name: 'foo' } as any);
+      const foo = filterItem('foo', { name: 'foo' } as LoadedFiddleTheme);
       expect(foo).toBe(true);
 
-      const bar = filterItem('foo', { name: 'bar' } as any);
+      const bar = filterItem('foo', { name: 'bar' } as LoadedFiddleTheme);
       expect(bar).toBe(false);
     });
   });
@@ -218,7 +218,7 @@ describe('AppearanceSettings component', () => {
     };
 
     it('returns null for non-matching', () => {
-      const result = renderItem({ name: 'foo' } as any, {
+      const result = renderItem({ name: 'foo' } as LoadedFiddleTheme, {
         ...mockItemProps,
         modifiers: {
           ...mockItemProps.modifiers,
@@ -230,7 +230,7 @@ describe('AppearanceSettings component', () => {
     });
 
     it('returns a MenuItem for matching', () => {
-      const result = renderItem({ name: 'foo' } as any, {
+      const result = renderItem({ name: 'foo' } as LoadedFiddleTheme, {
         ...mockItemProps,
       });
 

--- a/tests/renderer/components/settings-general-block-accelerators-spec.tsx
+++ b/tests/renderer/components/settings-general-block-accelerators-spec.tsx
@@ -20,20 +20,22 @@ describe('BlockAcceleratorsSettings component', () => {
 
   describe('handleBlockAcceleratorChange()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<BlockAcceleratorsSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<BlockAcceleratorsSettings>(
+        <BlockAcceleratorsSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
 
-      await instance.handleBlockAcceleratorChange({
+      instance.handleBlockAcceleratorChange({
         currentTarget: { checked: false, value: BlockableAccelerator.save },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.removeAcceleratorToBlock).toHaveBeenCalledWith(
         BlockableAccelerator.save,
       );
 
-      await instance.handleBlockAcceleratorChange({
+      instance.handleBlockAcceleratorChange({
         currentTarget: { checked: true, value: BlockableAccelerator.save },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.addAcceleratorToBlock).toHaveBeenCalledWith(
         BlockableAccelerator.save,

--- a/tests/renderer/components/settings-general-console-spec.tsx
+++ b/tests/renderer/components/settings-general-console-spec.tsx
@@ -3,12 +3,13 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { ConsoleSettings } from '../../../src/renderer/components/settings-general-console';
+import { AppState } from '../../../src/renderer/state';
 
 describe('ConsoleSettings component', () => {
-  let store: any;
+  let store: AppState;
 
   beforeEach(() => {
-    store = {};
+    store = {} as AppState;
   });
 
   it('renders', () => {
@@ -18,17 +19,19 @@ describe('ConsoleSettings component', () => {
 
   describe('handleClearOnRunChange()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<ConsoleSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleClearOnRunChange({
+      const wrapper = shallow<ConsoleSettings>(
+        <ConsoleSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
+      instance.handleClearOnRunChange({
         currentTarget: { checked: false },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isClearingConsoleOnRun).toBe(false);
 
-      await instance.handleClearOnRunChange({
+      instance.handleClearOnRunChange({
         currentTarget: { checked: true },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isClearingConsoleOnRun).toBe(true);
     });

--- a/tests/renderer/components/settings-general-font-spec.tsx
+++ b/tests/renderer/components/settings-general-font-spec.tsx
@@ -3,15 +3,16 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { FontSettings } from '../../../src/renderer/components/settings-general-font';
+import { AppState } from '../../../src/renderer/state';
 
 describe('FontSettings component', () => {
-  let store: any;
+  let store: AppState;
 
   beforeEach(() => {
     store = {
       fontSize: undefined,
       fontFamily: undefined,
-    };
+    } as AppState;
   });
 
   it('renders', () => {
@@ -21,21 +22,21 @@ describe('FontSettings component', () => {
 
   describe('handleSetFontFamily()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<FontSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<FontSettings>(<FontSettings appState={store} />);
+      const instance = wrapper.instance();
 
       const CALIBRI = 'Calibri';
       const VERDANA = 'Verdana';
-      await instance.handleSetFontFamily({
+      instance.handleSetFontFamily({
         currentTarget: { value: CALIBRI },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.fontFamily).toBe(CALIBRI);
       expect(instance.state.fontFamily).toEqual(CALIBRI);
 
-      await instance.handleSetFontFamily({
+      instance.handleSetFontFamily({
         currentTarget: { value: VERDANA },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.fontFamily).toBe(VERDANA);
       expect(instance.state.fontFamily).toEqual(VERDANA);
@@ -44,29 +45,29 @@ describe('FontSettings component', () => {
 
   describe('handleSetFontSize()', () => {
     it('handles a new selection', async () => {
-      const wrapper = shallow(<FontSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleSetFontSize({
+      const wrapper = shallow<FontSettings>(<FontSettings appState={store} />);
+      const instance = wrapper.instance();
+      instance.handleSetFontSize({
         currentTarget: { value: '12' },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.fontSize).toBe(12);
       expect(instance.state.fontSize).toEqual(12);
 
-      await instance.handleSetFontSize({
+      instance.handleSetFontSize({
         currentTarget: { value: '10' },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.fontSize).toBe(10);
       expect(instance.state.fontSize).toEqual(10);
     });
 
     it('handles being cleared', async () => {
-      const wrapper = shallow(<FontSettings appState={store} />);
-      const instance = wrapper.instance() as any;
-      await instance.handleSetFontSize({
+      const wrapper = shallow<FontSettings>(<FontSettings appState={store} />);
+      const instance = wrapper.instance();
+      instance.handleSetFontSize({
         currentTarget: { value: '' },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.fontSize).toBeUndefined();
       expect(instance.state.fontSize).toBeUndefined();

--- a/tests/renderer/components/settings-general-github-spec.tsx
+++ b/tests/renderer/components/settings-general-github-spec.tsx
@@ -34,18 +34,20 @@ describe('GitHubSettings component', () => {
 
   describe('Gist publish as revision component', () => {
     it('state changes', async () => {
-      const wrapper = shallow(<GitHubSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<GitHubSettings>(
+        <GitHubSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
 
-      await instance.handlePublishGistAsRevisionChange({
+      instance.handlePublishGistAsRevisionChange({
         currentTarget: { checked: false },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isPublishingGistAsRevision).toBe(false);
 
-      await instance.handlePublishGistAsRevisionChange({
+      instance.handlePublishGistAsRevisionChange({
         currentTarget: { checked: true },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.isPublishingGistAsRevision).toBe(true);
     });

--- a/tests/renderer/components/settings-general-mirror-spec.tsx
+++ b/tests/renderer/components/settings-general-mirror-spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FormEvent } from 'react';
 
 import { InputGroup, Radio } from '@blueprintjs/core';
 import { shallow } from 'enzyme';
@@ -21,13 +20,15 @@ describe('MirrorSettings component', () => {
 
   describe('modifyMirror()', () => {
     it('modify mirror', async () => {
-      const wrapper = shallow(<MirrorSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<MirrorSettings>(
+        <MirrorSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
 
       const [mirror, nightlyMirror] = ['mirror_test1', 'nightly_test2'];
 
-      instance.modifyMirror(false, mirror);
-      instance.modifyMirror(true, nightlyMirror);
+      (instance as any).modifyMirror(false, mirror);
+      (instance as any).modifyMirror(true, nightlyMirror);
 
       expect(store.electronMirror.sources.CUSTOM.electronMirror).toEqual(
         mirror,
@@ -41,13 +42,15 @@ describe('MirrorSettings component', () => {
 
   describe('changeSourceType()', () => {
     it('change source type', () => {
-      const wrapper = shallow(<MirrorSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<MirrorSettings>(
+        <MirrorSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
 
       store.electronMirror.sourceType = 'DEFAULT';
       const event = { target: { value: 'CUSTOM' } };
-      instance.changeSourceType(
-        (event as unknown) as FormEvent<HTMLInputElement>,
+      (instance as any).changeSourceType(
+        (event as unknown) as React.FormEvent<HTMLInputElement>,
       );
 
       expect(store.electronMirror.sourceType).toEqual('CUSTOM');

--- a/tests/renderer/components/settings-general-package-author-spec.tsx
+++ b/tests/renderer/components/settings-general-package-author-spec.tsx
@@ -20,21 +20,23 @@ describe('PackageAuthorSettings component', () => {
 
   describe('handlePackageAuthorChange()', () => {
     it('handles package author', async () => {
-      const wrapper = shallow(<PackageAuthorSettings appState={store} />);
-      const instance = wrapper.instance() as any;
+      const wrapper = shallow<PackageAuthorSettings>(
+        <PackageAuthorSettings appState={store} />,
+      );
+      const instance = wrapper.instance();
 
       const author = 'electron<electron@electron.org>';
 
-      await instance.handlePackageAuthorChange({
+      instance.handlePackageAuthorChange({
         currentTarget: { value: author },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.packageAuthor).toEqual(author);
       expect(instance.state.value).toEqual(author);
 
-      await instance.handlePackageAuthorChange({
+      instance.handlePackageAuthorChange({
         currentTarget: { value: 'test' },
-      });
+      } as React.FormEvent<HTMLInputElement>);
 
       expect(store.packageAuthor).toEqual('test');
       expect(instance.state.value).toEqual('test');

--- a/tests/renderer/components/settings-general-spec.tsx
+++ b/tests/renderer/components/settings-general-spec.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { GeneralSettings } from '../../../src/renderer/components/settings-general';
+import { AppState } from '../../../src/renderer/state';
 
 const doNothingFunc = () => {
   // Do Nothing
@@ -42,7 +43,7 @@ jest.mock('../../../src/renderer/components/settings-general-mirror', () => ({
 }));
 
 describe('GeneralSettings component', () => {
-  const store: any = {};
+  const store = {} as AppState;
 
   it('renders', () => {
     const wrapper = shallow(

--- a/tests/renderer/components/settings-spec.tsx
+++ b/tests/renderer/components/settings-spec.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { Settings } from '../../../src/renderer/components/settings';
+import { AppState } from '../../../src/renderer/state';
 
 jest.mock('../../../src/renderer/components/settings-general', () => ({
   GeneralSettings: 'settings-general',
@@ -17,12 +18,12 @@ jest.mock('../../../src/renderer/components/settings-credits', () => ({
 }));
 
 describe('Settings component', () => {
-  let store: any;
+  let store: AppState;
 
   beforeEach(() => {
     store = {
       isSettingsShowing: true,
-    };
+    } as AppState;
   });
 
   it('renders null if settings not showing', () => {
@@ -138,8 +139,8 @@ describe('Settings component', () => {
     });
 
     // Set the theme selector showing to true
-    const wrapper = shallow(<Settings appState={store} />);
-    const instance: any = wrapper.instance();
+    const wrapper = shallow<Settings>(<Settings appState={store} />);
+    const instance = wrapper.instance();
 
     // Toggle the state of the variable
     instance.toggleHasPopoverOpen();

--- a/tests/renderer/components/sidebar-file-tree-spec.tsx
+++ b/tests/renderer/components/sidebar-file-tree-spec.tsx
@@ -43,8 +43,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can bring up the Add File input', () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     instance.setState({ action: 'add' });
 
@@ -53,8 +55,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can toggle editor visibility', () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     instance.toggleVisibility('index.html');
 
@@ -62,8 +66,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can create new editors', () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     expect(editorMosaic.files.get('tester.js')).toBe(undefined);
     instance.createEditor('tester.js');
@@ -71,8 +77,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can delete editors', () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     expect(editorMosaic.files.get('index.html')).toBe(EditorPresence.Pending);
     instance.removeEditor('index.html');
@@ -80,8 +88,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can rename editors', async () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     const EDITOR_NAME = 'index.html';
     const EDITOR_NEW_NAME = 'new_index.html';
@@ -99,8 +109,10 @@ describe('SidebarFileTree component', () => {
   });
 
   it('can reset the editor layout', () => {
-    const wrapper = shallow(<SidebarFileTree appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const instance = wrapper.instance();
 
     editorMosaic.resetLayout = jest.fn();
 
@@ -110,12 +122,14 @@ describe('SidebarFileTree component', () => {
   });
 
   it('file is visible, click files tree, focus file content', async () => {
-    const sidebarFileTree = shallow(<SidebarFileTree appState={store} />);
-    const editors = shallow(
+    const sidebarFileTree = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const editors = shallow<Editors>(
       <Editors appState={(stateMock as unknown) as AppState} />,
     );
-    const sidebarFileTreeInstance: any = sidebarFileTree.instance() as any;
-    const editorsInstance: any = editors.instance() as any;
+    const sidebarFileTreeInstance = sidebarFileTree.instance();
+    const editorsInstance = editors.instance();
 
     sidebarFileTreeInstance.setFocusedFile('index.html');
 
@@ -126,12 +140,14 @@ describe('SidebarFileTree component', () => {
   });
 
   it('file is hidden, click files tree, make file visible and focus file content', function () {
-    const sidebarFileTree = shallow(<SidebarFileTree appState={store} />);
-    const editors = shallow(
+    const sidebarFileTree = shallow<SidebarFileTree>(
+      <SidebarFileTree appState={store} />,
+    );
+    const editors = shallow<Editors>(
       <Editors appState={(stateMock as unknown) as AppState} />,
     );
-    const sidebarFileTreeInstance: any = sidebarFileTree.instance() as any;
-    const editorsInstance: any = editors.instance() as any;
+    const sidebarFileTreeInstance = sidebarFileTree.instance();
+    const editorsInstance = editors.instance();
 
     sidebarFileTreeInstance.toggleVisibility('index.html');
 

--- a/tests/renderer/components/sidebar-package-manager-spec.tsx
+++ b/tests/renderer/components/sidebar-package-manager-spec.tsx
@@ -4,6 +4,7 @@ import { Button } from '@blueprintjs/core';
 import { mount, shallow } from 'enzyme';
 
 import { SidebarPackageManager } from '../../../src/renderer/components/sidebar-package-manager';
+import { AppState } from '../../../src/renderer/state';
 
 jest.mock('../../../src/renderer/npm-search', () => ({
   npmSearch: {
@@ -20,11 +21,11 @@ jest.mock('../../../src/renderer/npm-search', () => ({
 }));
 
 describe('SidebarPackageManager component', () => {
-  let store: any;
+  let store: AppState;
   beforeEach(() => {
     store = {
       modules: new Map<string, string>([['cow', '1.0.0']]),
-    };
+    } as AppState;
   });
 
   it('renders', () => {
@@ -33,17 +34,23 @@ describe('SidebarPackageManager component', () => {
   });
 
   it('can add a package', () => {
-    const wrapper = shallow(<SidebarPackageManager appState={store} />);
+    const wrapper = shallow<SidebarPackageManager>(
+      <SidebarPackageManager appState={store} />,
+    );
     const instance = wrapper.instance();
     instance.state = {
       suggestions: [],
       versionsCache: new Map(),
     };
 
-    (instance as any).addModuleToFiddle({
+    instance.addModuleToFiddle({
+      objectID: 'say',
       name: 'say',
       version: '2.0.0',
-      versions: ['1.0.0', '2.0.0'],
+      versions: {
+        '1.0.0': '',
+        '2.0.0': '',
+      },
     });
 
     expect(

--- a/tests/renderer/components/tour-spec.tsx
+++ b/tests/renderer/components/tour-spec.tsx
@@ -84,8 +84,8 @@ describe('VersionChooser component', () => {
 
   it('stops on stop()', () => {
     const mockStop = jest.fn();
-    const wrapper = shallow(<Tour tour={mockTour} onStop={mockStop} />);
-    const instance: any = wrapper.instance();
+    const wrapper = shallow<Tour>(<Tour tour={mockTour} onStop={mockStop} />);
+    const instance = wrapper.instance();
 
     instance.stop();
 
@@ -94,11 +94,11 @@ describe('VersionChooser component', () => {
 
   it('advances on advance()', () => {
     const mockStop = jest.fn();
-    const wrapper = shallow(<Tour tour={mockTour} onStop={mockStop} />);
-    const instance: any = wrapper.instance();
+    const wrapper = shallow<Tour>(<Tour tour={mockTour} onStop={mockStop} />);
+    const instance = wrapper.instance();
 
     instance.advance();
-    expect((wrapper.state('step') as any).name).toBe('mock-step-2');
+    expect(wrapper.state('step')?.name).toBe('mock-step-2');
 
     instance.advance();
     expect(wrapper.state('step')).toBe(null);
@@ -108,13 +108,13 @@ describe('VersionChooser component', () => {
     jest.useFakeTimers();
 
     const mockStop = jest.fn();
-    const wrapper = shallow(<Tour tour={mockTour} onStop={mockStop} />);
-    const instance: any = wrapper.instance();
+    const wrapper = shallow<Tour>(<Tour tour={mockTour} onStop={mockStop} />);
+    const instance = wrapper.instance();
 
     instance.forceUpdate = jest.fn();
     instance.onResize();
 
-    expect(instance.resizeHandle).toBeTruthy();
+    expect((instance as any).resizeHandle).toBeTruthy();
     jest.runAllTimers();
 
     expect(instance.forceUpdate).toHaveBeenCalled();
@@ -125,8 +125,8 @@ describe('VersionChooser component', () => {
     window.removeEventListener = jest.fn();
 
     const mockStop = jest.fn();
-    const wrapper = shallow(<Tour tour={mockTour} onStop={mockStop} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<Tour>(<Tour tour={mockTour} onStop={mockStop} />);
+    const instance = wrapper.instance();
 
     instance.componentWillUnmount();
     expect(window.removeEventListener).toHaveBeenCalled();

--- a/tests/renderer/components/tour-welcome-spec.tsx
+++ b/tests/renderer/components/tour-welcome-spec.tsx
@@ -29,8 +29,8 @@ describe('Header component', () => {
   });
 
   it('renders the tour once started', () => {
-    const wrapper = shallow(<WelcomeTour appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<WelcomeTour>(<WelcomeTour appState={store} />);
+    const instance = wrapper.instance();
 
     instance.startTour();
 
@@ -39,8 +39,8 @@ describe('Header component', () => {
   });
 
   it('stops the tour on stopTour()', () => {
-    const wrapper = shallow(<WelcomeTour appState={store} />);
-    const instance: any = wrapper.instance() as any;
+    const wrapper = shallow<WelcomeTour>(<WelcomeTour appState={store} />);
+    const instance = wrapper.instance();
 
     instance.stopTour();
 

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -31,7 +31,7 @@ describe('EditorMosaic', () => {
 
     // inject a real EditorMosaic into our mock scaffolding
     editorMosaic = new EditorMosaic();
-    app.state.editorMosaic = editorMosaic as any;
+    app.state.editorMosaic = editorMosaic;
 
     editor = (new MonacoEditorMock() as unknown) as Editor;
     valuesIn = createEditorValues();
@@ -233,7 +233,7 @@ describe('EditorMosaic', () => {
       // and then add Monaco editors
       for (const [file, value] of Object.entries(values)) {
         const editor = (new MonacoEditorMock() as unknown) as Editor;
-        editorMosaic.addEditor(file as any, editor);
+        editorMosaic.addEditor(file as EditorId, editor);
         editor.setValue(value as string);
       }
 

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -82,7 +82,7 @@ describe('ElectronTypes', () => {
     return jest.spyOn(global, 'fetch').mockResolvedValue({
       text: async () => text,
       json: async () => ({ files: nodeTypesData }),
-    } as any);
+    } as Response);
   }
 
   describe('setVersion({ source: local })', () => {

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -34,7 +34,7 @@ describe('FileManager', () => {
     // create a real FileManager and insert it into our mocks
     app = (window.ElectronFiddle.app as unknown) as AppMock;
     fm = new FileManager(((app as unknown) as App).state);
-    app.fileManager = fm as any;
+    ((app as unknown) as App).fileManager = fm;
   });
 
   describe('openFiddle()', () => {

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -4,6 +4,7 @@ import {
   InstallState,
   MAIN_JS,
   PACKAGE_NAME,
+  RunnableVersion,
   VersionSource,
 } from '../../src/interfaces';
 import { RemoteLoader } from '../../src/renderer/remote-loader';
@@ -36,9 +37,9 @@ describe('RemoteLoader', () => {
     ({ state: store } = app);
     store.channelsToShow = [ElectronReleaseChannel.stable];
     store.initVersions('4.0.0', {
-      '4.0.0': { version: '4.0.0' },
-      '4.0.0-beta': { version: '4.0.0-beta' },
-    } as any);
+      '4.0.0': { version: '4.0.0' } as RunnableVersion,
+      '4.0.0-beta': { version: '4.0.0-beta' } as RunnableVersion,
+    });
     instance = new RemoteLoader((store as unknown) as AppState);
 
     editorValues = createEditorValues();

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -24,7 +24,7 @@ jest.mock('node:path');
 
 describe('Runner component', () => {
   let store: StateMock;
-  let instance: any;
+  let instance: Runner;
   let fileManager: FileManagerMock;
   let mockVersions: Record<string, RunnableVersion>;
   let mockVersionsArray: RunnableVersion[];
@@ -389,7 +389,7 @@ describe('Runner component', () => {
     });
 
     it('handles an error in saveToTemp()', async () => {
-      (instance as any).saveToTemp = jest.fn();
+      instance.saveToTemp = jest.fn();
 
       expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(
         false,

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -1,4 +1,4 @@
-import { reaction } from 'mobx';
+import { IReactionDisposer, reaction } from 'mobx';
 
 import {
   BlockableAccelerator,
@@ -239,7 +239,7 @@ describe('AppState', () => {
     it('excludes channels', () => {
       appState.channelsToShow = ['Unsupported' as any];
       expect(appState.versionsToShow.length).toEqual(0);
-      appState.channelsToShow = ['Stable' as any];
+      appState.channelsToShow = [ElectronReleaseChannel.stable];
       expect(appState.versionsToShow.length).toEqual(mockVersionsArray.length);
     });
 
@@ -308,7 +308,7 @@ describe('AppState', () => {
       const ver = appState.versions[version];
       ver.state = InstallState.installed;
       await appState.removeVersion(ver);
-      expect(removeSpy).toHaveBeenCalledWith<any>(ver.version);
+      expect(removeSpy).toHaveBeenCalledWith(ver.version);
     });
 
     it('does not remove it if not necessary', async () => {
@@ -469,7 +469,7 @@ describe('AppState', () => {
   });
 
   describe('dialog helpers', () => {
-    let dispose: any;
+    let dispose: IReactionDisposer;
 
     afterEach(() => {
       if (dispose) dispose();

--- a/tests/renderer/task-runner-spec.tsx
+++ b/tests/renderer/task-runner-spec.tsx
@@ -11,13 +11,14 @@ import {
 import { App } from '../../src/renderer/app';
 import { TaskRunner } from '../../src/renderer/task-runner';
 import { AppMock } from '../mocks/app';
+import { RunnerMock } from '../mocks/runner';
 import { StateMock } from '../mocks/state';
 import { emitEvent, waitFor } from '../utils';
 
 describe('Task Runner component', () => {
   let app: AppMock;
   let appState: StateMock;
-  let runner: any;
+  let runner: RunnerMock;
 
   function makeRunnables(versions: string[]): RunnableVersion[] {
     return versions.map((version) => ({
@@ -31,7 +32,7 @@ describe('Task Runner component', () => {
     app = (window.ElectronFiddle.app as unknown) as AppMock;
     appState = app.state;
     runner = app.runner;
-    runner.autobisect.foo = 'a';
+    (runner.autobisect as any).foo = 'a';
     app.taskRunner = new TaskRunner((app as unknown) as App);
   });
 
@@ -84,7 +85,7 @@ describe('Task Runner component', () => {
       (appState.hideChannels as jest.Mock).mockResolvedValue(0);
       (appState.setVersion as jest.Mock).mockResolvedValue(0);
       (appState.showChannels as jest.Mock).mockResolvedValue(0);
-      (appState.versionsToShow as any) = makeRunnables(VERSIONS);
+      appState.versionsToShow = makeRunnables(VERSIONS);
       (runner.autobisect as jest.Mock).mockResolvedValueOnce(RESULT);
 
       await requestAndWait('bisect-task', req);
@@ -132,7 +133,7 @@ describe('Task Runner component', () => {
       (appState.hideChannels as jest.Mock).mockResolvedValue(0);
       (appState.setVersion as jest.Mock).mockResolvedValue(0);
       (appState.showChannels as jest.Mock).mockResolvedValue(0);
-      (appState.versionsToShow as any) = makeRunnables([VERSION]);
+      appState.versionsToShow = makeRunnables([VERSION]);
       (runner.run as jest.Mock).mockResolvedValueOnce(RESULT);
 
       await requestAndWait('test-task', req);

--- a/tests/renderer/utils/get-package-spec.ts
+++ b/tests/renderer/utils/get-package-spec.ts
@@ -1,6 +1,7 @@
 import * as semver from 'semver';
 
 import { MAIN_JS } from '../../../src/interfaces';
+import { AppState } from '../../../src/renderer/state';
 import {
   getForgeVersion,
   getPackageJson,
@@ -56,7 +57,7 @@ describe('get-package', () => {
         modules: new Map<string, string>([['say', '*']]),
         packageAuthor: defaultAuthor,
       };
-      const result = await getPackageJson(appState as any);
+      const result = await getPackageJson((appState as unknown) as AppState);
       expect(result).toEqual(buildExpectedPackage());
     });
 
@@ -70,7 +71,7 @@ describe('get-package', () => {
       appState.version = version;
       appState.packageAuthor = defaultAuthor;
 
-      const result = await getPackageJson(appState as any);
+      const result = await getPackageJson((appState as unknown) as AppState);
       const devDependencies = { [electronPkg]: version };
       expect(result).toEqual(buildExpectedPackage({ name, devDependencies }));
     });

--- a/tests/renderer/utils/position-for-rect-spec.ts
+++ b/tests/renderer/utils/position-for-rect-spec.ts
@@ -20,7 +20,7 @@ describe('position-for-rect', () => {
       it('returns a position on the top right if doable', () => {
         const target = { left: 50, top: 100, width: 175, height: 50 };
         const size = { width: 200, height: 150 };
-        const result = positionForRect(target as any, size);
+        const result = positionForRect(target as ClientRect, size);
 
         expect(result).toEqual({ left: 235, top: 100, type: 'right' });
       });
@@ -30,7 +30,7 @@ describe('position-for-rect', () => {
 
         const target = { left: 400, top: 100, width: 175, height: 50 };
         const size = { width: 200, height: 150 };
-        const result = positionForRect(target as any, size);
+        const result = positionForRect(target as ClientRect, size);
 
         expect(result).toEqual({ left: 190, top: 100, type: 'left' });
       });
@@ -44,7 +44,7 @@ describe('position-for-rect', () => {
       it('returns a position on the top right if doable', () => {
         const target = { left: 50, top: 100, width: 175, height: 50 };
         const size = { width: 200, height: 150 };
-        const result = positionForRect(target as any, size);
+        const result = positionForRect(target as ClientRect, size);
 
         expect(result).toEqual({ left: 235, top: 85, type: 'right' });
       });
@@ -54,7 +54,7 @@ describe('position-for-rect', () => {
 
         const target = { left: 400, top: 100, width: 175, height: 50 };
         const size = { width: 200, height: 150 };
-        const result = positionForRect(target as any, size);
+        const result = positionForRect(target as ClientRect, size);
 
         expect(result).toEqual({ left: 190, top: 85, type: 'left' });
       });
@@ -65,7 +65,7 @@ describe('position-for-rect', () => {
 
       const target = { left: 50, top: 100, width: 500, height: 50 };
       const size = { width: 200, height: 150 };
-      const result = positionForRect(target as any, size);
+      const result = positionForRect(target as ClientRect, size);
 
       expect(result).toEqual({ left: 200, top: 160, type: 'bottom' });
     });
@@ -76,7 +76,7 @@ describe('position-for-rect', () => {
 
       const target = { left: 50, top: 50, width: 700, height: 500 };
       const size = { width: 200, height: 200 };
-      const result = positionForRect(target as any, size);
+      const result = positionForRect(target as ClientRect, size);
 
       expect(result).toEqual({ left: 300, top: 240, type: 'bottom' });
     });

--- a/tests/renderer/utils/sort-versions-spec.ts
+++ b/tests/renderer/utils/sort-versions-spec.ts
@@ -23,7 +23,7 @@ describe('sort-versions', () => {
 
     const sorted = sortVersions([...unsorted]);
 
-    expect(sorted).toStrictEqual<any>([
+    expect(sorted).toStrictEqual([
       makeVersion('v3.0.0'),
       makeVersion('v2.0.0'),
       makeVersion('v1.0.0'),
@@ -47,7 +47,7 @@ describe('sort-versions', () => {
 
     const sorted = sortVersions([...unsorted]);
 
-    expect(sorted).toStrictEqual<any>([
+    expect(sorted).toStrictEqual([
       makeVersion('v3.0.0'),
       makeVersion('v3.0.0-beta.1'),
       makeVersion('v3.0.0-alpha.1'),

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -2,6 +2,7 @@ import {
   ElectronReleaseChannel,
   GlobalSetting,
   RunnableVersion,
+  Version,
   VersionSource,
 } from '../../src/interfaces';
 import {
@@ -23,7 +24,9 @@ describe('versions', () => {
   describe('getDefaultVersion()', () => {
     it('handles a stored version', () => {
       (localStorage.getItem as jest.Mock).mockReturnValue('2.0.2');
-      const output = getDefaultVersion([{ version: '2.0.2' }] as any);
+      const output = getDefaultVersion([
+        { version: '2.0.2' } as RunnableVersion,
+      ]);
       expect(output).toBe('2.0.2');
     });
 
@@ -39,7 +42,7 @@ describe('versions', () => {
         { version: '15.0.0-alpha.1' },
         { version: '12.0.0' },
         { version: '14.0.0-beta.1' },
-      ] as any);
+      ] as RunnableVersion[]);
       expect(output).toBe('13.0.0');
     });
 
@@ -53,7 +56,7 @@ describe('versions', () => {
       expect(
         getReleaseChannel({
           version: 'v4.0.0-nightly.20180817',
-        } as any),
+        } as Version),
       ).toBe(ElectronReleaseChannel.nightly);
     });
 
@@ -61,7 +64,7 @@ describe('versions', () => {
       expect(
         getReleaseChannel({
           version: 'v3.0.0-beta.4',
-        } as any),
+        } as Version),
       ).toBe(ElectronReleaseChannel.beta);
     });
 
@@ -69,12 +72,14 @@ describe('versions', () => {
       expect(
         getReleaseChannel({
           version: 'v3.0.0',
-        } as any),
+        } as Version),
       ).toBe(ElectronReleaseChannel.stable);
     });
 
     it('identifies an unknown release as stable', () => {
-      expect(getReleaseChannel({} as any)).toBe(ElectronReleaseChannel.stable);
+      expect(getReleaseChannel({} as Version)).toBe(
+        ElectronReleaseChannel.stable,
+      );
     });
   });
 
@@ -86,14 +91,14 @@ describe('versions', () => {
     });
 
     it('adds a local version', () => {
-      expect(addLocalVersion(mockVersions[1] as any)).toEqual([
+      expect(addLocalVersion(mockVersions[1] as Version)).toEqual([
         mockVersions[0],
         mockVersions[1],
       ]);
     });
 
     it('does not add duplicates', () => {
-      expect(addLocalVersion(mockVersions[0] as any)).toEqual([
+      expect(addLocalVersion(mockVersions[0] as Version)).toEqual([
         mockVersions[0],
       ]);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": true,
     "removeComments": false,
     "resolveJsonModule": true,
     "preserveConstEnums": true,


### PR DESCRIPTION
Refactoring to use `@observer` instead of `observer(...)` makes typings work properly with `shallow<T>(...)`. I went through and cleaned up all the usage of `any` in the tests to use proper typings, and fixed a few things which fell out as a result.