### PR TITLE
ci: another Windows code signing fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,12 @@ jobs:
       shell: bash.exe
     steps:
       - install
-      - run: |
-          WINDOWS_CODESIGN_FILE=$(npx ts-node ./tools/add-windows-cert.ts)
-          echo 'export WINDOWS_CODESIGN_FILE="$WINDOWS_CODESIGN_FILE"' >> "$BASH_ENV"
+      - run:
+          name: Write signing cert to disk
+          command: |
+            set -e
+            WINDOWS_CODESIGN_FILE=$(npx ts-node ./tools/add-windows-cert.ts)
+            echo "export WINDOWS_CODESIGN_FILE=\"$WINDOWS_CODESIGN_FILE\"" >> $BASH_ENV
       - run: npx yarn run publish --arch=<< parameters.arch >> --dry-run
       - store_artifacts:
           path: out

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -16,12 +16,9 @@ const iconDir = path.resolve(__dirname, 'assets', 'icons');
 const root = process.cwd();
 
 if (process.env['WINDOWS_CODESIGN_FILE']) {
-  const certPath = path.join(__dirname, 'win-certificate.pfx');
-  const certExists = fs.existsSync(certPath);
+  const certPath = process.env['WINDOWS_CODESIGN_FILE'];
 
-  if (certExists) {
-    process.env['WINDOWS_CODESIGN_FILE'] = certPath;
-  } else if (process.env['SIGN_OR_DIE']) {
+  if (!fs.existsSync(certPath) && process.env['SIGN_OR_DIE']) {
     throw new Error('Did not find Windows codesign file');
   }
 }

--- a/tools/add-windows-cert.ts
+++ b/tools/add-windows-cert.ts
@@ -7,7 +7,7 @@ export async function generateWindowsSigningCert() {
   try {
     const dir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'builder-folder-'));
 
-    const certAsBase64 = process.env.WINDOWS_SIGNING_CERT;
+    const certAsBase64 = process.env.WINDOWS_CODESIGN_P12;
     if (!certAsBase64) {
       throw new Error(`Could not find code sign cert base value`);
     }
@@ -28,6 +28,6 @@ export async function generateWindowsSigningCert() {
 
 if (require.main === module) {
   (async () => {
-    await generateWindowsSigningCert();
+    console.log(await generateWindowsSigningCert());
   })();
 }


### PR DESCRIPTION
The first attempt here in #1419 had some problems that this sorts out, namely:
* Environment variables on CircleCI changed names
* Wasn't properly getting and using the output of `tools/add-windows-cert.ts`