### PR TITLE
fix: update element selectors for tour

### DIFF
--- a/src/less/components/version-select.less
+++ b/src/less/components/version-select.less
@@ -1,5 +1,5 @@
 .bp3-fill {
-  .version-chooser  {
+  #version-chooser  {
     width: 100%;
   }
 }

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -360,6 +360,7 @@ export const GistActionButton = observer(
             <ButtonGroup className="button-gist-action">
               {this.renderPrivacyMenu()}
               <Button
+                id="button-action"
                 onClick={this.handleClick}
                 loading={isPerformingAction}
                 icon={getActionIcon()}

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -30,12 +30,12 @@ export const Runner = observer(
       } = this.props.appState;
 
       const state = currentElectronVersion?.state;
-      const props: ButtonProps = { className: 'button-run', disabled: true };
+      const props: ButtonProps = { disabled: true };
 
       if ([downloading, missing].includes(state) && !isOnline) {
         props.text = 'Offline';
         props.icon = 'satellite';
-        return <Button {...props} type={undefined} />;
+        return <Button id="button-run" {...props} type={undefined} />;
       }
 
       switch (state) {
@@ -78,7 +78,7 @@ export const Runner = observer(
         }
       }
 
-      return <Button {...props} type={undefined} />;
+      return <Button id="button-run" {...props} type={undefined} />;
     }
   },
 );

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -43,7 +43,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
     },
     {
       name: 'select-versions',
-      selector: 'button.version-chooser',
+      selector: '#version-chooser',
       title: '📇 Choose an Electron Version',
       content: (
         <>
@@ -60,13 +60,13 @@ export function getWelcomeTour(): Set<TourScriptStep> {
     },
     {
       name: 'button-run',
-      selector: '.button-run',
+      selector: '#button-run',
       title: '🚀 Run Your Fiddle',
       content: <p>Hit this button to give your Fiddle a try and start it.</p>,
     },
     {
-      name: 'button-publish',
-      selector: '.button-publish',
+      name: 'button-action',
+      selector: '#button-action',
       title: '🗺 Share Your Fiddle',
       content: (
         <>
@@ -111,7 +111,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
     },
     {
       name: 'main-editor',
-      selector: 'div.mosaic-window.main',
+      selector: 'div.mosaic-window.main\\.js',
       title: '📝 Main Script',
       content: (
         <>
@@ -137,7 +137,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
     },
     {
       name: 'html-editor',
-      selector: 'div.mosaic-window.html',
+      selector: 'div.mosaic-window.index\\.html',
       title: '📝 HTML',
       content: (
         <p>
@@ -152,7 +152,7 @@ export function getWelcomeTour(): Set<TourScriptStep> {
     },
     {
       name: 'renderer-editor',
-      selector: 'div.mosaic-window.renderer',
+      selector: 'div.mosaic-window.renderer\\.js',
       title: '📝  Renderer Script',
       content: (
         <>

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -266,7 +266,7 @@ export const VersionSelect = observer(
           disabled={!!this.props.disabled}
         >
           <Button
-            className="version-chooser"
+            id="version-chooser"
             text={`Electron v${version}`}
             icon={getItemIcon(currentVersion)}
             onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/renderer/utils/position-for-rect.ts
+++ b/src/renderer/utils/position-for-rect.ts
@@ -52,6 +52,14 @@ export function positionForRect(
     return { ...result, type: 'bottom' };
   }
 
+  // Okay, let's try bottom left
+  result.left = target.left - margin - size.width;
+  result.top = target.top + target.height + margin;
+
+  if (isResultOkay(result, size)) {
+    return { ...result, type: 'left' };
+  }
+
   // Top middle would require us to measure the
   // text height, which is a bit gross. I'll leave
   // this commented out for now, but if you need it

--- a/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-publish-button-spec.tsx.snap
@@ -58,6 +58,7 @@ exports[`Action button component renders 1`] = `
       </Blueprint3.Popover>
       <Blueprint3.Button
         icon="upload"
+        id="button-action"
         loading={false}
         onClick={[Function]}
         text="Publish"

--- a/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Runner component renders InstallState.downloading 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={true}
   icon={
     <Blueprint3.Spinner
@@ -10,51 +9,52 @@ exports[`Runner component renders InstallState.downloading 1`] = `
       value={50}
     />
   }
+  id="button-run"
   text="Downloading"
 />
 `;
 
 exports[`Runner component renders InstallState.installed 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={false}
   icon="play"
+  id="button-run"
   onClick={[MockFunction]}
   text="Run"
 />
 `;
 
-exports[`Runner component renders InstallState.missing 1`] = `
+exports[`Runner component renders InstallState.installing 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={true}
   icon={
     <Blueprint3.Spinner
       size={16}
     />
   }
-  text="Checking status"
+  id="button-run"
+  text="Unzipping"
 />
 `;
 
-exports[`Runner component renders InstallState.installing 1`] = `
+exports[`Runner component renders InstallState.missing 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={true}
   icon={
     <Blueprint3.Spinner
       size={16}
     />
   }
-  text="Unzipping"
+  id="button-run"
+  text="Checking status"
 />
 `;
 
 exports[`Runner component renders idle 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={false}
   icon="play"
+  id="button-run"
   onClick={[MockFunction]}
   text="Run"
 />
@@ -62,13 +62,13 @@ exports[`Runner component renders idle 1`] = `
 
 exports[`Runner component renders installing modules 1`] = `
 <Blueprint3.Button
-  className="button-run"
   disabled={false}
   icon={
     <Blueprint3.Spinner
       size={16}
     />
   }
+  id="button-run"
   text="Installing modules"
 />
 `;
@@ -76,9 +76,9 @@ exports[`Runner component renders installing modules 1`] = `
 exports[`Runner component renders running 1`] = `
 <Blueprint3.Button
   active={true}
-  className="button-run"
   disabled={false}
   icon="stop"
+  id="button-run"
   onClick={[MockFunction]}
   text="Stop"
 />

--- a/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/tour-welcome-spec.tsx.snap
@@ -84,7 +84,7 @@ exports[`Header component renders the tour once started 1`] = `
           </p>
         </React.Fragment>,
         "name": "select-versions",
-        "selector": "button.version-chooser",
+        "selector": "#version-chooser",
         "title": "📇 Choose an Electron Version",
       },
       {
@@ -92,7 +92,7 @@ exports[`Header component renders the tour once started 1`] = `
           Hit this button to give your Fiddle a try and start it.
         </p>,
         "name": "button-run",
-        "selector": ".button-run",
+        "selector": "#button-run",
         "title": "🚀 Run Your Fiddle",
       },
       {
@@ -104,8 +104,8 @@ exports[`Header component renders the tour once started 1`] = `
             You can also package your Fiddle as a standalone binary or as an installer from the "Tasks" menu.
           </p>
         </React.Fragment>,
-        "name": "button-publish",
-        "selector": ".button-publish",
+        "name": "button-action",
+        "selector": "#button-action",
         "title": "🗺 Share Your Fiddle",
       },
       {
@@ -142,7 +142,7 @@ exports[`Header component renders the tour once started 1`] = `
           </p>
         </React.Fragment>,
         "name": "main-editor",
-        "selector": "div.mosaic-window.main",
+        "selector": "div.mosaic-window.main\\.js",
         "title": "📝 Main Script",
       },
       {
@@ -163,7 +163,7 @@ exports[`Header component renders the tour once started 1`] = `
            like we would in Node.js.
         </p>,
         "name": "html-editor",
-        "selector": "div.mosaic-window.html",
+        "selector": "div.mosaic-window.index\\.html",
         "title": "📝 HTML",
       },
       {
@@ -188,7 +188,7 @@ exports[`Header component renders the tour once started 1`] = `
           </p>
         </React.Fragment>,
         "name": "renderer-editor",
-        "selector": "div.mosaic-window.renderer",
+        "selector": "div.mosaic-window.renderer\\.js",
         "title": "📝  Renderer Script",
       },
     }

--- a/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/version-select-spec.tsx.snap
@@ -76,9 +76,9 @@ exports[`VersionSelect component renders 1`] = `
   onItemSelect={[Function]}
 >
   <Blueprint3.Button
-    className="version-chooser"
     disabled={false}
     icon="cloud"
+    id="version-chooser"
     onContextMenu={[Function]}
     text="Electron v1.0.0"
   />

--- a/tools/webpack/webpack.renderer.config.ts
+++ b/tools/webpack/webpack.renderer.config.ts
@@ -72,7 +72,7 @@ export const rendererConfig: Configuration = {
     // Workaround for Blueprint issue
     // See https://github.com/palantir/blueprint/issues/3739
     new DefinePlugin({
-      'process.env': `(${JSON.stringify(process.env)})`,
+      'process.env': '{}',
     }),
   ],
   resolve: {


### PR DESCRIPTION
The "Show Tour" feature is failing to highlight correct elements as the selectors are no longer valid. Change some of the selectors to ID rather than class, as that seems more correct. The editor selectors have to remain as-is as they're also used in CSS, but because they have dots in the class name (eek) they need to be escaped to be used as selectors.