### PR TITLE
fix: mark fiddle as edited if files added/deleted

### DIFF
--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -165,6 +165,8 @@ export class EditorMosaic {
     } else {
       this.hide(id);
     }
+
+    this.isEdited = true;
   }
 
   /// show or hide files in the view
@@ -237,6 +239,8 @@ export class EditorMosaic {
     this.editors.delete(id);
     this.backups.delete(id);
     this.setVisible(getLeaves(this.mosaic).filter((v) => v !== id));
+
+    this.isEdited = true;
   }
 
   /** Wire up a newly-mounted Monaco editor */

--- a/tests/renderer/editor-mosaic-spec.ts
+++ b/tests/renderer/editor-mosaic-spec.ts
@@ -239,6 +239,24 @@ describe('EditorMosaic', () => {
     });
   });
 
+  describe('addNewFile()', () => {
+    it('sets isEdited to true', () => {
+      editorMosaic.set(createEditorValues());
+      editorMosaic.isEdited = false;
+      editorMosaic.addNewFile('foo.js');
+      expect(editorMosaic.isEdited).toBe(true);
+    });
+  });
+
+  describe('remove()', () => {
+    it('sets isEdited to true', () => {
+      editorMosaic.set(createEditorValues());
+      editorMosaic.isEdited = false;
+      editorMosaic.remove('renderer.js');
+      expect(editorMosaic.isEdited).toBe(true);
+    });
+  });
+
   describe('set()', () => {
     it('resets isEdited to false', () => {
       editorMosaic.isEdited = true;


### PR DESCRIPTION
Currently adding or deleting a file doesn't count as editing a fiddle which can lead to non-ideal behavior like adding a file without content and then switching selected versions and having the file disappear, or deleting a file and then closing the window and not being prompted to save.