### PR TITLE
fix: better handle env variables and execution flags settings changes

### DIFF
--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -77,15 +77,6 @@ export const ExecutionSettings = observer(
       }
     }
 
-    public componentDidUpdate() {
-      const { appState } = this.props;
-
-      for (const type of Object.values(SettingItemType)) {
-        const values = Object.values(this.state[type]);
-        appState[type] = values.filter((v) => v !== '');
-      }
-    }
-
     /**
      * Handles a change on whether or not the user data dir should be deleted
      * after a run.
@@ -122,12 +113,18 @@ export const ExecutionSettings = observer(
     ) {
       const { name, value } = event.currentTarget;
 
-      this.setState((prevState) => ({
-        [type]: {
-          ...prevState[type],
-          [name]: value,
+      this.setState(
+        (prevState) => ({
+          [type]: {
+            ...prevState[type],
+            [name]: value,
+          },
+        }),
+        () => {
+          const values = Object.values(this.state[type]);
+          this.props.appState[type] = values.filter((v) => v !== '');
         },
-      }));
+      );
     }
 
     /**
@@ -169,7 +166,10 @@ export const ExecutionSettings = observer(
           delete updated[idx];
         }
 
-        this.setState({ [type]: updated });
+        this.setState({ [type]: updated }, () => {
+          const values = Object.values(this.state[type]);
+          this.props.appState[type] = values.filter((v) => v !== '');
+        });
       };
 
       return (


### PR DESCRIPTION
The execution settings panel broke as a result of #1389. Making `SettingItemType` a proper enum broke the code which iterates over the values, as TypeScript is now creating a reverse mapping as well, which means `Object.values` was returning keys as well.

Refactored so that iterating the enum values is not necessary, and probably a bit better implementation as a result. It's still kind of funky how this state is stored on both `AppState` and `ExecutionSettingsState`, but this fixes the immediate breakage.