### PR TITLE
test: update `testMatch` for RTL tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   testEnvironmentOptions: {
     url: 'http://localhost',
   },
-  testMatch: ['**/rtl-spec/*.spec.*', '**/tests/**/*-spec.{ts,tsx}'],
+  testMatch: ['**/rtl-spec/**/*.spec.*', '**/tests/**/*-spec.{ts,tsx}'],
   resetMocks: true,
   bail: true,
   resetModules: true,


### PR DESCRIPTION
I moved RTL tests to a subfolder in #1432 and failed to update the regex to actually run these tests.

Should we have a coverage report in-PR to make it easier to spot any coverage drops?