### PR TITLE
feat: cancel download all versions option

### DIFF
--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -105,7 +105,7 @@ export const ElectronSettings = observer(
         downloadVersion,
         versionsToShow,
         startDownloadingAll,
-        stopDeletingAll,
+        stopDownloadingAll,
       } = this.props.appState;
 
       startDownloadingAll();
@@ -116,7 +116,7 @@ export const ElectronSettings = observer(
         if (!this.props.appState.isDownloadingAll) break;
       }
 
-      stopDeletingAll();
+      stopDownloadingAll();
     }
 
     /**

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -111,9 +111,9 @@ export const ElectronSettings = observer(
       startDownloadingAll();
 
       for (const ver of versionsToShow) {
-        if (!this.props.appState.isDownloadingAll) break;
-
         await downloadVersion(ver);
+
+        if (!this.props.appState.isDownloadingAll) break;
       }
 
       stopDeletingAll();

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -598,6 +598,7 @@ export class AppState {
 
     this.isUpdatingElectronVersions = false;
   }
+
   public startDownloadingAll() {
     this.isDownloadingAll = true;
   }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -186,6 +186,8 @@ export class AppState {
   public isTokenDialogShowing = false;
   public isTourShowing = !localStorage.getItem(GlobalSetting.hasShownTour);
   public isUpdatingElectronVersions = false;
+  public isDownloadingAll = false;
+  public isDeletingAll = false;
 
   // -- Editor Values stored when we close the editor ------------------
   private outputBuffer = '';
@@ -256,6 +258,8 @@ export class AppState {
       isTokenDialogShowing: observable,
       isTourShowing: observable,
       isUpdatingElectronVersions: observable,
+      isDeletingAll: observable,
+      isDownloadingAll: observable,
       isUsingSystemTheme: observable,
       localPath: observable,
       modules: observable,
@@ -296,6 +300,10 @@ export class AppState {
       versions: observable,
       versionsToShow: computed,
       changeRunnableState: action,
+      startDownloadingAll: action,
+      stopDownloadingAll: action,
+      startDeletingAll: action,
+      stopDeletingAll: action,
     });
 
     // Bind all actions
@@ -322,6 +330,10 @@ export class AppState {
     this.hideChannels = this.hideChannels.bind(this);
     this.showChannels = this.showChannels.bind(this);
     this.changeRunnableState = this.changeRunnableState.bind(this);
+    this.startDownloadingAll = this.startDownloadingAll.bind(this);
+    this.stopDownloadingAll = this.stopDownloadingAll.bind(this);
+    this.startDeletingAll = this.startDeletingAll.bind(this);
+    this.stopDeletingAll = this.stopDeletingAll.bind(this);
 
     // Populating the current state of every version present
     versions.forEach((ver: RunnableVersion) => {
@@ -585,6 +597,21 @@ export class AppState {
     }
 
     this.isUpdatingElectronVersions = false;
+  }
+  public startDownloadingAll() {
+    this.isDownloadingAll = true;
+  }
+
+  public stopDownloadingAll() {
+    this.isDownloadingAll = false;
+  }
+
+  public startDeletingAll() {
+    this.isDeletingAll = true;
+  }
+
+  public stopDeletingAll() {
+    this.isDeletingAll = false;
   }
 
   public async getName() {

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -59,6 +59,8 @@ export class StateMock {
   public packageAuthor = 'electron<electron@electron.org>';
   public electronMirror = ELECTRON_MIRROR;
   public isBisectCommandShowing = false;
+  public isDownloadingAll = false;
+  public isDeletingAll = false;
 
   public Bisector: BisectorMock | undefined = new BisectorMock();
   public addAcceleratorToBlock = jest.fn();
@@ -103,6 +105,10 @@ export class StateMock {
   public toggleAuthDialog = jest.fn();
   public toggleSettings = jest.fn();
   public updateElectronVersions = jest.fn();
+  public startDownloadingAll = jest.fn();
+  public stopDownloadingAll = jest.fn();
+  public startDeletingAll = jest.fn();
+  public stopDeletingAll = jest.fn();
   public installer = new InstallerMock();
   public versionRunner = new FiddleRunnerMock();
 
@@ -152,6 +158,8 @@ export class StateMock {
       packageAuthor: observable,
       electronMirror: observable,
       isBisectCommandShowing: observable,
+      isDeletingAll: observable,
+      isDownloadingAll: observable,
     });
 
     const { mockVersions: obj, mockVersionsArray: arr } = new VersionsMock();

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -93,6 +93,12 @@ export class StateMock {
     const { mockVersionsArray } = new VersionsMock();
     return { ver: this.versions[mockVersionsArray[0].version] };
   });
+  public startDownloadingAll = jest.fn().mockImplementation(() => {
+    this.isDownloadingAll = true;
+  });
+  public stopDownloadingAll = jest.fn().mockImplementation(() => {
+    this.isDownloadingAll = false;
+  });
   public showChannels = jest.fn();
   public showConfirmDialog = jest.fn();
   public showErrorDialog = jest.fn();
@@ -105,8 +111,6 @@ export class StateMock {
   public toggleAuthDialog = jest.fn();
   public toggleSettings = jest.fn();
   public updateElectronVersions = jest.fn();
-  public startDownloadingAll = jest.fn();
-  public stopDownloadingAll = jest.fn();
   public startDeletingAll = jest.fn();
   public stopDeletingAll = jest.fn();
   public installer = new InstallerMock();

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -158,7 +158,7 @@ describe('ElectronSettings component', () => {
     expect(store.downloadVersion).toHaveBeenCalled();
   });
 
-  it('handles the downloadAll() during stop downloads', async () => {
+  it('handles the downloadAll() during stopDownloadingAll()', async () => {
     const versionsToShowCount = store.versionsToShow.length;
     const downloadCount = 2;
 
@@ -174,24 +174,24 @@ describe('ElectronSettings component', () => {
     // Initiate download for all versions
     instance.handleDownloadAll();
 
-    // Count starts from 1 because stopDownload condition is checked after each download not before
-    let completedDownloads = 1;
+    // Count starts from 1 because the stopDownload condition is checked after each download, not before
+    let completedDownloadCount = 1;
 
     // Wait for downloads to complete
-    while (completedDownloads < versionsToShowCount - downloadCount) {
+    while (completedDownloadCount < versionsToShowCount - downloadCount) {
       await downloadPromise;
-      completedDownloads++;
+      completedDownloadCount++;
     }
 
     // Stop downloads
     await instance.handleStopDownloads();
 
-    // Assertions
+    // Stops downloading more versions
     expect(store.stopDownloadingAll).toHaveBeenCalled();
     expect(store.downloadVersion).not.toHaveBeenCalledTimes(
       versionsToShowCount,
     );
-    expect(store.downloadVersion).not.toHaveBeenCalledTimes(downloadCount);
+    expect(store.downloadVersion).toHaveBeenCalledTimes(completedDownloadCount);
   });
 
   describe('handleUpdateElectronVersions()', () => {

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -163,7 +163,6 @@ describe('ElectronSettings component', () => {
 
   it('handles the downloadAll() during stopDownloadingAll()', async () => {
     const versionsToShowCount = store.versionsToShow.length;
-    const downloadCount = 2;
 
     // Set up download promise
     const downloadPromise = new Promise((resolve) => setTimeout(resolve, 50));
@@ -180,8 +179,8 @@ describe('ElectronSettings component', () => {
     // Count starts from 1 because the stopDownload condition is checked after each download, not before
     let completedDownloadCount = 1;
 
-    // Wait for downloads to complete
-    while (completedDownloadCount < versionsToShowCount - downloadCount) {
+    // Wait for some downloads to complete
+    while (completedDownloadCount < versionsToShowCount - 2) {
       await downloadPromise;
       completedDownloadCount++;
     }

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -149,6 +149,9 @@ describe('ElectronSettings component', () => {
   });
 
   it('handles the downloadAll()', async () => {
+    store.startDownloadingAll.mockImplementation(
+      () => (store.isDownloadingAll = true),
+    );
     const wrapper = shallow(
       <ElectronSettings appState={(store as unknown) as AppState} />,
     );

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -156,6 +156,9 @@ describe('ElectronSettings component', () => {
     await instance.handleDownloadAll();
 
     expect(store.downloadVersion).toHaveBeenCalled();
+    expect(store.downloadVersion).toHaveBeenCalledTimes(
+      store.versionsToShow.length,
+    );
   });
 
   it('handles the downloadAll() during stopDownloadingAll()', async () => {

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -149,9 +149,6 @@ describe('ElectronSettings component', () => {
   });
 
   it('handles the downloadAll()', async () => {
-    store.startDownloadingAll.mockImplementation(
-      () => (store.isDownloadingAll = true),
-    );
     const wrapper = shallow(
       <ElectronSettings appState={(store as unknown) as AppState} />,
     );

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -743,4 +743,60 @@ describe('AppState', () => {
       expect(actual).toBe(expected);
     });
   });
+
+  describe('startDownloadingAll()', () => {
+    it('change isDownloadingAll to true when false', () => {
+      appState.isDownloadingAll = false;
+      appState.startDownloadingAll();
+      expect(appState.isDownloadingAll).toBe(true);
+    });
+
+    it('takes no action when isDownloadingAll is true', () => {
+      appState.isDownloadingAll = true;
+      appState.startDownloadingAll();
+      expect(appState.isDownloadingAll).toBe(true);
+    });
+  });
+
+  describe('stopDownloadingAll()', () => {
+    it('change isDownloadingAll to false when true', () => {
+      appState.isDownloadingAll = true;
+      appState.stopDownloadingAll();
+      expect(appState.isDownloadingAll).toBe(false);
+    });
+
+    it('takes no action when isDownloadingAll is false', () => {
+      appState.isDownloadingAll = false;
+      appState.stopDownloadingAll();
+      expect(appState.isDownloadingAll).toBe(false);
+    });
+  });
+
+  describe('startDeletingAll()', () => {
+    it('change isDeletingAll to true when false', () => {
+      appState.isDeletingAll = false;
+      appState.startDeletingAll();
+      expect(appState.isDeletingAll).toBe(true);
+    });
+
+    it('takes no action when isDeletingAll is true', () => {
+      appState.isDeletingAll = true;
+      appState.startDeletingAll();
+      expect(appState.isDeletingAll).toBe(true);
+    });
+  });
+
+  describe('stopDeletingAll()', () => {
+    it('change isDeletingAll to false when true', () => {
+      appState.isDeletingAll = true;
+      appState.stopDeletingAll();
+      expect(appState.isDeletingAll).toBe(false);
+    });
+
+    it('takes no action when isDeletingAll is false', () => {
+      appState.isDeletingAll = false;
+      appState.stopDeletingAll();
+      expect(appState.isDeletingAll).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description of your changes
Currently, if we click "Download All Versions" there's no way to cancel that, which is pretty bad since that can be hundreds of downloads. The only way to cancel is to quit the app.

 Introduced a `Stop Downloads` button in place of the `Download All Versions` button during download. Moved `isDownloadingAll` & `isDeletingAll` inside `AppState`. Did all of these according to the #1402 description. Some tests were failing because of these updates. Fixed the tests & also added new tests to cater to the changes.
 
 Please let me know if I need any updates to the code. 

### Before (When clicked `Download All Versions`)
![before](https://github.com/electron/fiddle/assets/12469224/24caeadf-b064-4a86-b7fe-25094a8dfd1e)


### After (When clicked `Download All Versions`)
![after](https://github.com/electron/fiddle/assets/12469224/3dcce7f6-95f4-4c1b-8b5a-3c2a96444378)


### Related issues

Closes #1402 



