### PR TITLE
fix: error loading big gists

### DIFF
--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -125,8 +125,11 @@ export class RemoteLoader {
       const values: EditorValues = {};
 
       for (const [id, data] of Object.entries(gist.data.files)) {
+        const content = data.truncated
+          ? await fetch(data.raw_url).then((r) => r.text())
+          : data.content;
         if (id === PACKAGE_NAME) {
-          const { dependencies, devDependencies } = JSON.parse(data.content);
+          const { dependencies, devDependencies } = JSON.parse(content);
           const deps: Record<string, string> = {
             ...dependencies,
             ...devDependencies,
@@ -177,7 +180,7 @@ export class RemoteLoader {
         if (!isSupportedFile(id)) continue;
 
         if (isKnownFile(id) || (await this.confirmAddFile(id))) {
-          values[id] = data.content;
+          values[id] = content;
         }
       }
 

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -167,25 +167,28 @@ describe('RemoteLoader', () => {
 
     it('handles gists with files over 1mb', async () => {
       const gistId = 'toobig';
+      const filename = 'index.js';
+      const content = 'hello im huge';
 
-      mockGistFiles['index.js'] = {
+      editorValues[filename] = content;
+      mockGistFiles[filename] = {
         truncated: true,
-        content: JSON.stringify('hello im huge', null, 2),
+        content: 'truncated',
         raw_url: 'https://gist.githubusercontent.com/IMTOOBIG',
       };
 
-      jest.spyOn(global, 'fetch').mockImplementationOnce(() =>
-        Promise.resolve({
-          text: () => Promise.resolve('hello im huge'),
-        } as Response),
-      );
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        text: () => Promise.resolve(content),
+      } as Response);
 
       mocked(getOctokit).mockResolvedValue({
         gists: mockGetGists,
       } as unknown as Octokit);
+      instance.confirmAddFile = jest.fn().mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
       expect(result).toBe(true);
+      expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
     });
 
     it('does not set an invalid Electron version from package.json', async () => {


### PR DESCRIPTION
Closes #1438 

Fixes an issue where loading gists over 1mb would throw an error due to the file being truncated. Per [Gist Docs](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#truncation), when the file is truncated, the full contents can be obtained by fetching the raw url. This adds error handling for that issue.

Tested w/ https://gist.github.com/codebytere/e06a6d4e650ee581f90d0159b701aaa2