### PR TITLE
fix: allow protocol launch in all platforms

### DIFF
--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -119,7 +119,7 @@ export const listenForProtocolHandler = () => {
   // pass protocol URL via npm start args in dev mode
   if (isDevMode() && process.env.npm_config_argv) {
     scanNpmArgv(process.env.npm_config_argv);
-  } else if (process.platform === 'win32') {
+  } else {
     scanArgv(process.argv);
   }
 };


### PR DESCRIPTION
Someone on Discord pointed out that the "Open in Fiddle" buttons on the website (https://www.electronjs.org/docs/latest/tutorial/examples) don't currently load the selected Fiddle on Linux, they just open the app. I'm not sure why we're only handling protocol launches on Windows, but I've tested on Ubuntu 22.04 and it works (not sure about macOS though).