### PR TITLE
fix: added fiddle-scrollbar to resize titlebar responsively

### DIFF
--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -42,8 +42,8 @@ export const Commands = observer(
         <div
           className={
             window.ElectronFiddle.platform === 'darwin'
-              ? 'commands is-mac'
-              : 'commands'
+              ? 'commands is-mac fiddle-scrollbar'
+              : 'commands fiddle-scrollbar'
           }
           onDoubleClick={this.handleDoubleClick}
         >


### PR DESCRIPTION
This fixes #1274
application resized horizontally to smaller screen size
![#1274-fix-screenshot1](https://github.com/electron/fiddle/assets/34007531/b210bd0f-f54e-4fcb-95ff-da4f96157e65)

application resized horizontally to larger screen size
![#1274-fix-screenshot2](https://github.com/electron/fiddle/assets/34007531/e191e0c8-0b3e-42b7-958c-74509761e7e3)
