### PR TITLE
test: improve typing with mocks

### DIFF
--- a/rtl-spec/commands-bisect.spec.tsx
+++ b/rtl-spec/commands-bisect.spec.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { mocked } from 'jest-mock';
 
-import { InstallState } from '../src/interfaces';
+import { InstallState, VersionSource } from '../src/interfaces';
 import { BisectHandler } from '../src/renderer/components/commands-bisect';
 import { AppState } from '../src/renderer/state';
 
@@ -59,8 +60,10 @@ describe('Bisect commands component', () => {
       });
       // the bisector returns the next version to inspect
       // when continuing the bisect process
-      (store.Bisector!.continue as jest.Mock).mockReturnValueOnce({
+      mocked(store.Bisector!.continue).mockReturnValueOnce({
         version: 'v10.0.0',
+        source: VersionSource.remote,
+        state: InstallState.downloaded,
       });
       await user.click(goodButton);
       expect(store.Bisector).toBeTruthy();
@@ -76,11 +79,17 @@ describe('Bisect commands component', () => {
     });
     // the bisector returns a tuple of two values when
     // the bisect is terminated
-    (store.Bisector!.continue as jest.Mock).mockReturnValueOnce([
+    mocked(store.Bisector!.continue).mockReturnValueOnce([
       {
         version: 'v10.0.0',
+        source: VersionSource.remote,
+        state: InstallState.downloaded,
       },
-      { version: 'v10.0.2' },
+      {
+        version: 'v10.0.2',
+        source: VersionSource.remote,
+        state: InstallState.downloaded,
+      },
     ]);
     await user.click(goodButton);
     expect(store.Bisector).toBeUndefined();

--- a/tests/main/command-line-spec.ts
+++ b/tests/main/command-line-spec.ts
@@ -1,3 +1,4 @@
+import { mocked } from 'jest-mock';
 // use a stable-sorting stringify for comparing expected & actual payloads
 import stringify from 'json-stable-stringify';
 
@@ -44,14 +45,14 @@ describe('processCommandLine()', () => {
   });
 
   function expectSendCalledOnceWith(event: IpcEvents, payload: string) {
-    const send = ipcMainManager.send as jest.Mock;
+    const send = mocked(ipcMainManager.send);
     expect(send).toHaveBeenCalledTimes(1);
     const [call] = send.mock.calls;
     expect(call.length).toEqual(2);
     const [ev, params] = call;
     expect(ev).toBe(event);
-    expect(params.length).toBe(1);
-    const [request] = params;
+    expect(params?.length).toBe(1);
+    const [request] = params!;
     expect(stringify(request).replace(/\\\\/g, '\\')).toBe(payload);
   }
 
@@ -205,7 +206,7 @@ describe('processCommandLine()', () => {
     describe(`watches for ${IpcEvents.TASK_DONE} events`, () => {
       async function expectDoneCausesExit(result: RunResult, exitCode: number) {
         const argv = [...ARGV, GOOD, BAD];
-        (ipcMainManager.send as jest.Mock).mockImplementationOnce(() => {
+        mocked(ipcMainManager.send).mockImplementationOnce(() => {
           const fakeEvent = {};
           ipcMainManager.emit(IpcEvents.TASK_DONE, fakeEvent, result);
         });
@@ -235,7 +236,7 @@ describe('processCommandLine()', () => {
 
         const fakeEvent = {};
         const entry: OutputEntry = { text, timeString };
-        (ipcMainManager.send as jest.Mock).mockImplementationOnce(() => {
+        mocked(ipcMainManager.send).mockImplementationOnce(() => {
           ipcMainManager.emit(IpcEvents.OUTPUT_ENTRY, fakeEvent, entry);
         });
 

--- a/tests/main/content-spec.ts
+++ b/tests/main/content-spec.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { Response, fetch } from 'cross-fetch';
 import { app } from 'electron';
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 import * as tmp from 'tmp';
 
 let fakeUserData: tmp.DirResult | null;
@@ -55,7 +56,7 @@ describe('content', () => {
   const VERSION_NOT_IN_FIXTURES = '10.0.0';
 
   beforeAll(() => {
-    (app.getPath as jest.Mock).mockImplementation((name: string) => {
+    mocked(app.getPath).mockImplementation((name: string) => {
       if (name === 'userData') {
         // set it to be a newly-allocated tmpdir
         if (!fakeUserData) {
@@ -66,6 +67,8 @@ describe('content', () => {
           });
         }
       }
+
+      return '';
     });
   });
 
@@ -78,11 +81,11 @@ describe('content', () => {
 
   describe('getTestTemplate()', () => {
     beforeEach(() => {
-      (fetch as jest.Mock).mockImplementation(fetchFromFilesystem);
+      mocked(fetch).mockImplementation(fetchFromFilesystem);
     });
 
     afterEach(() => {
-      (fetch as jest.Mock).mockClear();
+      mocked(fetch).mockClear();
     });
 
     it('loads a test template', async () => {
@@ -96,10 +99,10 @@ describe('content', () => {
 
   describe('getTemplate()', () => {
     beforeEach(() => {
-      (fetch as jest.Mock).mockImplementation(fetchFromFilesystem);
+      mocked(fetch).mockImplementation(fetchFromFilesystem);
     });
     afterEach(() => {
-      (fetch as jest.Mock).mockClear();
+      mocked(fetch).mockClear();
     });
 
     it('returns the same promise if the work is already pending', async () => {
@@ -143,7 +146,7 @@ describe('content', () => {
     });
 
     it('returns the same promise if the work is already pending', async () => {
-      (isReleasedMajor as jest.Mock).mockReturnValue(true);
+      mocked(isReleasedMajor).mockReturnValue(true);
       const version = VERSION_IN_FIXTURES;
       const a = getTemplate(version);
       const b = getTemplate(version);

--- a/tests/main/context-menu-spec.ts
+++ b/tests/main/context-menu-spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { BrowserWindow, ContextMenuParams, Menu } from 'electron';
+import { mocked } from 'jest-mock';
 
 import {
   createContextMenu,
@@ -43,10 +44,10 @@ describe('context-menu', () => {
     });
 
     it('creates a default context-menu with inspect for dev mode', () => {
-      (Menu.buildFromTemplate as jest.Mock).mockReturnValue({
+      mocked(Menu.buildFromTemplate).mockReturnValue({
         popup: jest.fn(),
-      });
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      } as Partial<Menu> as Menu);
+      mocked(isDevMode).mockReturnValueOnce(true);
 
       mockWindow.webContents.emit('context-menu', null, mockFlags);
 
@@ -64,22 +65,22 @@ describe('context-menu', () => {
     });
 
     it('creates a default context-menu without inspect in production', () => {
-      (Menu.buildFromTemplate as jest.Mock).mockReturnValue({
+      mocked(Menu.buildFromTemplate).mockReturnValue({
         popup: jest.fn(),
-      });
-      (isDevMode as jest.Mock).mockReturnValueOnce(false);
+      } as Partial<Menu> as Menu);
+      mocked(isDevMode).mockReturnValueOnce(false);
 
       mockWindow.webContents.emit('context-menu', null, mockFlags);
-      const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+      const template = mocked(Menu.buildFromTemplate).mock.calls[0][0];
 
       expect(template).toHaveLength(7);
     });
 
     it('disables cut/copy/paste if not in editFlags', () => {
-      (Menu.buildFromTemplate as jest.Mock).mockReturnValue({
+      mocked(Menu.buildFromTemplate).mockReturnValue({
         popup: jest.fn(),
-      });
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      } as Partial<Menu> as Menu);
+      mocked(isDevMode).mockReturnValueOnce(true);
 
       mockWindow.webContents.emit('context-menu', null, mockFlags);
 
@@ -98,10 +99,10 @@ describe('context-menu', () => {
     });
 
     it('enables cut/copy/paste if in editFlags', () => {
-      (Menu.buildFromTemplate as jest.Mock).mockReturnValue({
+      mocked(Menu.buildFromTemplate).mockReturnValue({
         popup: jest.fn(),
-      });
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      } as Partial<Menu> as Menu);
+      mocked(isDevMode).mockReturnValueOnce(true);
 
       mockWindow.webContents.emit('context-menu', null, {
         ...mockFlags,
@@ -129,19 +130,19 @@ describe('context-menu', () => {
 
   describe('getInspectItems()', () => {
     it('returns an empty array if not in devMode', () => {
-      (isDevMode as jest.Mock).mockReturnValueOnce(false);
+      mocked(isDevMode).mockReturnValueOnce(false);
       const result = getInspectItems(mockWindow, {} as ContextMenuParams);
       expect(result).toHaveLength(0);
     });
 
     it('returns an inspect item if in devMode', () => {
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      mocked(isDevMode).mockReturnValueOnce(true);
       const result = getInspectItems(mockWindow, {} as ContextMenuParams);
       expect(result).toHaveLength(1);
     });
 
     it('inspects on click', () => {
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      mocked(isDevMode).mockReturnValueOnce(true);
       const result = getInspectItems(mockWindow, {
         x: 5,
         y: 10,
@@ -152,37 +153,33 @@ describe('context-menu', () => {
     });
 
     it('focuses the dev tools if already open', () => {
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      mocked(isDevMode).mockReturnValueOnce(true);
       const result = getInspectItems(mockWindow, {
         x: 5,
         y: 10,
       } as ContextMenuParams);
-      (
-        mockWindow.webContents.isDevToolsOpened as jest.Mock
-      ).mockReturnValueOnce(true);
+      mocked(mockWindow.webContents.isDevToolsOpened).mockReturnValueOnce(true);
       (mockWindow.webContents as any).devToolsWebContents =
         new WebContentsMock();
 
       (result[0] as any).click();
       expect(mockWindow.webContents.inspectElement).toHaveBeenCalled();
       expect(
-        mockWindow.webContents.devToolsWebContents!.focus as jest.Mock,
+        mockWindow.webContents.devToolsWebContents!.focus,
       ).toHaveBeenCalled();
     });
 
     it('catches an error', () => {
-      (isDevMode as jest.Mock).mockReturnValueOnce(true);
+      mocked(isDevMode).mockReturnValueOnce(true);
       const result = getInspectItems(mockWindow, {
         x: 5,
         y: 10,
       } as ContextMenuParams);
-      (
-        mockWindow.webContents.isDevToolsOpened as jest.Mock
-      ).mockReturnValueOnce(true);
+      mocked(mockWindow.webContents.isDevToolsOpened).mockReturnValueOnce(true);
       (mockWindow.webContents as any).devToolsWebContents =
         new WebContentsMock();
-      (
-        mockWindow.webContents.devToolsWebContents!.focus as jest.Mock
+      mocked(
+        mockWindow.webContents.devToolsWebContents!.focus,
       ).mockImplementationOnce(() => {
         throw new Error('💩');
       });

--- a/tests/main/devtools-spec.ts
+++ b/tests/main/devtools-spec.ts
@@ -2,6 +2,8 @@
  * @jest-environment node
  */
 
+import { mocked } from 'jest-mock';
+
 import { setupDevTools } from '../../src/main/devtools';
 import { isDevMode } from '../../src/main/utils/devmode';
 
@@ -16,7 +18,7 @@ jest.mock('electron-devtools-installer', () => ({
 describe('devtools', () => {
   it('does not set up developer tools if not in dev mode', () => {
     const devtools = require('electron-devtools-installer');
-    (isDevMode as jest.Mock).mockReturnValue(false);
+    mocked(isDevMode).mockReturnValue(false);
     setupDevTools();
 
     expect(devtools.default).toHaveBeenCalledTimes(0);
@@ -24,7 +26,7 @@ describe('devtools', () => {
 
   it('sets up developer tools if in dev mode', () => {
     const devtools = require('electron-devtools-installer');
-    (isDevMode as jest.Mock).mockReturnValue(true);
+    mocked(isDevMode).mockReturnValue(true);
     setupDevTools();
 
     expect(devtools.default).toHaveBeenCalledTimes(1);
@@ -34,7 +36,7 @@ describe('devtools', () => {
     const devtools = require('electron-devtools-installer');
     // throw devtool error
     devtools.default.mockRejectedValue(new Error('devtool error'));
-    (isDevMode as jest.Mock).mockReturnValue(true);
+    mocked(isDevMode).mockReturnValue(true);
 
     try {
       await setupDevTools();

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -31,10 +31,13 @@ const mockTarget = {
 
 describe('files', () => {
   beforeEach(() => {
-    (dialog.showOpenDialog as jest.Mock).mockResolvedValue({
+    mocked(dialog.showOpenDialog).mockResolvedValue({
       filePaths: ['my/fake/path'],
+      canceled: false,
     });
-    (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+    mocked(getOrCreateMainWindow).mockReturnValue(
+      mockTarget as Partial<Electron.BrowserWindow> as Electron.BrowserWindow,
+    );
 
     ipcMainManager.readyWebContents.add(mockTarget.webContents);
   });
@@ -63,7 +66,9 @@ describe('files', () => {
     });
 
     it('notifies the main window of the event', async () => {
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+      mocked(getOrCreateMainWindow).mockReturnValue(
+        mockTarget as Partial<Electron.BrowserWindow> as Electron.BrowserWindow,
+      );
 
       await showOpenDialog();
 
@@ -98,20 +103,20 @@ describe('files', () => {
     });
 
     it('handles not getting a path returned', async () => {
-      (dialog.showOpenDialogSync as jest.Mock).mockReturnValueOnce([]);
+      mocked(dialog.showOpenDialogSync).mockReturnValueOnce([]);
       await showSaveDialog();
       expect(fs.pathExists).toHaveBeenCalledTimes(0);
     });
 
     it('ensures that the target is empty on save', async () => {
       const consent = true;
-      (dialog.showOpenDialogSync as jest.Mock).mockReturnValue(['path']);
+      mocked(dialog.showOpenDialogSync).mockReturnValue(['path']);
       mocked(dialog.showMessageBox).mockResolvedValue({
         response: consent ? 1 : 0,
         checkboxChecked: false,
       });
-      (fs.pathExists as jest.Mock).mockReturnValue(true);
-      (fs.readdir as jest.Mock).mockReturnValue([MAIN_JS]);
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+      (fs.readdir as jest.Mock).mockResolvedValue([MAIN_JS]);
       ipcMainManager.readyWebContents.add(mockTarget.webContents);
 
       await showSaveDialog();
@@ -122,14 +127,16 @@ describe('files', () => {
 
     it('does not overwrite files without consent', async () => {
       const consent = false;
-      (dialog.showOpenDialogSync as jest.Mock).mockReturnValue(['path']);
+      mocked(dialog.showOpenDialogSync).mockReturnValue(['path']);
       mocked(dialog.showMessageBox).mockResolvedValue({
         response: consent ? 1 : 0,
         checkboxChecked: false,
       });
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
-      (fs.pathExists as jest.Mock).mockReturnValue(true);
-      (fs.readdir as jest.Mock).mockReturnValue([MAIN_JS]);
+      mocked(getOrCreateMainWindow).mockReturnValue(
+        mockTarget as Partial<Electron.BrowserWindow> as Electron.BrowserWindow,
+      );
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+      (fs.readdir as jest.Mock).mockResolvedValue([MAIN_JS]);
 
       await showSaveDialog();
 
@@ -139,11 +146,13 @@ describe('files', () => {
 
     it('does not overwrite files if an error happens', async () => {
       const err = new Error('💩');
-      (dialog.showOpenDialogSync as jest.Mock).mockReturnValue(['path']);
-      (dialog.showMessageBox as jest.Mock).mockRejectedValue(err);
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
-      (fs.pathExists as jest.Mock).mockReturnValue(true);
-      (fs.readdir as jest.Mock).mockReturnValue([MAIN_JS]);
+      mocked(dialog.showOpenDialogSync).mockReturnValue(['path']);
+      mocked(dialog.showMessageBox).mockRejectedValue(err);
+      mocked(getOrCreateMainWindow).mockReturnValue(
+        mockTarget as Partial<Electron.BrowserWindow> as Electron.BrowserWindow,
+      );
+      (fs.pathExists as jest.Mock).mockResolvedValue(true);
+      (fs.readdir as jest.Mock).mockResolvedValue([MAIN_JS]);
 
       let caughtError: unknown;
       try {

--- a/tests/main/first-run-spec.ts
+++ b/tests/main/first-run-spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { app, dialog } from 'electron';
+import { mocked } from 'jest-mock';
 
 import { onFirstRunMaybe } from '../../src/main/first-run';
 import { isFirstRun } from '../../src/main/utils/check-first-run';
@@ -14,6 +15,7 @@ jest.mock('../../src/main/utils/check-first-run', () => ({
 
 const mockDialogResponse = {
   response: 1,
+  checkboxChecked: false,
 };
 
 describe('first-run', () => {
@@ -22,7 +24,7 @@ describe('first-run', () => {
   beforeEach(() => {
     overridePlatform('darwin');
 
-    (dialog.showMessageBox as jest.Mock).mockResolvedValue(mockDialogResponse);
+    mocked(dialog.showMessageBox).mockResolvedValue(mockDialogResponse);
   });
 
   afterEach(() => {
@@ -40,8 +42,8 @@ describe('first-run', () => {
     });
 
     it(`doesn't run unless required (is already in app folder)`, () => {
-      (isFirstRun as jest.Mock).mockReturnValueOnce(true);
-      (app.isInApplicationsFolder as jest.Mock).mockReturnValue(true);
+      mocked(isFirstRun).mockReturnValueOnce(true);
+      mocked(app.isInApplicationsFolder).mockReturnValue(true);
 
       onFirstRunMaybe();
 
@@ -49,9 +51,9 @@ describe('first-run', () => {
     });
 
     it(`doesn't run unless required (dev mode)`, () => {
-      (isFirstRun as jest.Mock).mockReturnValueOnce(true);
+      mocked(isFirstRun).mockReturnValueOnce(true);
       (process as any).defaultApp = true;
-      (app.isInApplicationsFolder as jest.Mock).mockReturnValue(false);
+      mocked(app.isInApplicationsFolder).mockReturnValue(false);
 
       onFirstRunMaybe();
 
@@ -61,8 +63,8 @@ describe('first-run', () => {
     it(`doesn't run unless required (Windows, Linux)`, () => {
       overridePlatform('win32');
 
-      (isFirstRun as jest.Mock).mockReturnValueOnce(true);
-      (app.isInApplicationsFolder as jest.Mock).mockReturnValue(false);
+      mocked(isFirstRun).mockReturnValueOnce(true);
+      mocked(app.isInApplicationsFolder).mockReturnValue(false);
 
       onFirstRunMaybe();
 
@@ -70,8 +72,8 @@ describe('first-run', () => {
     });
 
     it(`moves the app when requested to do so`, async () => {
-      (isFirstRun as jest.Mock).mockReturnValue(true);
-      (app.isInApplicationsFolder as jest.Mock).mockReturnValue(false);
+      mocked(isFirstRun).mockReturnValue(true);
+      mocked(app.isInApplicationsFolder).mockReturnValue(false);
 
       mockDialogResponse.response = 1;
       await onFirstRunMaybe();

--- a/tests/main/ipc-spec.ts
+++ b/tests/main/ipc-spec.ts
@@ -3,6 +3,7 @@
  */
 
 import * as electron from 'electron';
+import { mocked } from 'jest-mock';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { ipcMainManager } from '../../src/main/ipc';
@@ -32,9 +33,9 @@ describe('IpcMainManager', () => {
           send: jest.fn(),
           isDestroyed: () => false,
         } as unknown as Electron.WebContents,
-      };
+      } as electron.BrowserWindow;
 
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(mockTarget);
+      mocked(getOrCreateMainWindow).mockReturnValue(mockTarget);
       ipcMainManager.readyWebContents.add(mockTarget.webContents);
 
       ipcMainManager.send(IpcEvents.FIDDLE_RUN);
@@ -50,7 +51,7 @@ describe('IpcMainManager', () => {
         isDestroyed: () => false,
       } as unknown as Electron.WebContents;
 
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(null);
+      mocked(getOrCreateMainWindow).mockReturnValue(null as any);
       ipcMainManager.readyWebContents.add(mockTarget);
 
       ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget);
@@ -63,7 +64,7 @@ describe('IpcMainManager', () => {
         send: jest.fn(),
       } as unknown as Electron.WebContents;
 
-      (getOrCreateMainWindow as jest.Mock).mockReturnValue(null);
+      mocked(getOrCreateMainWindow).mockReturnValue(null as any);
 
       ipcMainManager.send(IpcEvents.FIDDLE_RUN, undefined, mockTarget);
 

--- a/tests/main/main-spec.ts
+++ b/tests/main/main-spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { BrowserWindow, app, systemPreferences } from 'electron';
+import { mocked } from 'jest-mock';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { setupAboutPanel } from '../../src/main/about-panel';
@@ -56,12 +57,12 @@ describe('main', () => {
   });
 
   beforeEach(() => {
-    (app.getPath as jest.Mock).mockImplementation((name) => name);
+    mocked(app.getPath).mockImplementation((name) => name);
   });
 
   describe('main()', () => {
     it('quits during Squirrel events', () => {
-      (shouldQuit as jest.Mock).mockReturnValueOnce(true);
+      mocked(shouldQuit).mockReturnValueOnce(true);
 
       main([]);
       expect(app.quit).toHaveBeenCalledTimes(1);
@@ -125,18 +126,19 @@ describe('main', () => {
       // Since ipcMainManager is mocked, we can't just .emit to trigger
       // the event. Instead, call the callback as soon as the listener
       // is instantiated.
-      (ipcMainManager.on as jest.Mock).mockImplementationOnce(
-        (channel, callback) => {
-          if (channel === IpcEvents.SHOW_WINDOW) {
-            callback({});
-          }
-        },
-      );
+      mocked(ipcMainManager.on).mockImplementationOnce((channel, callback) => {
+        if (channel === IpcEvents.SHOW_WINDOW) {
+          callback({});
+        }
+        return ipcMainManager;
+      });
     });
 
     it('shows the window', () => {
       const mockWindow = new BrowserWindowMock();
-      (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(mockWindow);
+      mocked(BrowserWindow.fromWebContents).mockReturnValue(
+        mockWindow as unknown as BrowserWindow,
+      );
       setupShowWindow();
       expect(mockWindow.show).toHaveBeenCalled();
     });
@@ -156,23 +158,20 @@ describe('main', () => {
         // Since ipcMainManager is mocked, we can't just .emit to trigger
         // the event. Instead, call the callback as soon as the listener
         // is instantiated.
-        (ipcMainManager.on as jest.Mock).mockImplementationOnce(
+        mocked(ipcMainManager.on).mockImplementationOnce(
           (channel, callback) => {
             if (channel === IpcEvents.CLICK_TITLEBAR_MAC) {
               callback({});
             }
+            return ipcMainManager;
           },
         );
       });
 
       it('should minimize the window if AppleActionOnDoubleClick is minimize', () => {
-        const mockWindow = new BrowserWindowMock();
-        (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(
-          mockWindow,
-        );
-        (systemPreferences.getUserDefault as jest.Mock).mockReturnValue(
-          'Minimize',
-        );
+        const mockWindow = new BrowserWindowMock() as unknown as BrowserWindow;
+        mocked(BrowserWindow.fromWebContents).mockReturnValue(mockWindow);
+        mocked(systemPreferences.getUserDefault).mockReturnValue('Minimize');
 
         setupTitleBarClickMac();
 
@@ -183,13 +182,11 @@ describe('main', () => {
 
       it('should maximize the window if AppleActionOnDoubleClick is maximize and the window is not maximized', () => {
         const mockWindow = new BrowserWindowMock();
-        mockWindow.isMaximized.mockReturnValue(false);
-        (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(
-          mockWindow,
+        mocked(mockWindow.isMaximized).mockReturnValue(false);
+        mocked(BrowserWindow.fromWebContents).mockReturnValue(
+          mockWindow as unknown as BrowserWindow,
         );
-        (systemPreferences.getUserDefault as jest.Mock).mockReturnValue(
-          'Maximize',
-        );
+        mocked(systemPreferences.getUserDefault).mockReturnValue('Maximize');
 
         setupTitleBarClickMac();
 
@@ -201,12 +198,10 @@ describe('main', () => {
       it('should unmaximize the window if AppleActionOnDoubleClick is maximize and the window is maximized', () => {
         const mockWindow = new BrowserWindowMock();
         mockWindow.isMaximized.mockReturnValue(true);
-        (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(
-          mockWindow,
+        mocked(BrowserWindow.fromWebContents).mockReturnValue(
+          mockWindow as unknown as BrowserWindow,
         );
-        (systemPreferences.getUserDefault as jest.Mock).mockReturnValue(
-          'Maximize',
-        );
+        mocked(systemPreferences.getUserDefault).mockReturnValue('Maximize');
 
         setupTitleBarClickMac();
 
@@ -217,11 +212,11 @@ describe('main', () => {
 
       it('should do nothing if AppleActionOnDoubleClick is an unknown value', () => {
         const mockWindow = new BrowserWindowMock();
-        (BrowserWindow.fromWebContents as jest.Mock).mockReturnValue(
-          mockWindow,
+        mocked(BrowserWindow.fromWebContents).mockReturnValue(
+          mockWindow as unknown as BrowserWindow,
         );
-        (systemPreferences.getUserDefault as jest.Mock).mockReturnValue(
-          undefined,
+        mocked(systemPreferences.getUserDefault).mockReturnValue(
+          undefined as any,
         );
         setupTitleBarClickMac();
         expect(mockWindow.minimize).not.toHaveBeenCalled();

--- a/tests/main/menu-spec.ts
+++ b/tests/main/menu-spec.ts
@@ -3,6 +3,7 @@
  */
 
 import * as electron from 'electron';
+import { mocked } from 'jest-mock';
 
 import { BlockableAccelerator } from '../../src/interfaces';
 import { IpcEvents } from '../../src/ipc-events';
@@ -17,7 +18,7 @@ jest.mock('../../src/main/ipc');
 describe('menu', () => {
   beforeEach(() => {
     electron.app.name = 'Electron Fiddle';
-    (electron.dialog.showOpenDialog as jest.Mock).mockResolvedValue({});
+    mocked(electron.dialog.showOpenDialog).mockResolvedValue({} as any);
   });
 
   afterEach(() => {
@@ -30,8 +31,7 @@ describe('menu', () => {
 
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       expect(result.length).toBe(8);
 
       result.forEach((submenu: Electron.MenuItemConstructorOptions) => {
@@ -47,8 +47,7 @@ describe('menu', () => {
 
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       expect(result.length).toBe(7);
 
       result.forEach((submenu: Electron.MenuItemConstructorOptions) => {
@@ -64,8 +63,7 @@ describe('menu', () => {
 
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       expect(result.length).toBe(7);
 
       result.forEach((submenu: Electron.MenuItemConstructorOptions) => {
@@ -81,8 +79,7 @@ describe('menu', () => {
 
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       const submenu = result[2]
         .submenu as Array<Electron.MenuItemConstructorOptions>;
 
@@ -104,8 +101,7 @@ describe('menu', () => {
 
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       const submenu = result[2]
         .submenu as Array<Electron.MenuItemConstructorOptions>;
 
@@ -121,13 +117,14 @@ describe('menu', () => {
     it('overwrites Select All command', () => {
       setupMenu();
 
-      const result = (electron.Menu.buildFromTemplate as jest.Mock).mock
-        .calls[0][0];
+      const result = mocked(electron.Menu.buildFromTemplate).mock.calls[0][0];
       // use find here because the index is platform-specific
-      const submenu = result.find((r: any) => r.label === 'Edit')
-        .submenu as Array<Electron.MenuItemConstructorOptions>;
+      const submenu = result.find((r: any) => r.label === 'Edit')?.submenu as
+        | Array<Electron.MenuItemConstructorOptions>
+        | undefined;
+      expect(submenu).toBeDefined();
 
-      const selectAll = submenu.find(({ label }) => label === 'Select All');
+      const selectAll = submenu!.find(({ label }) => label === 'Select All');
       (selectAll as any).click();
       expect(ipcMainManager.send).toHaveBeenCalledWith(
         IpcEvents.SELECT_ALL_IN_EDITOR,
@@ -174,7 +171,7 @@ describe('menu', () => {
       let help: any;
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         help = menu[menu.length - 1];
       });
@@ -191,10 +188,11 @@ describe('menu', () => {
           toggleDevTools: jest.fn(),
         };
 
-        (electron.BrowserWindow.getFocusedWindow as jest.Mock).mockReturnValue({
+        mocked(electron.BrowserWindow.getFocusedWindow).mockReturnValue({
           isDestroyed: () => false,
-          webContents: mocks,
-        });
+          webContents:
+            mocks as Partial<electron.WebContents> as electron.WebContents,
+        } as Partial<electron.BrowserWindow> as electron.BrowserWindow);
 
         help.submenu[3].click();
         expect(mocks.toggleDevTools).toHaveBeenCalled();
@@ -226,7 +224,7 @@ describe('menu', () => {
       let preferences: any;
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         preferences = menu[0];
       });
@@ -243,7 +241,7 @@ describe('menu', () => {
       let quit: any;
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         quit = menu[0];
       });
@@ -258,7 +256,7 @@ describe('menu', () => {
       let showMe: any;
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         showMe = menu[menu.length - 2];
       });
@@ -276,7 +274,7 @@ describe('menu', () => {
       let tasks: any;
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         tasks = menu[menu.length - 3];
       });
@@ -314,7 +312,7 @@ describe('menu', () => {
       }
 
       beforeEach(() => {
-        const mock = (electron.Menu.buildFromTemplate as jest.Mock).mock;
+        const mock = mocked(electron.Menu.buildFromTemplate).mock;
         const menu = mock.calls[0][0];
         file = menu[1];
       });

--- a/tests/main/npm-spec.ts
+++ b/tests/main/npm-spec.ts
@@ -1,3 +1,5 @@
+import { mocked } from 'jest-mock';
+
 import {
   addModules,
   getIsPackageManagerInstalled,
@@ -19,7 +21,7 @@ describe('npm', () => {
       it('returns true if npm installed', async () => {
         overridePlatform('darwin');
 
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm');
 
@@ -30,7 +32,7 @@ describe('npm', () => {
       it('returns true if npm installed', async () => {
         overridePlatform('win32');
 
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm', true);
 
@@ -41,7 +43,7 @@ describe('npm', () => {
       it('returns false if npm not installed', async () => {
         overridePlatform('darwin');
 
-        (exec as jest.Mock).mockRejectedValueOnce('/usr/bin/fake-npm');
+        mocked(exec).mockRejectedValueOnce('/usr/bin/fake-npm');
 
         const result = await getIsPackageManagerInstalled('npm', true);
 
@@ -50,7 +52,7 @@ describe('npm', () => {
       });
 
       it('uses the cache', async () => {
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-npm');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-npm');
 
         const one = await getIsPackageManagerInstalled('npm', true);
         expect(one).toBe(true);
@@ -72,7 +74,7 @@ describe('npm', () => {
       it('returns true if yarn installed', async () => {
         overridePlatform('darwin');
 
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn');
 
@@ -83,7 +85,7 @@ describe('npm', () => {
       it('returns true if yarn installed', async () => {
         overridePlatform('win32');
 
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn', true);
 
@@ -94,7 +96,7 @@ describe('npm', () => {
       it('returns false if yarn not installed', async () => {
         overridePlatform('darwin');
 
-        (exec as jest.Mock).mockRejectedValueOnce('/usr/bin/fake-yarn');
+        mocked(exec).mockRejectedValueOnce('/usr/bin/fake-yarn');
 
         const result = await getIsPackageManagerInstalled('yarn', true);
 
@@ -103,7 +105,7 @@ describe('npm', () => {
       });
 
       it('uses the cache', async () => {
-        (exec as jest.Mock).mockResolvedValueOnce('/usr/bin/fake-yarn');
+        mocked(exec).mockResolvedValueOnce('/usr/bin/fake-yarn');
 
         const one = await getIsPackageManagerInstalled('yarn', true);
         expect(one).toBe(true);

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs';
 
 import { app } from 'electron';
+import { mocked } from 'jest-mock';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { ipcMainManager } from '../../src/main/ipc';
@@ -23,7 +24,7 @@ describe('protocol', () => {
   beforeEach(() => {
     ipcMainManager.removeAllListeners();
     ipcMainManager.send = jest.fn();
-    (app.isReady as jest.Mock).mockReturnValue(true);
+    mocked(app.isReady).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -36,7 +37,7 @@ describe('protocol', () => {
     it('attempts to setup the protocol handler', () => {
       overridePlatform('win32');
 
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      mocked(fs.existsSync).mockReturnValue(true);
       setupProtocolHandler();
       expect(app.setAsDefaultProtocolClient).toHaveBeenCalled();
     });
@@ -48,7 +49,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[1][1];
+      const handler = mocked(app.on).mock.calls[1][1];
 
       handler({}, ['electron-fiddle://gist/hi']);
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -62,7 +63,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/hi');
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -76,7 +77,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/username/gistID');
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -90,7 +91,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://noop');
       handler({}, 'electron-fiddle://gist/noop/noop/null');
@@ -112,18 +113,18 @@ describe('protocol', () => {
 
     it('waits for the app to be ready', () => {
       overridePlatform('darwin');
-      (app.isReady as jest.Mock).mockReturnValue(false);
+      mocked(app.isReady).mockReturnValue(false);
 
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://gist/hi-ready');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
       expect(app.once).toHaveBeenCalled();
 
-      const cb = (app.once as jest.Mock).mock.calls[0][1];
-      (app.isReady as jest.Mock).mockReturnValue(true);
+      const cb = mocked(app.once).mock.calls[0][1];
+      mocked(app.isReady).mockReturnValue(true);
 
       cb();
 
@@ -137,7 +138,7 @@ describe('protocol', () => {
       // electron-fiddle://electron/{tag}/{path}
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 
@@ -155,7 +156,7 @@ describe('protocol', () => {
     it('handles a flawed electron path url', () => {
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://electron/v4.0.0');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -164,7 +165,7 @@ describe('protocol', () => {
     it('handles a flawed url (unclear instruction)', () => {
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://noop/123');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -173,7 +174,7 @@ describe('protocol', () => {
     it('handles a flawed url (no instruction)', () => {
       listenForProtocolHandler();
 
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -183,7 +184,7 @@ describe('protocol', () => {
       listenForProtocolHandler();
 
       const mainWindow = getOrCreateMainWindow();
-      const handler = (app.on as jest.Mock).mock.calls[0][1];
+      const handler = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 

--- a/tests/main/templates-spec.ts
+++ b/tests/main/templates-spec.ts
@@ -1,5 +1,7 @@
 import * as path from 'node:path';
 
+import { mocked } from 'jest-mock';
+
 import { MAIN_JS } from '../../src/interfaces';
 import { getTemplateValues } from '../../src/main/templates';
 import { getEmptyContent } from '../../src/utils/editor-utils';
@@ -34,7 +36,7 @@ describe('templates', () => {
         [MAIN_JS],
       );
 
-      (console.log as jest.Mock).mockClear();
+      mocked(console.log).mockClear();
     });
   });
 });

--- a/tests/main/themes-spec.ts
+++ b/tests/main/themes-spec.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import { shell } from 'electron';
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 
 import {
   THEMES_PATH,
@@ -22,7 +23,7 @@ describe('themes', () => {
     });
 
     it('reads the themes folder for themes', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      mocked(fs.existsSync).mockReturnValue(true);
       (fs.readdir as jest.Mock).mockReturnValueOnce([
         'test-theme1.json',
         'test-theme2.json',
@@ -45,12 +46,12 @@ describe('themes', () => {
     });
 
     it('only reads files ending in .json', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      mocked(fs.existsSync).mockReturnValue(true);
       (fs.readdir as jest.Mock).mockReturnValueOnce([
         'test-theme1.json',
         '.DS_Store',
       ]);
-      (fs.readJSON as jest.Mock).mockReturnValue({ test: true });
+      (fs.readJSON as jest.Mock).mockResolvedValue({ test: true });
 
       const themes = await getAvailableThemes();
 
@@ -63,7 +64,7 @@ describe('themes', () => {
     });
 
     it('handles a readdir error', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+      mocked(fs.existsSync).mockReturnValueOnce(true);
       (fs.readdir as jest.Mock).mockRejectedValueOnce('Bwap');
 
       const themes = await getAvailableThemes();
@@ -71,7 +72,7 @@ describe('themes', () => {
     });
 
     it('handles a readJSON error', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+      mocked(fs.existsSync).mockReturnValueOnce(true);
       (fs.readdir as jest.Mock).mockImplementationOnce(() => ['hi']);
       (fs.readJSON as jest.Mock).mockRejectedValueOnce('Bwap');
 
@@ -97,7 +98,7 @@ describe('themes', () => {
     });
 
     it('reads the right file if ends with .json', async () => {
-      (fs.readJSON as jest.Mock).mockReturnValueOnce({});
+      (fs.readJSON as jest.Mock).mockResolvedValueOnce({});
 
       const theme = await readThemeFile('myfile.json');
       const expected = path.normalize(`~/.electron-fiddle/themes/myfile.json`);
@@ -107,7 +108,7 @@ describe('themes', () => {
     });
 
     it('reads the right file if does not end with .json', async () => {
-      (fs.readJSON as jest.Mock).mockReturnValueOnce({});
+      (fs.readJSON as jest.Mock).mockResolvedValueOnce({});
 
       const theme = await readThemeFile('myfile');
       const expected = path.normalize(`~/.electron-fiddle/themes/myfile.json`);

--- a/tests/main/update-spec.ts
+++ b/tests/main/update-spec.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { mocked } from 'jest-mock';
 
 jest.useFakeTimers();
 jest.spyOn(global, 'setTimeout');
@@ -16,7 +17,7 @@ describe('update', () => {
     setupUpdates();
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
-    (setTimeout as unknown as jest.Mock).mock.calls[0][0]();
+    mocked(setTimeout).mock.calls[0][0]();
     expect(updateElectronApp).toHaveBeenCalled();
   });
 });

--- a/tests/main/utils/check-first-run-spec.ts
+++ b/tests/main/utils/check-first-run-spec.ts
@@ -1,5 +1,6 @@
 import * as electron from 'electron';
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 
 import { isFirstRun } from '../../../src/main/utils/check-first-run';
 
@@ -10,22 +11,22 @@ jest.mock('fs-extra', () => ({
 
 describe('isFirstRun', () => {
   beforeEach(() => {
-    (electron.app.getPath as jest.Mock).mockReturnValue('path');
+    mocked(electron.app.getPath).mockReturnValue('path');
   });
 
   it('reports a non-first run', () => {
-    (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+    mocked(fs.existsSync).mockReturnValueOnce(true);
     expect(isFirstRun()).toBe(false);
   });
 
   it('reports a first run', () => {
-    (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
+    mocked(fs.existsSync).mockReturnValueOnce(false);
     expect(isFirstRun()).toBe(true);
     expect(fs.outputFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('handles an error', () => {
-    (fs.existsSync as jest.Mock).mockImplementationOnce(() => {
+    mocked(fs.existsSync).mockImplementationOnce(() => {
       throw new Error('bwap bwap');
     });
 

--- a/tests/main/utils/exec-spec.ts
+++ b/tests/main/utils/exec-spec.ts
@@ -1,3 +1,5 @@
+import { mocked } from 'jest-mock';
+
 import { overridePlatform, resetPlatform } from '../../utils';
 
 jest.mock('node:child_process');
@@ -58,7 +60,7 @@ describe('exec', () => {
     it('handles errors', async () => {
       let errored = false;
       const cpExec = require('node:child_process').exec;
-      (cpExec as jest.Mock).mockImplementation((_a: any, _b: any, c: any) =>
+      mocked(cpExec).mockImplementation((_a: any, _b: any, c: any) =>
         c(new Error('Poop!')),
       );
 

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -5,6 +5,7 @@
 import * as path from 'node:path';
 
 import * as electron from 'electron';
+import { mocked } from 'jest-mock';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { createContextMenu } from '../../src/main/context-menu';
@@ -52,7 +53,7 @@ describe('windows', () => {
     };
 
     beforeEach(() => {
-      (path.join as jest.Mock).mockReturnValue('/fake/path');
+      mocked(path.join).mockReturnValue('/fake/path');
     });
 
     afterEach(() => {
@@ -129,15 +130,13 @@ describe('windows', () => {
 
       // can't .emit() to trigger .handleOnce() so instead we mock
       // to instantly call the listener.
-      let result: any;
-      (electron.app.getPath as jest.Mock).mockImplementation((name) => name);
-      (electron.ipcMain.handle as jest.Mock).mockImplementation(
-        (event, listener) => {
-          if (event === IpcEvents.GET_APP_PATHS) {
-            result = listener();
-          }
-        },
-      );
+      let result: Record<string, string> = {};
+      mocked(electron.app.getPath).mockImplementation((name) => name);
+      mocked(electron.ipcMain.handle).mockImplementation((event, listener) => {
+        if (event === IpcEvents.GET_APP_PATHS) {
+          result = listener(null as any);
+        }
+      });
       getOrCreateMainWindow();
       expect(Object.values(result).length).toBeGreaterThan(0);
       for (const prop in result) {

--- a/tests/preload/preload-spec.ts
+++ b/tests/preload/preload-spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import * as electron from 'electron';
+import { mocked } from 'jest-mock';
 
 import { IpcEvents } from '../../src/ipc-events';
 import { setupFiddleGlobal } from '../../src/preload/preload';
@@ -25,7 +26,7 @@ describe('preload', () => {
       const obj = {
         appPath: '/fake/path',
       };
-      (electron.ipcRenderer.invoke as jest.Mock).mockResolvedValue(obj);
+      mocked(electron.ipcRenderer.invoke).mockResolvedValue(obj);
 
       await setupFiddleGlobal();
 

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -1,3 +1,5 @@
+import { mocked } from 'jest-mock';
+
 import { EditorValues, MAIN_JS, SetFiddleOptions } from '../../src/interfaces';
 import { App } from '../../src/renderer/app';
 import { EditorMosaic, EditorPresence } from '../../src/renderer/editor-mosaic';
@@ -26,16 +28,12 @@ describe('App component', () => {
   });
 
   beforeEach(() => {
-    (window.ElectronFiddle.getTemplate as jest.Mock).mockResolvedValue({
+    mocked(window.ElectronFiddle.getTemplate).mockResolvedValue({
       [MAIN_JS]: '// content',
     });
-    (window.ElectronFiddle.readThemeFile as jest.Mock).mockResolvedValue(
-      defaultDark,
-    );
-    (window.ElectronFiddle.getReleasedVersions as jest.Mock).mockReturnValue(
-      [],
-    );
-    (window.ElectronFiddle.getLatestStable as jest.Mock).mockReturnValue({
+    mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(defaultDark);
+    mocked(window.ElectronFiddle.getReleasedVersions).mockReturnValue([]);
+    mocked(window.ElectronFiddle.getLatestStable).mockReturnValue({
       version: '24.0.0',
     });
 
@@ -92,7 +90,7 @@ describe('App component', () => {
   describe('openFiddle()', () => {
     it('understands gists', async () => {
       const { fetchGistAndLoad } = app.remoteLoader;
-      (fetchGistAndLoad as jest.Mock).mockResolvedValue(true);
+      mocked(fetchGistAndLoad).mockResolvedValue(true);
 
       const gistId = '8c5fc0c6a5153d49b5a4a56d3ed9da8f';
       await app.openFiddle({ gistId });
@@ -101,7 +99,7 @@ describe('App component', () => {
 
     it('understands files', async () => {
       const { openFiddle } = app.fileManager;
-      (openFiddle as jest.Mock).mockResolvedValueOnce(undefined);
+      mocked(openFiddle).mockResolvedValueOnce(undefined);
 
       const filePath = '/fake/path';
       await app.openFiddle({ filePath });
@@ -231,7 +229,7 @@ describe('App component', () => {
     });
 
     it('removes the dark theme option if required', async () => {
-      (window.ElectronFiddle.readThemeFile as jest.Mock).mockResolvedValue(
+      mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(
         defaultLight,
       );
       document.body.classList.add('bp3-dark');
@@ -250,21 +248,19 @@ describe('App component', () => {
     it('sets native theme', async () => {
       app.state.isUsingSystemTheme = false;
 
-      (window.ElectronFiddle.readThemeFile as jest.Mock).mockResolvedValue(
+      mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(
         defaultLight,
       );
       await app.loadTheme('defaultLight');
-      expect(
-        window.ElectronFiddle.setNativeTheme as jest.Mock,
-      ).toHaveBeenCalledWith('light');
+      expect(window.ElectronFiddle.setNativeTheme).toHaveBeenCalledWith(
+        'light',
+      );
 
-      (window.ElectronFiddle.readThemeFile as jest.Mock).mockResolvedValue(
+      mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(
         defaultDark,
       );
       await app.loadTheme('custom-dark');
-      expect(
-        window.ElectronFiddle.setNativeTheme as jest.Mock,
-      ).toHaveBeenCalledWith('dark');
+      expect(window.ElectronFiddle.setNativeTheme).toHaveBeenCalledWith('dark');
     });
   });
 
@@ -304,17 +300,17 @@ describe('App component', () => {
 
         // isUsingSystemTheme and prefersDark
         app.state.isUsingSystemTheme = false;
-        (window.matchMedia as jest.Mock).mockReturnValue({
+        mocked(window.matchMedia).mockReturnValue({
           matches: true,
-        });
+        } as MediaQueryList);
         app.state.isUsingSystemTheme = true;
         expect(app.state.setTheme).toHaveBeenCalledWith(defaultDark.file);
 
         // isUsingSystemTheme and not prefersDark
         app.state.isUsingSystemTheme = false;
-        (window.matchMedia as jest.Mock).mockReturnValue({
+        mocked(window.matchMedia).mockReturnValue({
           matches: false,
-        });
+        } as MediaQueryList);
         app.state.isUsingSystemTheme = true;
         expect(app.state.setTheme).toHaveBeenCalledWith(defaultLight.file);
       });
@@ -324,9 +320,9 @@ describe('App component', () => {
         app.setupThemeListeners();
         app.state.isUsingSystemTheme = true;
 
-        expect(
-          window.ElectronFiddle.setNativeTheme as jest.Mock,
-        ).toHaveBeenCalledWith('system');
+        expect(window.ElectronFiddle.setNativeTheme).toHaveBeenCalledWith(
+          'system',
+        );
       });
     });
 
@@ -442,8 +438,7 @@ describe('App component', () => {
       expect(e.returnValue).toBe(false);
 
       await waitFor(
-        () =>
-          (window.ElectronFiddle.showWindow as jest.Mock).mock.calls.length > 0,
+        () => mocked(window.ElectronFiddle.showWindow).mock.calls.length > 0,
       );
       expect(window.close).toHaveBeenCalled();
     });
@@ -463,8 +458,7 @@ describe('App component', () => {
       expect(e.returnValue).toBe(false);
 
       await waitFor(
-        () =>
-          (window.ElectronFiddle.showWindow as jest.Mock).mock.calls.length > 0,
+        () => mocked(window.ElectronFiddle.showWindow).mock.calls.length > 0,
       );
       expect(window.ElectronFiddle.confirmQuit).toHaveBeenCalled();
       expect(window.close).toHaveBeenCalledTimes(1);
@@ -485,8 +479,7 @@ describe('App component', () => {
       expect(e.returnValue).toBe(false);
 
       await waitFor(
-        () =>
-          (window.ElectronFiddle.showWindow as jest.Mock).mock.calls.length > 0,
+        () => mocked(window.ElectronFiddle.showWindow).mock.calls.length > 0,
       );
       expect(window.close).not.toHaveBeenCalled();
       expect(!app.state.isQuitting);

--- a/tests/renderer/components/commands-publish-button-spec.tsx
+++ b/tests/renderer/components/commands-publish-button-spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
+import { Octokit } from '@octokit/rest';
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import {
   EditorValues,
@@ -63,14 +65,16 @@ describe('Action button component', () => {
 
     // have the octokit getter use our mock
     mocktokit = new OctokitMock();
-    (getOctokit as jest.Mock).mockImplementation(() => mocktokit);
+    mocked(getOctokit).mockImplementation(
+      async () => mocktokit as unknown as Octokit,
+    );
 
     // build ExpectedGistCreateOpts
     const editorValues = createEditorValues();
     const files = getGistFiles(editorValues);
     expectedGistOpts = { description, files, public: true } as const;
 
-    (window.ElectronFiddle.getTemplate as jest.Mock).mockResolvedValue({
+    mocked(window.ElectronFiddle.getTemplate).mockResolvedValue({
       [MAIN_JS]: '// content',
     });
   });
@@ -124,7 +128,7 @@ describe('Action button component', () => {
     expect(instance.performGistAction).not.toHaveBeenCalled();
 
     // If authed, continue to performGistAction
-    (state.toggleAuthDialog as jest.Mock).mockImplementationOnce(
+    mocked(state.toggleAuthDialog).mockImplementationOnce(
       () => (state.gitHubToken = 'github-token'),
     );
     await instance.handleClick();
@@ -185,7 +189,7 @@ describe('Action button component', () => {
       it('are replaced with default content for required files', async () => {
         const values = { [MAIN_JS]: '' } as const;
 
-        (app.getEditorValues as jest.Mock).mockReturnValueOnce(values);
+        mocked(app.getEditorValues).mockResolvedValueOnce(values);
         const { instance } = createActionButton();
         state.showInputDialog = jest.fn().mockResolvedValueOnce(description);
         await instance.performGistAction();
@@ -199,7 +203,7 @@ describe('Action button component', () => {
         const required = { [MAIN_JS]: '// fnord' };
         const optional = { 'foo.js': '' };
 
-        (app.getEditorValues as jest.Mock).mockReturnValueOnce({
+        mocked(app.getEditorValues).mockResolvedValueOnce({
           ...required,
           ...optional,
         });
@@ -298,9 +302,7 @@ describe('Action button component', () => {
 
       await instance.performGistAction();
 
-      expect(
-        window.ElectronFiddle.showWarningDialog as jest.Mock,
-      ).toHaveBeenCalledWith(
+      expect(window.ElectronFiddle.showWarningDialog).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: expect.stringContaining(errorMessage),
           message: expect.stringContaining('Updating Fiddle Gist failed.'),
@@ -335,9 +337,7 @@ describe('Action button component', () => {
 
       await instance.performGistAction();
 
-      expect(
-        window.ElectronFiddle.showWarningDialog as jest.Mock,
-      ).toHaveBeenCalledWith(
+      expect(window.ElectronFiddle.showWarningDialog).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: expect.stringContaining(errorMessage),
           message: expect.stringContaining('Deleting Fiddle Gist failed.'),

--- a/tests/renderer/components/commands-spec.tsx
+++ b/tests/renderer/components/commands-spec.tsx
@@ -62,9 +62,7 @@ describe('Commands component', () => {
     const tag = { tagName: 'DIV' };
     instance.handleDoubleClick({ target: tag, currentTarget: tag });
 
-    expect(
-      window.ElectronFiddle.macTitlebarClicked as jest.Mock,
-    ).toHaveBeenCalled();
+    expect(window.ElectronFiddle.macTitlebarClicked).toHaveBeenCalled();
   });
 
   it('handleDoubleClick() should not handle input tag', () => {
@@ -76,9 +74,7 @@ describe('Commands component', () => {
       currentTarget: { tagName: 'DIV' },
     });
 
-    expect(
-      window.ElectronFiddle.macTitlebarClicked as jest.Mock,
-    ).toHaveBeenCalledTimes(0);
+    expect(window.ElectronFiddle.macTitlebarClicked).toHaveBeenCalledTimes(0);
   });
 
   it('show setting', () => {

--- a/tests/renderer/components/dialog-add-theme-spec.tsx
+++ b/tests/renderer/components/dialog-add-theme-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import { AddThemeDialog } from '../../../src/renderer/components/dialog-add-theme';
 import { AppState } from '../../../src/renderer/state';
@@ -76,9 +77,9 @@ describe('AddThemeDialog component', () => {
       });
 
       const themePath = '~/.electron-fiddle/themes/testingLight';
-      (window.ElectronFiddle.createThemeFile as jest.Mock).mockResolvedValue({
+      mocked(window.ElectronFiddle.createThemeFile).mockResolvedValue({
         file: themePath,
-      });
+      } as LoadedFiddleTheme);
 
       await instance.createNewThemeFromMonaco('testingLight', defaultLight);
 

--- a/tests/renderer/components/dialog-add-version-spec.tsx
+++ b/tests/renderer/components/dialog-add-version-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import { AddVersionDialog } from '../../../src/renderer/components/dialog-add-version';
 import { AppState } from '../../../src/renderer/state';
@@ -58,16 +59,14 @@ describe('AddVersionDialog component', () => {
     const inp = wrapper.find('#custom-electron-version');
     inp.dive().find('input[type="file"]').simulate('click', { preventDefault });
 
-    expect(
-      window.ElectronFiddle.selectLocalVersion as jest.Mock,
-    ).toHaveBeenCalled();
+    expect(window.ElectronFiddle.selectLocalVersion).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
   });
 
   describe('selectLocalVersion()', () => {
     it('updates state', async () => {
       const wrapper = shallow(<AddVersionDialog appState={store} />);
-      (window.ElectronFiddle.selectLocalVersion as jest.Mock).mockReturnValue({
+      mocked(window.ElectronFiddle.selectLocalVersion).mockResolvedValue({
         folderPath: '/test/',
         isValidElectron: true,
         localName: 'Test',

--- a/tests/renderer/components/dialog-bisect-spec.tsx
+++ b/tests/renderer/components/dialog-bisect-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import {
   ElectronReleaseChannel,
@@ -106,9 +107,9 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
   describe('onSubmit()', () => {
     it('initiates a bisect instance and sets a version', async () => {
       const version = '1.0.0';
-      (Bisector as jest.Mock).mockReturnValue({
+      mocked(Bisector).mockReturnValue({
         getCurrentVersion: () => ({ version }),
-      });
+      } as any);
 
       const versions = generateVersionRange(numVersions);
 
@@ -158,7 +159,7 @@ describe.each([8, 15])('BisectDialog component', (numVersions) => {
         startIndex: 4,
       });
 
-      (runner.autobisect as jest.Mock).mockResolvedValue(RunResult.SUCCESS);
+      mocked(runner.autobisect).mockResolvedValue(RunResult.SUCCESS);
 
       // click the 'auto' button
       const instance1: any = wrapper.instance();

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
+import { Octokit } from '@octokit/rest';
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import { TokenDialog } from '../../../src/renderer/components/dialog-token';
 import { AppState } from '../../../src/renderer/state';
@@ -37,7 +39,7 @@ describe('TokenDialog component', () => {
     const wrapper = shallow(<TokenDialog appState={store} />);
     const instance: any = wrapper.instance();
 
-    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
+    mocked(window.navigator.clipboard.readText).mockResolvedValueOnce(
       mockValidToken,
     );
     await instance.onTokenInputFocused();
@@ -50,7 +52,7 @@ describe('TokenDialog component', () => {
     const wrapper = shallow(<TokenDialog appState={store} />);
     const instance: any = wrapper.instance();
 
-    (window.navigator.clipboard.readText as jest.Mock).mockResolvedValueOnce(
+    mocked(window.navigator.clipboard.readText).mockResolvedValueOnce(
       mockInvalidToken,
     );
     await instance.onTokenInputFocused();
@@ -108,7 +110,7 @@ describe('TokenDialog component', () => {
   });
 
   describe('onSubmitToken()', () => {
-    let mockOctokit: any;
+    let mockOctokit: Octokit;
     const mockUser = {
       avatar_url: 'https://avatars.fake/hi',
       login: 'test-login',
@@ -121,9 +123,9 @@ describe('TokenDialog component', () => {
         users: {
           getAuthenticated: jest.fn().mockResolvedValue({ data: mockUser }),
         },
-      };
+      } as unknown as Octokit;
 
-      (getOctokit as jest.Mock).mockResolvedValue(mockOctokit);
+      mocked(getOctokit).mockResolvedValue(mockOctokit);
     });
 
     it('handles missing input', async () => {
@@ -150,7 +152,9 @@ describe('TokenDialog component', () => {
     });
 
     it('handles an error', async () => {
-      mockOctokit.users.getAuthenticated.mockReturnValue({ data: null });
+      mocked(mockOctokit.users.getAuthenticated).mockResolvedValue({
+        data: null,
+      } as any);
 
       const wrapper = shallow(<TokenDialog appState={store} />);
       wrapper.setState({ tokenInput: mockValidToken });

--- a/tests/renderer/components/settings-electron-spec.tsx
+++ b/tests/renderer/components/settings-electron-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { mount, shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import {
   ElectronReleaseChannel,
@@ -282,7 +283,7 @@ describe('ElectronSettings component', () => {
 
   describe('disableDownload()', () => {
     it('disables download buttons where return values are true', () => {
-      (disableDownload as jest.Mock).mockReturnValue(true);
+      mocked(disableDownload).mockReturnValue(true);
 
       const version = '3.0.0';
       const ver = {

--- a/tests/renderer/components/settings-general-appearance-spec.tsx
+++ b/tests/renderer/components/settings-general-appearance-spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { IItemRendererProps } from '@blueprintjs/select';
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import {
   AppearanceSettings,
@@ -15,7 +16,7 @@ const mockThemes = [
   {
     name: 'defaultDark',
     file: 'defaultDark',
-  },
+  } as LoadedFiddleTheme,
 ];
 const doNothingFunc = () => {
   // Do Nothing
@@ -27,7 +28,7 @@ describe('AppearanceSettings component', () => {
   beforeEach(() => {
     ({ state: store } = window.ElectronFiddle.app);
 
-    (window.ElectronFiddle.getAvailableThemes as jest.Mock).mockResolvedValue(
+    mocked(window.ElectronFiddle.getAvailableThemes).mockResolvedValue(
       mockThemes,
     );
   });
@@ -109,7 +110,7 @@ describe('AppearanceSettings component', () => {
         />,
       );
       const instance: any = wrapper.instance();
-      (window.ElectronFiddle.openThemeFolder as jest.Mock).mockRejectedValue(
+      mocked(window.ElectronFiddle.openThemeFolder).mockRejectedValue(
         new Error('Bwap'),
       );
 
@@ -136,13 +137,17 @@ describe('AppearanceSettings component', () => {
     });
 
     it('adds the newly created theme to the Themes dropdown', async () => {
-      const arr: Array<FiddleTheme> = [];
-      (window.ElectronFiddle.getAvailableThemes as jest.Mock).mockResolvedValue(
-        arr,
-      );
-      (window.ElectronFiddle.createThemeFile as jest.Mock).mockImplementation(
-        (theme: FiddleTheme) => {
-          arr.push(theme);
+      const arr: Array<LoadedFiddleTheme> = [];
+      mocked(window.ElectronFiddle.getAvailableThemes).mockResolvedValue(arr);
+      mocked(window.ElectronFiddle.createThemeFile).mockImplementation(
+        async (theme: FiddleTheme) => {
+          const loadedTheme = {
+            ...theme,
+            name: '',
+            file: '',
+          };
+          arr.push(loadedTheme);
+          return loadedTheme;
         },
       );
       const wrapper = shallow(
@@ -165,7 +170,7 @@ describe('AppearanceSettings component', () => {
         />,
       );
       const instance: any = wrapper.instance();
-      (window.ElectronFiddle.createThemeFile as jest.Mock).mockRejectedValue(
+      mocked(window.ElectronFiddle.createThemeFile).mockRejectedValue(
         new Error('Bwap'),
       );
 
@@ -177,9 +182,7 @@ describe('AppearanceSettings component', () => {
   describe('handleAddTheme()', () => {
     it('refreshes the Themes dropdown', async () => {
       const arr: Array<LoadedFiddleTheme> = [];
-      (window.ElectronFiddle.getAvailableThemes as jest.Mock).mockResolvedValue(
-        arr,
-      );
+      mocked(window.ElectronFiddle.getAvailableThemes).mockResolvedValue(arr);
       const wrapper = shallow(
         <AppearanceSettings
           appState={store}

--- a/tests/renderer/components/tour-spec.tsx
+++ b/tests/renderer/components/tour-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { mount, shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import { Tour } from '../../../src/renderer/components/tour';
 import { overrideRendererPlatform } from '../../utils';
@@ -74,7 +75,7 @@ describe('VersionChooser component', () => {
   });
 
   it('handles a missing target', () => {
-    (document.querySelector as jest.Mock).mockReturnValueOnce(null);
+    mocked(document.querySelector).mockReturnValueOnce(null);
 
     const mockStop = jest.fn();
     const wrapper = shallow(<Tour tour={mockTour} onStop={mockStop} />);

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { shallow } from 'enzyme';
+import { mocked } from 'jest-mock';
 
 import {
   ElectronReleaseChannel,
@@ -93,7 +94,7 @@ describe('VersionSelect component', () => {
 
   describe('disableDownload', () => {
     it('disables download buttons when return value is true', () => {
-      (disableDownload as jest.Mock).mockReturnValueOnce(true);
+      mocked(disableDownload).mockReturnValueOnce(true);
 
       const item = renderItem(mockVersion1, {
         handleClick: () => ({}),
@@ -108,7 +109,7 @@ describe('VersionSelect component', () => {
     });
 
     it('does not disable enabled download buttons when return value is false', () => {
-      (disableDownload as jest.Mock).mockReturnValueOnce(false);
+      mocked(disableDownload).mockReturnValueOnce(false);
 
       const item = renderItem(mockVersion1, {
         handleClick: () => ({}),

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -1,3 +1,4 @@
+import { mocked } from 'jest-mock';
 import { reaction } from 'mobx';
 
 import { EditorId, EditorValues, MAIN_JS } from '../../src/interfaces';
@@ -83,7 +84,7 @@ describe('EditorMosaic', () => {
       // setup: put visible file into the mosaic and then hide it.
       // this should cause EditorMosaic to cache the viewstate offscreen.
       const viewState = Symbol('some unique viewstate');
-      (editor.saveViewState as jest.Mock).mockReturnValueOnce(viewState);
+      mocked(editor.saveViewState).mockReturnValueOnce(viewState as any);
       editorMosaic.addEditor(id, editor);
       editorMosaic.hide(id);
       expect(editorMosaic.files.get(id)).toBe(EditorPresence.Hidden);
@@ -430,7 +431,7 @@ describe('EditorMosaic', () => {
       const id = MAIN_JS;
       editorMosaic.set(valuesIn);
       editorMosaic.addEditor(id, editor);
-      (editor.hasTextFocus as jest.Mock).mockReturnValue(true);
+      mocked(editor.hasTextFocus).mockReturnValue(true);
 
       expect(editorMosaic.focusedEditor()).toBe(editor);
     });
@@ -447,13 +448,13 @@ describe('EditorMosaic', () => {
       const content = '// content';
       const editor = new MonacoEditorMock() as unknown as Editor;
       editorMosaic.set({ [id]: content });
-      await editorMosaic.addEditor(id, editor);
+      editorMosaic.addEditor(id, editor);
 
       editorMosaic.layout();
       editorMosaic.layout();
       editorMosaic.layout();
       editorMosaic.layout();
-      await waitFor(() => (editor.layout as jest.Mock).mock.calls.length > 0);
+      await waitFor(() => mocked(editor.layout).mock.calls.length > 0);
 
       expect(editor.layout).toHaveBeenCalledTimes(1);
     });

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
 
+import { ReleaseInfo } from '@electron/fiddle-core';
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 import * as tmp from 'tmp';
 
 import {
@@ -160,9 +162,9 @@ describe('ElectronTypes', () => {
     });
 
     it('fetches types', async () => {
-      (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue({
+      mocked(window.ElectronFiddle.getReleaseInfo).mockResolvedValue({
         node: '16.2.0',
-      });
+      } as ReleaseInfo);
 
       const types = 'here are the types';
       const fetchSpy = makeFetchSpy(types);
@@ -222,9 +224,7 @@ describe('ElectronTypes', () => {
     });
 
     it('does not crash if no release info', async () => {
-      (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue(
-        undefined,
-      );
+      mocked(window.ElectronFiddle.getReleaseInfo).mockResolvedValue(undefined);
 
       await electronTypes.setVersion(remoteVersion);
       expect(addExtraLib).not.toHaveBeenCalled();

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 
 import { Files, PACKAGE_NAME, SetFiddleOptions } from '../../src/interfaces';
 import { App } from '../../src/renderer/app';
@@ -26,8 +27,8 @@ describe('FileManager', () => {
   let fm: FileManager;
 
   beforeEach(() => {
-    (readFiddle as jest.Mock).mockResolvedValue(editorValues);
-    (window.ElectronFiddle.getTemplateValues as jest.Mock).mockResolvedValue(
+    mocked(readFiddle).mockResolvedValue(editorValues);
+    mocked(window.ElectronFiddle.getTemplateValues).mockResolvedValue(
       editorValues,
     );
 
@@ -51,7 +52,7 @@ describe('FileManager', () => {
       expect(isSupportedFile(file));
       const content = '// content';
       const values = { ...editorValues, [file]: content };
-      (readFiddle as jest.Mock).mockResolvedValue(values);
+      mocked(readFiddle).mockResolvedValue(values);
       app.remoteLoader.confirmAddFile.mockResolvedValue(true);
 
       await fm.openFiddle(filePath);
@@ -71,7 +72,7 @@ describe('FileManager', () => {
         ...editorValues,
         [PACKAGE_NAME]: JSON.stringify(pj, null, 2),
       };
-      (readFiddle as jest.Mock).mockResolvedValue(values);
+      mocked(readFiddle).mockResolvedValue(values);
 
       await fm.openFiddle(filePath);
       expect(app.remoteLoader.setElectronVersion).toBeCalledWith('17.0.0');
@@ -93,7 +94,7 @@ describe('FileManager', () => {
         ...editorValues,
         [PACKAGE_NAME]: JSON.stringify(pj, null, 2),
       };
-      (readFiddle as jest.Mock).mockResolvedValue(values);
+      mocked(readFiddle).mockResolvedValue(values);
 
       await fm.openFiddle(filePath);
       expect(readFiddle).toHaveBeenCalledWith(filePath, true);
@@ -146,7 +147,7 @@ describe('FileManager', () => {
     });
 
     it('handles an error (output)', async () => {
-      (fs.outputFile as jest.Mock).mockImplementation(() => {
+      mocked(fs.outputFile).mockImplementation(() => {
         throw new Error('bwap');
       });
 
@@ -158,7 +159,7 @@ describe('FileManager', () => {
     });
 
     it('handles an error (remove)', async () => {
-      (fs.remove as jest.Mock).mockImplementation(() => {
+      mocked(fs.remove).mockImplementation(() => {
         throw new Error('bwap');
       });
       await fm.saveFiddle('/fake/path');
@@ -239,7 +240,7 @@ describe('FileManager', () => {
 
   describe('cleanup()', () => {
     it('attempts to remove a directory if it exists', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+      mocked(fs.existsSync).mockReturnValueOnce(true);
 
       const result = await fm.cleanup('/fake/dir');
 
@@ -248,7 +249,7 @@ describe('FileManager', () => {
     });
 
     it('does not attempt to remove a directory if it does not exists', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
+      mocked(fs.existsSync).mockReturnValueOnce(false);
 
       const result = await fm.cleanup('/fake/dir');
 
@@ -257,7 +258,7 @@ describe('FileManager', () => {
     });
 
     it('handles an error', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+      mocked(fs.existsSync).mockReturnValueOnce(true);
       (fs.remove as jest.Mock).mockRejectedValueOnce('bwapbwap');
 
       const result = await fm.cleanup('/fake/dir');

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -1,3 +1,6 @@
+import { Octokit } from '@octokit/rest';
+import { mocked } from 'jest-mock';
+
 import {
   EditorValues,
   ElectronReleaseChannel,
@@ -69,7 +72,9 @@ describe('RemoteLoader', () => {
   describe('fetchGistAndLoad()', () => {
     it('loads a fiddle', async () => {
       const gistId = 'abcdtestid';
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
       store.gistId = gistId;
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -94,7 +99,9 @@ describe('RemoteLoader', () => {
         download_url: `https://${PACKAGE_NAME}`,
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -116,7 +123,9 @@ describe('RemoteLoader', () => {
           },
         }),
       };
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: errorGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: errorGetGists,
+      } as unknown as Octokit);
       store.gistId = gistId;
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -144,10 +153,10 @@ describe('RemoteLoader', () => {
         download_url: `https://${PACKAGE_NAME}`,
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
-      (window.ElectronFiddle.isReleasedMajor as jest.Mock).mockResolvedValue(
-        true,
-      );
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
+      mocked(window.ElectronFiddle.isReleasedMajor).mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -172,7 +181,9 @@ describe('RemoteLoader', () => {
         download_url: `https://${PACKAGE_NAME}`,
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -206,7 +217,9 @@ describe('RemoteLoader', () => {
         download_url: `https://${PACKAGE_NAME}`,
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -234,7 +247,9 @@ describe('RemoteLoader', () => {
         download_url: `https://${filename}`,
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ gists: mockGetGists });
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
       instance.confirmAddFile = jest.fn().mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -244,13 +259,13 @@ describe('RemoteLoader', () => {
     });
 
     it('handles an error', async () => {
-      (getOctokit as jest.Mock).mockResolvedValue({
+      mocked(getOctokit).mockResolvedValue({
         gists: {
           get: async () => {
             throw new Error('Bwap bwap');
           },
         },
-      });
+      } as unknown as Octokit);
 
       const result = await instance.fetchGistAndLoad('abcdtestid');
       expect(result).toBe(false);
@@ -269,11 +284,13 @@ describe('RemoteLoader', () => {
     });
 
     it('loads an Electron example', async () => {
-      (window.ElectronFiddle.getTemplate as jest.Mock).mockResolvedValue({
+      mocked(window.ElectronFiddle.getTemplate).mockResolvedValue({
         [MAIN_JS]: '// content',
       });
 
-      (getOctokit as jest.Mock).mockResolvedValue({ repos: mockGetRepos });
+      mocked(getOctokit).mockResolvedValue({
+        repos: mockGetRepos,
+      } as unknown as Octokit);
 
       await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
 
@@ -290,13 +307,13 @@ describe('RemoteLoader', () => {
     });
 
     it('handles an error', async () => {
-      (getOctokit as jest.Mock).mockResolvedValue({
+      mocked(getOctokit).mockResolvedValue({
         repos: {
           getContents: async () => {
             throw new Error('Bwap bwap');
           },
         },
-      });
+      } as unknown as Octokit);
 
       const result = await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
       expect(result).toBe(false);
@@ -304,13 +321,13 @@ describe('RemoteLoader', () => {
 
     it('handles incorrect results', async () => {
       store.showErrorDialog = jest.fn().mockResolvedValueOnce(true);
-      (getOctokit as jest.Mock).mockResolvedValue({
+      mocked(getOctokit).mockResolvedValue({
         repos: {
           getContents: async () => ({
             not_an_array: true,
           }),
         },
-      });
+      } as unknown as Octokit);
 
       const result = await instance.fetchExampleAndLoad('v4.0.0', 'test/path');
       expect(result).toBe(false);
@@ -330,7 +347,7 @@ describe('RemoteLoader', () => {
     });
 
     it('enables release channel when authorized', async () => {
-      instance.verifyReleaseChannelEnabled = jest.fn().mockReturnValue(true);
+      instance.verifyReleaseChannelEnabled = jest.fn().mockResolvedValue(true);
 
       const result = await instance.setElectronVersion('4.0.0-beta');
       expect(result).toBe(true);
@@ -367,7 +384,7 @@ describe('RemoteLoader', () => {
   describe('loadFiddleFromElectronExample()', () => {
     it('loads the example with confirmation', async () => {
       store.showConfirmDialog = jest.fn().mockResolvedValueOnce(true);
-      instance.verifyReleaseChannelEnabled = jest.fn().mockReturnValue(true);
+      instance.verifyReleaseChannelEnabled = jest.fn().mockResolvedValue(true);
       instance.fetchExampleAndLoad = jest.fn();
       await instance.loadFiddleFromElectronExample({
         path: 'test/path',

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { mocked } from 'jest-mock';
 import * as semver from 'semver';
 
 import {
@@ -37,9 +38,9 @@ describe('Runner component', () => {
     store.getName.mockResolvedValue('test-app-name');
     store.modules = new Map<string, string>([['cow', '*']]);
 
-    (
-      window.ElectronFiddle.getIsPackageManagerInstalled as jest.Mock
-    ).mockReturnValue(true);
+    mocked(
+      window.ElectronFiddle.getIsPackageManagerInstalled,
+    ).mockResolvedValue(true);
 
     instance = new Runner(store as unknown as AppState);
   });
@@ -213,7 +214,7 @@ describe('Runner component', () => {
     });
 
     it('does not run if writing files fails', async () => {
-      (fileManager.saveToTemp as jest.Mock).mockRejectedValueOnce('bwap bwap');
+      mocked(fileManager.saveToTemp).mockRejectedValueOnce('bwap bwap');
 
       expect(await instance.run()).toBe(RunResult.INVALID);
     });
@@ -356,7 +357,7 @@ describe('Runner component', () => {
     });
 
     it('handles an error', async () => {
-      (window.ElectronFiddle.addModules as jest.Mock).mockRejectedValueOnce(
+      mocked(window.ElectronFiddle.addModules).mockRejectedValueOnce(
         'bwap bwap',
       );
 
@@ -398,7 +399,7 @@ describe('Runner component', () => {
     });
 
     it('handles an error in packageInstall()', async () => {
-      (window.ElectronFiddle.addModules as jest.Mock).mockRejectedValueOnce(
+      mocked(window.ElectronFiddle.addModules).mockRejectedValueOnce(
         'bwap bwap',
       );
 
@@ -408,7 +409,7 @@ describe('Runner component', () => {
     });
 
     it('handles an error in packageRun()', async () => {
-      (window.ElectronFiddle.packageRun as jest.Mock).mockRejectedValueOnce(
+      mocked(window.ElectronFiddle.packageRun).mockRejectedValueOnce(
         'bwap bwap',
       );
 
@@ -418,9 +419,9 @@ describe('Runner component', () => {
     });
 
     it('does attempt a forge operation if npm is not installed', async () => {
-      (
-        window.ElectronFiddle.getIsPackageManagerInstalled as jest.Mock
-      ).mockReturnValueOnce(false);
+      mocked(
+        window.ElectronFiddle.getIsPackageManagerInstalled,
+      ).mockResolvedValueOnce(false);
 
       expect(await instance.performForgeOperation(ForgeCommands.MAKE)).toBe(
         false,
@@ -433,9 +434,9 @@ describe('Runner component', () => {
       ['does not attempt installation if npm is not installed', false, 0],
       ['does attempt installation if npm is installed', true, 1],
     ])('%s', async (_: unknown, haveNpm: boolean, numCalls: number) => {
-      (
-        window.ElectronFiddle.getIsPackageManagerInstalled as jest.Mock
-      ).mockReturnValue(haveNpm);
+      mocked(
+        window.ElectronFiddle.getIsPackageManagerInstalled,
+      ).mockResolvedValue(haveNpm);
       await instance.installModules({
         dir: '/fake/path',
         packageManager: 'npm',

--- a/tests/renderer/task-runner-spec.tsx
+++ b/tests/renderer/task-runner-spec.tsx
@@ -1,3 +1,5 @@
+import { mocked } from 'jest-mock';
+
 import {
   BisectRequest,
   ElectronReleaseChannel,
@@ -39,7 +41,7 @@ describe('Task Runner component', () => {
   async function requestAndWait(event: FiddleEvent, req: any) {
     emitEvent(event, req);
     await waitFor(
-      () => (window.ElectronFiddle.taskDone as jest.Mock).mock.calls.length > 0,
+      () => mocked(window.ElectronFiddle.taskDone).mock.calls.length > 0,
     );
   }
 
@@ -80,13 +82,13 @@ describe('Task Runner component', () => {
     it('invokes the runner and returns the result', async () => {
       const RESULT = RunResult.SUCCESS;
 
-      (app.openFiddle as jest.Mock).mockResolvedValue(0);
-      (appState.hasVersion as jest.Mock).mockReturnValueOnce(true);
-      (appState.hideChannels as jest.Mock).mockResolvedValue(0);
-      (appState.setVersion as jest.Mock).mockResolvedValue(0);
-      (appState.showChannels as jest.Mock).mockResolvedValue(0);
+      app.openFiddle.mockResolvedValue(0);
+      appState.hasVersion.mockReturnValueOnce(true);
+      appState.hideChannels.mockResolvedValue(0);
+      appState.setVersion.mockResolvedValue(0);
+      appState.showChannels.mockResolvedValue(0);
       appState.versionsToShow = makeRunnables(VERSIONS);
-      (runner.autobisect as jest.Mock).mockResolvedValueOnce(RESULT);
+      runner.autobisect.mockResolvedValueOnce(RESULT);
 
       await requestAndWait('bisect-task', req);
 
@@ -103,7 +105,7 @@ describe('Task Runner component', () => {
 
     it('returns invalid if an exception is thrown', async () => {
       const RESULT = RunResult.INVALID;
-      (app.openFiddle as jest.Mock).mockRejectedValue('💩');
+      app.openFiddle.mockRejectedValue('💩');
 
       await requestAndWait('bisect-task', req);
 
@@ -128,13 +130,13 @@ describe('Task Runner component', () => {
     it('invokes the runner and returns the result', async () => {
       const RESULT = RunResult.FAILURE;
 
-      (app.openFiddle as jest.Mock).mockResolvedValue(0);
-      (appState.hasVersion as jest.Mock).mockReturnValueOnce(true);
-      (appState.hideChannels as jest.Mock).mockResolvedValue(0);
-      (appState.setVersion as jest.Mock).mockResolvedValue(0);
-      (appState.showChannels as jest.Mock).mockResolvedValue(0);
+      app.openFiddle.mockResolvedValue(0);
+      appState.hasVersion.mockReturnValueOnce(true);
+      appState.hideChannels.mockResolvedValue(0);
+      appState.setVersion.mockResolvedValue(0);
+      appState.showChannels.mockResolvedValue(0);
       appState.versionsToShow = makeRunnables([VERSION]);
-      (runner.run as jest.Mock).mockResolvedValueOnce(RESULT);
+      runner.run.mockResolvedValueOnce(RESULT);
 
       await requestAndWait('test-task', req);
 
@@ -151,12 +153,12 @@ describe('Task Runner component', () => {
     it('returns invalid if an exception is thrown', async () => {
       const RESULT = RunResult.INVALID;
 
-      (app.openFiddle as jest.Mock).mockResolvedValue(0);
-      (appState.hasVersion as jest.Mock).mockReturnValueOnce(false);
-      (appState.hideChannels as jest.Mock).mockResolvedValue(0);
-      (appState.setVersion as jest.Mock).mockResolvedValue(0);
-      (appState.showChannels as jest.Mock).mockResolvedValue(0);
-      (runner.run as jest.Mock).mockResolvedValueOnce(RESULT);
+      app.openFiddle.mockResolvedValue(0);
+      appState.hasVersion.mockReturnValueOnce(false);
+      appState.hideChannels.mockResolvedValue(0);
+      appState.setVersion.mockResolvedValue(0);
+      appState.showChannels.mockResolvedValue(0);
+      runner.run.mockResolvedValueOnce(RESULT);
 
       await requestAndWait('test-task', req);
 

--- a/tests/renderer/themes-spec.tsx
+++ b/tests/renderer/themes-spec.tsx
@@ -1,4 +1,7 @@
+import { mocked } from 'jest-mock';
+
 import { activateTheme, getTheme } from '../../src/renderer/themes';
+import { LoadedFiddleTheme } from '../../src/themes-defaults';
 
 describe('themes', () => {
   describe('activateTheme()', () => {
@@ -27,17 +30,17 @@ describe('themes', () => {
     });
 
     it('returns a named theme', async () => {
-      (window.ElectronFiddle.readThemeFile as jest.Mock).mockReturnValue({
+      mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue({
         name: 'Test',
         common: { test: true },
-      });
+      } as unknown as LoadedFiddleTheme);
 
       const theme = await getTheme('test');
       expect(theme.name).toBe('Test');
     });
 
     it('handles a read error', async () => {
-      (window.ElectronFiddle.readThemeFile as jest.Mock).mockReturnValue(null);
+      mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(null);
 
       const theme = await getTheme('test');
       expect(theme.name).toBe('Fiddle (Dark)');

--- a/tests/renderer/utils/get-package-spec.ts
+++ b/tests/renderer/utils/get-package-spec.ts
@@ -1,3 +1,4 @@
+import { mocked } from 'jest-mock';
 import * as semver from 'semver';
 
 import { MAIN_JS } from '../../../src/interfaces';
@@ -20,9 +21,7 @@ describe('get-package', () => {
 
   describe('getPackageJson()', () => {
     beforeAll(() => {
-      (window.ElectronFiddle.getUsername as jest.Mock).mockReturnValue(
-        'test-user',
-      );
+      mocked(window.ElectronFiddle.getUsername).mockReturnValue('test-user');
     });
 
     const appState = new StateMock();

--- a/tests/renderer/versions-spec.ts
+++ b/tests/renderer/versions-spec.ts
@@ -1,3 +1,5 @@
+import { mocked } from 'jest-mock';
+
 import {
   ElectronReleaseChannel,
   GlobalSetting,
@@ -23,7 +25,7 @@ const mockVersions: Array<Partial<RunnableVersion>> = [
 describe('versions', () => {
   describe('getDefaultVersion()', () => {
     it('handles a stored version', () => {
-      (localStorage.getItem as jest.Mock).mockReturnValue('2.0.2');
+      mocked(localStorage.getItem).mockReturnValue('2.0.2');
       const output = getDefaultVersion([
         { version: '2.0.2' } as RunnableVersion,
       ]);
@@ -31,8 +33,8 @@ describe('versions', () => {
     });
 
     it('uses the newest stable as a fallback', () => {
-      (localStorage.getItem as jest.Mock).mockReturnValue(null);
-      (window.ElectronFiddle.getLatestStable as jest.Mock).mockReturnValue({
+      mocked(localStorage.getItem).mockReturnValue(null);
+      mocked(window.ElectronFiddle.getLatestStable).mockReturnValue({
         version: '13.0.0',
       });
       const output = getDefaultVersion([
@@ -85,7 +87,7 @@ describe('versions', () => {
 
   describe('addLocalVersion()', () => {
     beforeEach(() => {
-      (window.localStorage.getItem as jest.Mock).mockReturnValue(
+      mocked(window.localStorage.getItem).mockReturnValue(
         JSON.stringify([mockVersions[0]]),
       );
     });
@@ -126,7 +128,7 @@ describe('versions', () => {
     });
 
     it('migrates an old format if necessary', () => {
-      (window.localStorage.getItem as jest.Mock).mockReturnValueOnce(
+      mocked(window.localStorage.getItem).mockReturnValueOnce(
         `
         [{
           "url": "/Users/felixr/Code/electron/src/out/Debug",
@@ -155,7 +157,7 @@ describe('versions', () => {
 
   describe('fetchVersions()', () => {
     it('removes knownVersions from localStorage', async () => {
-      (window.ElectronFiddle.fetchVersions as jest.Mock).mockResolvedValue([]);
+      mocked(window.ElectronFiddle.fetchVersions).mockResolvedValue([]);
       await fetchVersions();
       expect(localStorage.removeItem).toHaveBeenCalledWith(
         GlobalSetting.knownVersion,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,7 @@
 import { configure as enzymeConfigure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createSerializer } from 'enzyme-to-json';
+import { mocked } from 'jest-mock';
 import { configure as mobxConfigure } from 'mobx';
 
 import { ElectronFiddleMock } from './mocks/mocks';
@@ -94,8 +95,8 @@ beforeEach(() => {
   document.body.innerHTML = '<div id="app" />';
 
   (window.ElectronFiddle as any) = new ElectronFiddleMock();
-  (window.localStorage.setItem as jest.Mock).mockReset();
-  (window.localStorage.getItem as jest.Mock).mockReset();
-  (window.localStorage.removeItem as jest.Mock).mockReset();
-  (window.open as jest.Mock).mockReset();
+  mocked(window.localStorage.setItem).mockReset();
+  mocked(window.localStorage.getItem).mockReset();
+  mocked(window.localStorage.removeItem).mockReset();
+  mocked(window.open).mockReset();
 });

--- a/tests/transforms/forge-spec.ts
+++ b/tests/transforms/forge-spec.ts
@@ -1,3 +1,6 @@
+import { ReleaseInfo } from '@electron/fiddle-core';
+import { mocked } from 'jest-mock';
+
 import { PACKAGE_NAME } from '../../src/interfaces';
 import { forgeTransform } from '../../src/renderer/transforms/forge';
 import { getForgeVersion } from '../../src/renderer/utils/get-package';
@@ -59,10 +62,10 @@ describe('forgeTransform()', () => {
   });
 
   it('forces ABI for nightly builds', async () => {
-    (window.ElectronFiddle.getReleaseInfo as jest.Mock).mockResolvedValue({
+    mocked(window.ElectronFiddle.getReleaseInfo).mockResolvedValue({
       version: '26.0.0-nightly.20230411',
       modules: '116',
-    });
+    } as ReleaseInfo);
     const filesBefore = new Map();
     filesBefore.set(
       PACKAGE_NAME,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,3 +1,4 @@
+import { mocked } from 'jest-mock';
 import { toJS } from 'mobx';
 
 import { FiddleEvent } from '../src/interfaces';
@@ -60,10 +61,10 @@ export function resetRendererArch() {
 }
 
 export function mockFetchOnce(text: string) {
-  (window.fetch as jest.Mock).mockResolvedValueOnce({
+  mocked(window.fetch).mockResolvedValueOnce({
     text: jest.fn().mockResolvedValue(text),
     json: jest.fn().mockImplementation(async () => JSON.parse(text)),
-  });
+  } as unknown as Response);
 }
 
 export class FetchMock {

--- a/tests/utils/read-fiddle-spec.ts
+++ b/tests/utils/read-fiddle-spec.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 
 import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
 
 import { EditorId, EditorValues, MAIN_JS } from '../../src/interfaces';
 import {
@@ -20,7 +21,7 @@ describe('read-fiddle', () => {
   });
 
   afterEach(() => {
-    (console.warn as jest.Mock).mockClear();
+    mocked(console.warn).mockClear();
   });
 
   function setupFSMocks(editorValues: EditorValues) {


### PR DESCRIPTION
Uses `mocked` from `jest-mock` to tighten up the typings for mocks with the intention of catching more bugs. Caught one legitimate bug as a result, #1417.

Calls to `fs` functions remain untouched because they're overloaded functions so `mocked` can't automatically infer the intended one.