### PR TITLE
ci: restore usage of `load-release-secrets`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
       - install
       - attach_workspace:
           at: .
+      - load-release-secrets
       - run: yarn run publish --from-dry-run
   notify-sentry-deploy:
     docker:


### PR DESCRIPTION
This was removed to work around an issue that has now been resolved in the secrets service.