### PR TITLE
chore: revert rgba style change

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -5,6 +5,8 @@
     "./src/less/*-vendor.less"
   ],
   "rules": {
+    "alpha-value-notation": null,
+    "color-function-notation": null,
     "import-notation": "string"
   }
 }

--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -25,7 +25,7 @@
 
   .bp3-button:hover,
   .bp3-button.bp3-minimal:hover {
-    background-color: rgb(138 155 168 / 15%);
+    background-color: rgba(138, 155, 168, 0.15);
   }
 
   .bp3-menu-item.bp3-active.bp3-intent-primary {

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -18,7 +18,7 @@ body {
   }
 
   .shadow {
-    box-shadow: 0 4px 8px 0 rgb(0 0 0 / 20%), 0 6px 20px 0 rgb(0 0 0 / 19%);
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   }
 
   .timestamp {
@@ -44,7 +44,7 @@ body {
 
 .resize {
   width: 6px;
-  background: rgb(0 0 0 / 20%);
+  background: rgba(0, 0, 0, 0.2);
   margin-left: 9px;
   margin-right: 0;
   cursor: col-resize;


### PR DESCRIPTION
Reverts the changes to use `rgb(...)` with modern color syntax in #1393, and disables the lint rules. The change wasn't playing nice with the CSS output from the LESS files, and I tried updating a few relevant dependencies but wasn't able to fix it. I'm thinking it might have to do with `@blueprintjs/*`, which we're not going to upgrade any time soon.