### PR TITLE
ci: use larger resource class for Linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
         type: enum
         enum: [ 'x64', 'arm64','armv7l' ]
     executor: node/linux
+    resource_class: medium+
     steps:
       - run: sudo apt-get update && sudo apt install rpm squashfs-tools
       - install


### PR DESCRIPTION
We're seeing OOM occasionally on Linux builds due to over parallelization during packaging (due to running in a Docker container and getting the number of system CPUs, not how many vCPUs are available). Since it's right on the cusp (doesn't OOM every time), let's just bump the resource class as that's simplest and this job only runs on release builds.