### PR TITLE
refactor: move local path exists check to main process

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -109,6 +109,7 @@ declare global {
         { dir, packageManager }: PMOperationOptions,
         command: string,
       ): Promise<string>;
+      pathExists(path: string): boolean;
       platform: string;
       pushOutputEntry(entry: OutputEntry): void;
       readThemeFile(name?: string): Promise<LoadedFiddleTheme | null>;

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -58,6 +58,7 @@ export enum IpcEvents {
   GET_RELEASE_INFO = 'GET_RELEASE_INFO',
   GET_PROJECT_NAME = 'GET_PROJECT_NAME',
   GET_USERNAME = 'GET_USERNAME',
+  PATH_EXISTS = 'PATH_EXISTS',
 }
 
 export const ipcMainEvents = [
@@ -94,6 +95,7 @@ export const ipcMainEvents = [
   IpcEvents.GET_RELEASE_INFO,
   IpcEvents.GET_PROJECT_NAME,
   IpcEvents.GET_USERNAME,
+  IpcEvents.PATH_EXISTS,
 ];
 
 export const WEBCONTENTS_READY_FOR_IPC_SIGNAL =

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -9,6 +9,9 @@ import { isSupportedFile } from '../utils/editor-utils';
  * Ensures that we're listening to file events
  */
 export function setupFileListeners() {
+  ipcMainManager.on(IpcEvents.PATH_EXISTS, (event, path: string) => {
+    event.returnValue = fs.existsSync(path);
+  });
   ipcMainManager.on(IpcEvents.FS_SAVE_FIDDLE_DIALOG, () => {
     showSaveDialog();
   });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -135,6 +135,8 @@ export async function setupFiddleGlobal() {
         command,
       );
     },
+    pathExists: (path: string) =>
+      ipcRenderer.sendSync(IpcEvents.PATH_EXISTS, path),
     platform: process.platform,
     pushOutputEntry(entry) {
       ipcRenderer.send(IpcEvents.OUTPUT_ENTRY, entry);

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -4,7 +4,6 @@ import {
   ProgressObject,
   Runner,
 } from '@electron/fiddle-core';
-import * as fs from 'fs-extra';
 import {
   action,
   autorun,
@@ -924,7 +923,7 @@ export class AppState {
     }
 
     const { localPath, version } = ver;
-    if (localPath && !fs.existsSync(localPath)) {
+    if (localPath && !window.ElectronFiddle.pathExists(localPath)) {
       const err = `Local Electron build missing for version ${version} - please verify it is in the correct location or remove and re-add it.`;
       return { err };
     }

--- a/tests/main/files-spec.ts
+++ b/tests/main/files-spec.ts
@@ -47,6 +47,7 @@ describe('files', () => {
       setupFileListeners();
 
       expect(ipcMainManager.eventNames()).toEqual([
+        IpcEvents.PATH_EXISTS,
         IpcEvents.FS_SAVE_FIDDLE_DIALOG,
       ]);
 


### PR DESCRIPTION
A minimal refactor to remove a usage of `fs-extra` in the renderer.