### PR TITLE
Add @autobind decorator for binding class methods

### DIFF
--- a/src/renderer/bisect.ts
+++ b/src/renderer/bisect.ts
@@ -1,5 +1,7 @@
 import { RunnableVersion } from '../interfaces';
+import { autobind } from 'bind-decorator';
 
+@autobind
 export class Bisector {
   public revList: Array<RunnableVersion>;
   public minRev: number;
@@ -7,10 +9,6 @@ export class Bisector {
   private pivot: number;
 
   constructor(revList: Array<RunnableVersion>) {
-    this.getCurrentVersion = this.getCurrentVersion.bind(this);
-    this.continue = this.continue.bind(this);
-    this.calculatePivot = this.calculatePivot.bind(this);
-
     this.revList = revList;
     this.minRev = 0;
     this.maxRev = revList.length - 1;


### PR DESCRIPTION
**Changes Made:**

- Added the `@autobind` decorator from the `bind-decorator` library to automatically bind class methods.
- Removed manual method binding using `.bind(this)` for improved code readability and maintainability.

**Context:**

This pull request addresses the issue #1027 which requested the Use Typescript Decorators for binding this to class Methods.

**How to Test:**

1. Clone this PR branch.
2. Install the autobind-decorator  library by running the following command:

**Additional Notes:**

- Please review the changes and provide feedback.
- Let me know if any further adjustments or clarifications are needed.