### PR TITLE
ci: download Apple Developer ID Intermediate certificate

### DIFF
--- a/tools/add-macos-cert.sh
+++ b/tools/add-macos-cert.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 KEY_CHAIN=build.keychain
 MACOS_CERT_P12_FILE=certificate.p12
 
@@ -27,9 +29,18 @@ security default-keychain -s $KEY_CHAIN
 # Unlock the keychain
 security unlock-keychain -p actions $KEY_CHAIN
 
+# The latest Developer ID Intermediate Certificate from Apple is
+# missing on CircleCI, but we need it for the cert to be valid
+curl https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o DeveloperIDG2CA.cer
+sudo security add-trusted-cert -d -r unspecified -k $KEY_CHAIN DeveloperIDG2CA.cer
+rm -f DeveloperIDG2CA.cer
+
 security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign;
 
 security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# Debugging output
+security find-identity
 
 # remove certs
 rm -fr *.p12


### PR DESCRIPTION
This is missing on CircleCI machines and causes the new certificate for macOS code signing to not be seen as valid.