### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   node: electronjs/node@1.2.0
-  win: circleci/windows@5.0.0
 
 commands:
   install:
@@ -47,9 +46,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64' ]
-    macos:
-      xcode: '13.4.0'
-    resource_class: macos.x86.medium.gen2
+    executor: node/macos
     steps:
       - install
       - test
@@ -58,9 +55,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64', 'ia32' ]
-    executor:
-      name: win/default
-      shell: bash.exe
+    executor: node/windows
     steps:
       - install
       - test
@@ -69,8 +64,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64','armv7l' ]
-    docker:
-      - image: cimg/base:stable
+    executor: node/linux
     steps:
       - install
       - test
@@ -79,9 +73,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64' ]
-    macos:
-      xcode: '13.4.0'
-    resource_class: macos.x86.medium.gen2
+    executor: node/macos
     steps:
       - install
       - run: chmod +x tools/add-macos-cert.sh && ./tools/add-macos-cert.sh
@@ -99,9 +91,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64', 'ia32' ]
-    executor:
-      name: win/default
-      shell: bash.exe
+    executor: node/windows
     steps:
       - install
       - run:
@@ -122,8 +112,7 @@ jobs:
       arch:
         type: enum
         enum: [ 'x64', 'arm64','armv7l' ]
-    docker:
-      - image: cimg/base:stable
+    executor: node/linux
     steps:
       - run: sudo apt-get update && sudo apt install rpm squashfs-tools
       - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: electronjs/node@1.3.0
+  node: electronjs/node@1.4.1
 
 commands:
   install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
     steps:
       - run: git config --global core.autocrlf input
       - node/install:
-          node-version: 18.17
+          node-version: '18.17'
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,9 @@ commands:
       - node/install:
           node-version: '18.17'
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-dependencies-{{ arch }}
-      - run: yarn install --frozen-lockfile
+      - node/install-packages
       - run: yarn run contributors
       - run: yarn run electron-releases
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
   load-gh-token:
     steps:
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.1.0
+  node: electronjs/node@1.2.0
   win: circleci/windows@5.0.0
 
 commands:
@@ -9,19 +9,12 @@ commands:
     steps:
       - run: git config --global core.autocrlf input
       - node/install:
-          # NOTE: nvm-windows only supports proper semver strings
-          # we could omit the patch release whenever we have 1.1.0:
-          # https://github.com/coreybutler/nvm-windows/releases/tag/1.1.10
-          # This is the file to check:
-          # https://github.com/CircleCI-Public/ansible/blob/main/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml#L13
-          node-version: '18.17.0'
-      - run: nvm use 18.17.0
+          node-version: 18.17
       - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
             - v1-dependencies-{{ arch }}
-      - run: npm install --global yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run contributors
       - run: yarn run electron-releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: electronjs/node@1.2.0
+  node: electronjs/node@1.3.0
 
 commands:
   install:


### PR DESCRIPTION
Use `electronjs/node` orb to pick up caching of Node.js installs, clear the note about using Node.js versions without the patch number (works now), and simplify the config a little.