### PR TITLE
ci: use Node.js v18.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,8 @@ commands:
           # https://github.com/coreybutler/nvm-windows/releases/tag/1.1.10
           # This is the file to check:
           # https://github.com/CircleCI-Public/ansible/blob/main/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml#L13
-          #
-          # TODO: bump to 18.16 (LTS) when https://github.com/nodejs/node/issues/47563 lands
-          node-version: '18.15.0'
-      - run: nvm use 18.15.0
+          node-version: '18.17.0'
+      - run: nvm use 18.17.0
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
Clears TODO where we couldn't use Node.js v18.16.x due to an upstream bug with Docker containers.