### PR TITLE
refactor: move getting Node.js types to main process

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -9,6 +9,7 @@ import {
   IPackageManager,
   InstallState,
   MessageOptions,
+  NodeTypes,
   OutputEntry,
   PMOperationOptions,
   RunResult,
@@ -96,6 +97,9 @@ declare global {
       getTestTemplate(): Promise<EditorValues>;
       getLatestStable(): SemVer | undefined;
       getLocalVersionState(ver: Version): InstallState;
+      getNodeTypes(
+        version: string,
+      ): Promise<{ version: string; types: NodeTypes } | undefined>;
       getOldestSupportedMajor(): number | undefined;
       getReleaseInfo(version: string): Promise<ReleaseInfo | undefined>;
       getReleasedVersions(): Array<Version>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -235,3 +235,7 @@ export enum AppStateBroadcastMessageType {
   isDownloadingAll = 'isDownloadingAll',
   syncVersions = 'syncVersions',
 }
+
+export type NodeTypeDTS = `${string}.d.ts`;
+
+export type NodeTypes = Record<NodeTypeDTS, string>;

--- a/src/ipc-events.ts
+++ b/src/ipc-events.ts
@@ -59,6 +59,7 @@ export enum IpcEvents {
   GET_PROJECT_NAME = 'GET_PROJECT_NAME',
   GET_USERNAME = 'GET_USERNAME',
   PATH_EXISTS = 'PATH_EXISTS',
+  GET_NODE_TYPES = 'GET_NODE_TYPES',
 }
 
 export const ipcMainEvents = [
@@ -96,6 +97,7 @@ export const ipcMainEvents = [
   IpcEvents.GET_PROJECT_NAME,
   IpcEvents.GET_USERNAME,
   IpcEvents.PATH_EXISTS,
+  IpcEvents.GET_NODE_TYPES,
 ];
 
 export const WEBCONTENTS_READY_FOR_IPC_SIGNAL =

--- a/src/main/electron-types.ts
+++ b/src/main/electron-types.ts
@@ -1,0 +1,142 @@
+import * as path from 'node:path';
+
+import { ElectronVersions } from '@electron/fiddle-core';
+import fetch from 'cross-fetch';
+import { IpcMainEvent, app } from 'electron';
+import * as fs from 'fs-extra';
+import packageJson from 'package-json';
+import readdir from 'recursive-readdir';
+import semver from 'semver';
+
+import { ipcMainManager } from './ipc';
+import { NodeTypes } from '../interfaces';
+import { IpcEvents } from '../ipc-events';
+
+let electronTypes: ElectronTypes;
+
+export class ElectronTypes {
+  constructor(
+    private readonly knownVersions: ElectronVersions,
+    private readonly nodeCacheDir: string,
+  ) {}
+
+  public async getNodeTypes(
+    version: string,
+  ): Promise<{ version: string; types: NodeTypes } | undefined> {
+    // Get the Node.js version corresponding to the current Electron version.
+    const v = this.knownVersions.getReleaseInfo(version)?.node;
+
+    if (!v) return;
+
+    try {
+      const dir = this.getCacheDir(v);
+      const ver = await this.cacheAndReturnNodeTypesVersion(v, dir);
+
+      return { version: ver, types: await this.getTypesFromDir(dir) };
+    } catch (err) {
+      console.debug(
+        `Unable to get Node.js types for Electron "${version}": ${err.message}`,
+      );
+      return;
+    }
+  }
+
+  private async getTypesFromDir(dir: string): Promise<NodeTypes> {
+    const types: NodeTypes = {};
+
+    try {
+      const files = (await readdir(dir)).filter((f) => f.endsWith('.d.ts'));
+
+      for (const file of files) {
+        types[path.relative(dir, file) as keyof NodeTypes] = fs.readFileSync(
+          file,
+          'utf8',
+        );
+      }
+    } catch (err) {
+      console.debug(`Unable to read types from "${dir}": ${err.message}`);
+    }
+
+    return types;
+  }
+
+  private getCacheDir(version: string) {
+    return path.join(this.nodeCacheDir, version);
+  }
+
+  /**
+   * This function ensures that the Node.js version for a given version of
+   * Electron is downloaded and cached. It can be the case that DefinitelyTyped
+   * doesn't have specific Node.js versions, and if it's missing a certain version,
+   * we instead download the most recent version of Node.js in that release line older
+   * than the target version and return that. This also allows Electron versions to share
+   * versions of Node.js types.
+   *
+   * @param version - version of Node.js to fetch types for.
+   * @param dir - directory where the Node.js types version may be stored.
+   * @returns the version of Node.js types for this version of Electron.
+   */
+  private async cacheAndReturnNodeTypesVersion(version: string, dir: string) {
+    if (fs.existsSync(dir)) return version;
+
+    let downloadVersion = version;
+    let response = await fetch(
+      `https://unpkg.com/@types/node@${version}/?meta`,
+    );
+
+    if (response.status === 404) {
+      const types = await packageJson('@types/node', {
+        version: semver.major(version).toString(),
+        fullMetadata: false,
+      });
+
+      downloadVersion = types.version as string;
+      console.log(
+        `falling back to the latest applicable Node.js version type: ${downloadVersion}`,
+      );
+
+      const maybeCachedDir = path.join(this.nodeCacheDir, downloadVersion);
+      if (fs.existsSync(maybeCachedDir)) return downloadVersion;
+
+      response = await fetch(
+        `https://unpkg.com/@types/node@${downloadVersion}/?meta`,
+      );
+    }
+
+    const { files: fileJson } = (await response.json()) as {
+      files: { path: string }[];
+    };
+    await Promise.all(
+      fileJson
+        .flatMap((item: { files?: { path: string }[]; path: string }) => {
+          return item.files ? item.files.map((f: any) => f.path) : item.path;
+        })
+        .filter((path: string) => path.endsWith('.d.ts'))
+        .map(async (path: string) => {
+          const res = await fetch(
+            `https://unpkg.com/@types/node@${downloadVersion}${path}`,
+          );
+          const text = await res.text();
+          fs.outputFileSync(`${dir}${path}`, text);
+        }),
+    );
+
+    return downloadVersion;
+  }
+}
+
+export async function setupTypes(knownVersions: ElectronVersions) {
+  const userDataPath = app.getPath('userData');
+
+  electronTypes = new ElectronTypes(
+    knownVersions,
+    path.join(userDataPath, 'nodejs-typedef'),
+  );
+
+  ipcMainManager.handle(
+    IpcEvents.GET_NODE_TYPES,
+    (_: IpcMainEvent, version: string) => {
+      return electronTypes.getNodeTypes(version);
+    },
+  );
+}

--- a/src/main/electron-types.ts
+++ b/src/main/electron-types.ts
@@ -48,7 +48,7 @@ export class ElectronTypes {
       const files = (await readdir(dir)).filter((f) => f.endsWith('.d.ts'));
 
       for (const file of files) {
-        types[path.relative(dir, file) as keyof NodeTypes] = fs.readFileSync(
+        types[path.relative(dir, file) as keyof NodeTypes] = await fs.readFile(
           file,
           'utf8',
         );

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { processCommandLine } from './command-line';
 import { setupContent } from './content';
 import { setupDevTools } from './devtools';
 import { setupDialogs } from './dialogs';
+import { setupTypes } from './electron-types';
 import { onFirstRunMaybe } from './first-run';
 import { ipcMainManager } from './ipc';
 import { setupNpm } from './npm';
@@ -59,9 +60,10 @@ export async function onReady() {
   setupThemes();
   setupIsDevMode();
   setupNpm();
-  await setupVersions();
+  const knownVersions = await setupVersions();
   setupGetProjectName();
   setupGetUsername();
+  setupTypes(knownVersions);
 
   // Do this after setting everything up to ensure that
   // any IPC listeners are set up before they're used

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -107,6 +107,9 @@ export async function setupFiddleGlobal() {
         ignoreCache,
       );
     },
+    getNodeTypes(version) {
+      return ipcRenderer.invoke(IpcEvents.GET_NODE_TYPES, version);
+    },
     getProjectName(localPath?: string) {
       return ipcRenderer.invoke(IpcEvents.GET_PROJECT_NAME, localPath);
     },

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -45,7 +45,6 @@ export class App {
     this.electronTypes = new ElectronTypes(
       window.ElectronFiddle.monaco,
       path.join(USER_DATA_PATH, 'electron-typedef'),
-      path.join(USER_DATA_PATH, 'nodejs-typedef'),
     );
   }
 

--- a/tests/main/electron-types-spec.ts
+++ b/tests/main/electron-types-spec.ts
@@ -1,0 +1,117 @@
+import * as path from 'node:path';
+
+import { ReleaseInfo } from '@electron/fiddle-core';
+import { fetch } from 'cross-fetch';
+import * as fs from 'fs-extra';
+import { mocked } from 'jest-mock';
+import * as tmp from 'tmp';
+
+import {
+  InstallState,
+  RunnableVersion,
+  VersionSource,
+} from '../../src/interfaces';
+import { ElectronTypes } from '../../src/main/electron-types';
+import { ElectronVersionsMock } from '../mocks/fiddle-core';
+import { NodeTypesMock } from '../mocks/mocks';
+
+jest.mock('cross-fetch');
+jest.unmock('fs-extra');
+
+const { Response } = jest.requireActual('cross-fetch');
+
+describe('ElectronTypes', () => {
+  const version = '10.11.12';
+  const nodeVersion = '16.2.0';
+  let remoteVersion: RunnableVersion;
+  let tmpdir: tmp.DirResult;
+  let electronTypes: ElectronTypes;
+  let nodeTypesData: NodeTypesMock[];
+  let electronVersions: ElectronVersionsMock;
+
+  beforeEach(() => {
+    tmpdir = tmp.dirSync({
+      template: 'electron-fiddle-typedefs-XXXXXX',
+      unsafeCleanup: true,
+    });
+
+    const nodeCacheDir = path.join(tmpdir.name, 'node-cache');
+    const localDir = path.join(tmpdir.name, 'local');
+
+    fs.ensureDirSync(nodeCacheDir);
+    fs.ensureDirSync(localDir);
+
+    remoteVersion = {
+      version,
+      state: InstallState.installed,
+      source: VersionSource.remote,
+    } as const;
+
+    electronVersions = new ElectronVersionsMock();
+    electronTypes = new ElectronTypes(electronVersions as any, nodeCacheDir);
+    nodeTypesData = require('../fixtures/node-types.json');
+
+    mocked(electronVersions.getReleaseInfo).mockReturnValue({
+      node: nodeVersion,
+    } as ReleaseInfo);
+  });
+
+  afterEach(async () => {
+    tmpdir.removeCallback();
+  });
+
+  describe('getNodeTypes', () => {
+    it('fetches types', async () => {
+      mocked(fetch).mockImplementation(
+        () =>
+          new Response(JSON.stringify({ files: nodeTypesData }), {
+            status: 200,
+            statusText: 'OK',
+          }),
+      );
+
+      const version = { ...remoteVersion, version: '15.0.0-nightly.20210628' };
+      await expect(
+        electronTypes.getNodeTypes(version.version),
+      ).resolves.toEqual({ types: expect.anything(), version: nodeVersion });
+
+      expect(fetch).toHaveBeenCalledTimes(nodeTypesData.length);
+
+      for (const file of nodeTypesData.filter(({ path }) =>
+        path.endsWith('.d.ts'),
+      )) {
+        expect(fetch).toHaveBeenCalledWith(expect.stringMatching(file.path));
+      }
+    });
+
+    it('does not crash if fetch() rejects', async () => {
+      mocked(fetch).mockRejectedValue(new Error('💩'));
+      await expect(
+        electronTypes.getNodeTypes(remoteVersion.version),
+      ).resolves.toBe(undefined);
+      expect(fetch).toHaveBeenCalled();
+    });
+
+    it('does not crash if fetch() does not find the package', async () => {
+      mocked(fetch).mockResolvedValue(
+        new Response('Cannot find package', {
+          status: 404,
+          statusText: 'Not Found',
+        }),
+      );
+      await expect(
+        electronTypes.getNodeTypes(remoteVersion.version),
+      ).resolves.toBe(undefined);
+      expect(fetch).toHaveBeenCalled();
+    });
+
+    it('does not crash if no release info', async () => {
+      mocked(electronVersions.getReleaseInfo).mockReturnValue(undefined);
+
+      await expect(
+        electronTypes.getNodeTypes(remoteVersion.version),
+      ).resolves.toBe(undefined);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -17,6 +17,7 @@ export class ElectronFiddleMock {
   public getIsPackageManagerInstalled = jest.fn();
   public getLatestStable = jest.fn();
   public getLocalVersionState = jest.fn();
+  public getNodeTypes = jest.fn();
   public getOldestSupportedMajor = jest.fn();
   public getReleaseInfo = jest.fn();
   public getReleasedVersions = jest.fn();

--- a/tests/mocks/electron-types.ts
+++ b/tests/mocks/electron-types.ts
@@ -10,4 +10,5 @@ export interface NodeTypesMock {
   integrity: string;
   lastModified: string;
   size: number;
+  files?: NodeTypesMock[];
 }

--- a/tests/mocks/fiddle-core.ts
+++ b/tests/mocks/fiddle-core.ts
@@ -13,3 +13,7 @@ export class FiddleRunnerMock {
     return this.child;
   };
 }
+
+export class ElectronVersionsMock {
+  public getReleaseInfo = jest.fn();
+}

--- a/tests/renderer/electron-types-spec.ts
+++ b/tests/renderer/electron-types-spec.ts
@@ -1,12 +1,12 @@
 import * as path from 'node:path';
 
-import { ReleaseInfo } from '@electron/fiddle-core';
 import * as fs from 'fs-extra';
 import { mocked } from 'jest-mock';
 import * as tmp from 'tmp';
 
 import {
   InstallState,
+  NodeTypes,
   RunnableVersion,
   VersionSource,
 } from '../../src/interfaces';
@@ -36,11 +36,9 @@ describe('ElectronTypes', () => {
     });
 
     const electronCacheDir = path.join(tmpdir.name, 'electron-cache');
-    const nodeCacheDir = path.join(tmpdir.name, 'node-cache');
     const localDir = path.join(tmpdir.name, 'local');
 
     fs.ensureDirSync(electronCacheDir);
-    fs.ensureDirSync(nodeCacheDir);
     fs.ensureDirSync(localDir);
 
     monaco = new MonacoMock();
@@ -67,11 +65,7 @@ describe('ElectronTypes', () => {
     } as const;
     localFile = path.join(localDir, 'gen/electron/tsc/typings/electron.d.ts');
 
-    electronTypes = new ElectronTypes(
-      monaco as any,
-      electronCacheDir,
-      nodeCacheDir,
-    );
+    electronTypes = new ElectronTypes(monaco as any, electronCacheDir);
     nodeTypesData = require('../fixtures/node-types.json');
   });
 
@@ -83,7 +77,7 @@ describe('ElectronTypes', () => {
   function makeFetchSpy(text: string) {
     return jest.spyOn(global, 'fetch').mockResolvedValue({
       text: async () => text,
-      json: async () => ({ files: nodeTypesData }),
+      json: async () => ({}),
     } as Response);
   }
 
@@ -162,26 +156,25 @@ describe('ElectronTypes', () => {
     });
 
     it('fetches types', async () => {
-      mocked(window.ElectronFiddle.getReleaseInfo).mockResolvedValue({
-        node: '16.2.0',
-      } as ReleaseInfo);
-
+      const version = { ...remoteVersion, version: '15.0.0-nightly.20210628' };
       const types = 'here are the types';
       const fetchSpy = makeFetchSpy(types);
+      mocked(window.ElectronFiddle.getNodeTypes).mockResolvedValue({
+        version: version.version,
+        types: nodeTypesData
+          .flatMap((entry) => (entry.files ? entry.files : entry))
+          .filter(({ path }) => path.endsWith('.d.ts')) as unknown as NodeTypes,
+      });
 
-      const version = { ...remoteVersion, version: '15.0.0-nightly.20210628' };
       await electronTypes.setVersion(version);
 
-      expect(fetchSpy).toHaveBeenCalledTimes(nodeTypesData.length + 1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(
         expect.stringMatching('electron-nightly'),
       );
-
-      for (const file of nodeTypesData.filter(({ path }) =>
-        path.endsWith('.d.ts'),
-      )) {
-        expect(fetchSpy).toHaveBeenCalledWith(expect.stringMatching(file.path));
-      }
+      expect(window.ElectronFiddle.getNodeTypes).toHaveBeenCalledWith(
+        version.version,
+      );
 
       expect(addExtraLib).toHaveBeenCalledTimes(52);
       expect(addExtraLib).toHaveBeenCalledWith(types);
@@ -223,10 +216,10 @@ describe('ElectronTypes', () => {
       expect(addExtraLib).not.toHaveBeenCalled();
     });
 
-    it('does not crash if no release info', async () => {
-      mocked(window.ElectronFiddle.getReleaseInfo).mockResolvedValue(undefined);
-
+    it('does not crash if types are not found', async () => {
+      mocked(window.ElectronFiddle.getNodeTypes).mockResolvedValue(undefined);
       await electronTypes.setVersion(remoteVersion);
+      expect(window.ElectronFiddle.getNodeTypes).toHaveBeenCalledTimes(1);
       expect(addExtraLib).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
First PR to shift the file operations around Node.js types to the main process.