### PR TITLE
ci: fix code signing on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
           paths:
             - out
   win-build:
+    environment:
+      SIGN_OR_DIE: true
     parameters:
       arch:
         type: enum
@@ -109,7 +111,9 @@ jobs:
       shell: bash.exe
     steps:
       - install
-      - run: export WINDOWS_CODESIGN_FILE=$(ts-node ./tools/add-windows-cert.ts)
+      - run: |
+          WINDOWS_CODESIGN_FILE=$(npx ts-node ./tools/add-windows-cert.ts)
+          echo 'export WINDOWS_CODESIGN_FILE="$WINDOWS_CODESIGN_FILE"' >> "$BASH_ENV"
       - run: npx yarn run publish --arch=<< parameters.arch >> --dry-run
       - store_artifacts:
           path: out

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -21,7 +21,15 @@ if (process.env['WINDOWS_CODESIGN_FILE']) {
 
   if (certExists) {
     process.env['WINDOWS_CODESIGN_FILE'] = certPath;
+  } else if (process.env['SIGN_OR_DIE']) {
+    throw new Error('Did not find Windows codesign file');
   }
+
+  if (!process.env['WINDOWS_CODESIGN_PASSWORD'] && process.env['SIGN_OR_DIE']) {
+    throw new Error('Did not find "WINDOWS_CODESIGN_PASSWORD" env variable');
+  }
+} else if (process.env['SIGN_OR_DIE']) {
+  throw new Error('Did not find "WINDOWS_CODESIGN_FILE" env variable');
 }
 
 const commonLinuxConfig = {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -24,12 +24,18 @@ if (process.env['WINDOWS_CODESIGN_FILE']) {
   } else if (process.env['SIGN_OR_DIE']) {
     throw new Error('Did not find Windows codesign file');
   }
+}
 
-  if (!process.env['WINDOWS_CODESIGN_PASSWORD'] && process.env['SIGN_OR_DIE']) {
-    throw new Error('Did not find "WINDOWS_CODESIGN_PASSWORD" env variable');
-  }
-} else if (process.env['SIGN_OR_DIE']) {
-  throw new Error('Did not find "WINDOWS_CODESIGN_FILE" env variable');
+if (
+  process.env['SIGN_OR_DIE'] &&
+  !(
+    process.env['WINDOWS_CODESIGN_FILE'] &&
+    process.env['WINDOWS_CODESIGN_PASSWORD']
+  )
+) {
+  throw new Error(
+    'Did not find "WINDOWS_CODESIGN_{FILE|PASSWORD}" env variable(s)',
+  );
 }
 
 const commonLinuxConfig = {

--- a/tools/add-windows-cert.ts
+++ b/tools/add-windows-cert.ts
@@ -25,3 +25,9 @@ export async function generateWindowsSigningCert() {
     throw new Error(`Could not generate code signing cert: ${err}`);
   }
 }
+
+if (require.main === module) {
+  (async () => {
+    await generateWindowsSigningCert();
+  })();
+}


### PR DESCRIPTION
There were a couple of issues preventing code signing on Windows from working properly, and it was silently failing. Fix those up and try to fail loudly if something isn't right.