### PR TITLE
ci: use GitHub actions for Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  coveralls: coveralls/coveralls@2.2.1
   node: electronjs/node@1.4.1
 
 commands:
@@ -61,7 +60,6 @@ jobs:
     steps:
       - install
       - test
-      - coveralls/upload
   mac-build:
     parameters:
       arch:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,31 @@
+name: Coveralls
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  test:
+    name: Check Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 18.x
+          cache: yarn
+      - name: Install
+        run: yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000
+      - run: yarn run contributors
+      - run: yarn run electron-releases
+      - name: test
+        run: yarn test:ci
+      - name: Coveralls
+        uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2.2.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If you use Coveralls from anything other than GitHub actions you need to provide a repo token, which doesn't work with forks because we don't want to expose secrets to them. It works on GitHub actions though, so bring it back there.