### PR TITLE
fix: deleting gist files

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -213,8 +213,8 @@ export const GistActionButton = observer(
 
         const files = this.gistFilesList(values);
         for (const id of Object.keys(oldFiles)) {
-          // Gist files are deleted by setting content to an empty string.
-          if (!(id in files)) files[id] = { content: '' };
+          // Delete files that have been removed or renamed.
+          if (!(id in files)) files[id] = null as any;
         }
 
         const gist = await octo.gists.update({


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1457.

The previous logic appears to have been based on a misconception:

> Gist files are deleted by setting content to an empty string.

Per [docs](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#update-a-gist):

> To delete a file, set the whole file to null. For example: `hello.py : null`. The file will also be deleted if the specified object does not contain at least one of content or filename.