### PR TITLE
build(deps): bump @electron/fiddle-core to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@blueprintjs/core": "^3.36.0",
     "@blueprintjs/popover2": "^0.12.2",
     "@blueprintjs/select": "^3.15.0",
-    "@electron/fiddle-core": "^1.3.1",
+    "@electron/fiddle-core": "^1.3.2",
     "@octokit/rest": "^16.43.1",
     "@sentry/electron": "^4.10.0",
     "algoliasearch": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,10 +1182,10 @@
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
-"@electron/fiddle-core@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@electron/fiddle-core/-/fiddle-core-1.3.1.tgz#b73cd9e278068d0aff445cba7203cd7682d2e33c"
-  integrity sha512-W2avioiGHVl2wzc4xUVk80x6elgmNTf/TNtaGxIA3I60h4OeOr3Un9pArhIPq0vVHAFTGtBaWVVKP7aHOoBs1A==
+"@electron/fiddle-core@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@electron/fiddle-core/-/fiddle-core-1.3.2.tgz#6c1a14c921762df3a43d51fd844da6ed08a5ec8b"
+  integrity sha512-WvTtiX13XCo1pn9Bv/b/+KofHTYCKUILggi/UuMpj/gSIRA8phWfIniaD4TYtX4HPtOtWstxc1IwZd0XriR5og==
   dependencies:
     "@electron/get" "^2.0.0"
     debug "^4.3.3"


### PR DESCRIPTION
Fixes #1468

Potentially some other issues related to versions getting stuck in a state when an error occurs.