### PR TITLE
fix: dispose previous local types when they change

### DIFF
--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -123,10 +123,12 @@ describe('ElectronTypes', () => {
       await electronTypes.setVersion(localVersion);
       expect(addExtraLib).toHaveBeenCalledWith(oldTypes);
 
+      expect(disposable.dispose).not.toHaveBeenCalled();
       const newTypes = saveTypesFile('some changed types');
       expect(newTypes).not.toEqual(oldTypes);
       await waitFor(() => addExtraLib.mock.calls.length > 1);
       expect(addExtraLib).toHaveBeenCalledWith(newTypes);
+      expect(disposable.dispose).toHaveBeenCalledTimes(1);
     });
 
     it('stops watching old types files when the version changes', async () => {


### PR DESCRIPTION
Follow-up to #1221. Since the types for local Electron versions can be updated, we should dispose any existing Electron types before adding the new ones.