### PR TITLE
build: add more metadata to Linux packages

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -19,7 +19,9 @@ if (process.env['WINDOWS_CODESIGN_FILE']) {
 }
 
 const commonLinuxConfig = {
+  categories: ['Development', 'Utility'],
   icon: {
+    '1024x1024': path.resolve(iconDir, 'fiddle.png'),
     scalable: path.resolve(iconDir, 'fiddle.svg'),
   },
   mimeType: ['x-scheme-handler/electron-fiddle'],
@@ -137,7 +139,11 @@ const config = {
     {
       name: '@reforged/maker-appimage',
       platforms: ['linux'],
-      config: commonLinuxConfig,
+      config: {
+        options: {
+          categories: commonLinuxConfig.categories,
+        },
+      },
     },
   ],
   publishers: [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.33.0",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
+  "homepage": "https://electronjs.org/fiddle",
   "main": "./.webpack/main",
   "scripts": {
     "contributors": "node ./tools/contributors.js",


### PR DESCRIPTION
* Adds `homepage` to `package.json` so that a website is displayed when installing the `.deb` on Ubuntu
* Adds software categories
* Adds the PNG icon as well as the SVG (not sure it actually gets used anywhere yet, but intend to do follow-up)