### PR TITLE
feat: add support for JSON files in editors

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -137,7 +137,7 @@ export const enum GenericDialogType {
   'success' = 'success',
 }
 
-export type EditorId = `${string}.${'js' | 'html' | 'css'}`;
+export type EditorId = `${string}.${'js' | 'html' | 'css' | 'json'}`;
 
 export type EditorValues = Record<EditorId, string>;
 

--- a/src/main/utils/read-fiddle.ts
+++ b/src/main/utils/read-fiddle.ts
@@ -22,9 +22,17 @@ export async function readFiddle(
     // TODO(dsanders11): Remove options once issue fixed:
     // https://github.com/isaacs/node-graceful-fs/issues/223
     const files = await fs.readdir(folder, { encoding: 'utf8' });
-    const names = files.filter(
-      (f) => isSupportedFile(f) || (includePackageJson && f === PACKAGE_NAME),
-    );
+    const names = files.filter((f) => {
+      if (f === 'package-lock.json') {
+        return false;
+      }
+
+      if (f === PACKAGE_NAME) {
+        return includePackageJson;
+      }
+
+      return isSupportedFile(f);
+    });
 
     const values = await Promise.allSettled(
       names.map((name) => fs.readFile(path.join(folder, name), 'utf8')),

--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -14,7 +14,7 @@ import { ContextMenu2, Tooltip2 } from '@blueprintjs/popover2';
 import classNames from 'classnames';
 import { observer } from 'mobx-react';
 
-import { EditorId } from '../../interfaces';
+import { EditorId, PACKAGE_NAME } from '../../interfaces';
 import { EditorPresence } from '../editor-mosaic';
 import { AppState } from '../state';
 import { isRequiredFile, isSupportedFile } from '../utils/editor-utils';
@@ -189,9 +189,19 @@ export const SidebarFileTree = observer(
 
       if (!id) return;
 
+      if (
+        id.endsWith('.json') &&
+        [PACKAGE_NAME, 'package-lock.json'].includes(id)
+      ) {
+        await appState.showErrorDialog(
+          'Cannot add package.json or package-lock.json as custom files',
+        );
+        return;
+      }
+
       if (!isSupportedFile(id)) {
         await appState.showErrorDialog(
-          `Invalid filename "${id}": Must be a file ending in .js, .html, or .css`,
+          `Invalid filename "${id}": Must be a file ending in .js, .html, .css, or .json`,
         );
         return;
       }

--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -194,7 +194,7 @@ export const SidebarFileTree = observer(
         [PACKAGE_NAME, 'package-lock.json'].includes(id)
       ) {
         await appState.showErrorDialog(
-          'Cannot add package.json or package-lock.json as custom files',
+          `Cannot add ${PACKAGE_NAME} or package-lock.json as custom files`,
         );
         return;
       }

--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -145,7 +145,7 @@ export class EditorMosaic {
       [PACKAGE_NAME, 'package-lock.json'].includes(id)
     ) {
       throw new Error(
-        'Cannot add package.json or package-lock.json as custom files',
+        `Cannot add ${PACKAGE_NAME} or package-lock.json as custom files`,
       );
     }
 

--- a/src/renderer/editor-mosaic.ts
+++ b/src/renderer/editor-mosaic.ts
@@ -8,7 +8,7 @@ import {
   isSupportedFile,
   monacoLanguage,
 } from './utils/editor-utils';
-import { EditorId, EditorValues } from '../interfaces';
+import { EditorId, EditorValues, PACKAGE_NAME } from '../interfaces';
 
 export type Editor = MonacoType.editor.IStandaloneCodeEditor;
 
@@ -140,8 +140,20 @@ export class EditorMosaic {
 
   /** Add a file. If we already have a file with that name, replace it. */
   private addFile(id: EditorId, value: string) {
-    if (!isSupportedFile(id))
-      throw new Error(`Cannot add file "${id}": Must be .js, .html, or .css`);
+    if (
+      id.endsWith('.json') &&
+      [PACKAGE_NAME, 'package-lock.json'].includes(id)
+    ) {
+      throw new Error(
+        'Cannot add package.json or package-lock.json as custom files',
+      );
+    }
+
+    if (!isSupportedFile(id)) {
+      throw new Error(
+        `Cannot add file "${id}": Must be .js, .html, .css, or .json`,
+      );
+    }
 
     // create a monaco model with the file's contents
     const { monaco } = window;

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -128,6 +128,7 @@ export class RemoteLoader {
         const content = data.truncated
           ? await fetch(data.raw_url).then((r) => r.text())
           : data.content;
+
         if (id === PACKAGE_NAME) {
           const { dependencies, devDependencies } = JSON.parse(content);
           const deps: Record<string, string> = {
@@ -176,6 +177,10 @@ export class RemoteLoader {
 
           this.appState.modules = new Map(Object.entries(deps));
         }
+
+        // JSON files are supported, but we don't want to add package.json
+        // or the lockfile to the visible editor array.
+        if ([PACKAGE_NAME, 'package-lock.json'].includes(id)) continue;
 
         if (!isSupportedFile(id)) continue;
 

--- a/src/renderer/utils/editor-utils.ts
+++ b/src/renderer/utils/editor-utils.ts
@@ -56,5 +56,6 @@ export function monacoLanguage(filename: string) {
   const suffix = getSuffix(filename);
   if (suffix === 'css') return 'css';
   if (suffix === 'html') return 'html';
+  if (suffix === 'json') return 'json';
   return 'javascript';
 }

--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -6,6 +6,7 @@ const EMPTY_EDITOR_CONTENT = {
   css: '/* Empty */',
   html: '<!-- Empty -->',
   js: '// Empty',
+  json: '{}',
 } as const;
 
 export function getEmptyContent(filename: string): string {
@@ -32,5 +33,5 @@ export function getSuffix(filename: string) {
 }
 
 export function isSupportedFile(filename: string): filename is EditorId {
-  return /\.(css|html|js)$/i.test(filename);
+  return /\.(css|html|js|json)$/i.test(filename);
 }

--- a/tests/main/utils/read-fiddle-spec.ts
+++ b/tests/main/utils/read-fiddle-spec.ts
@@ -55,7 +55,7 @@ describe('read-fiddle', () => {
     expect(fiddle).toStrictEqual(mockValues);
   });
 
-  it('reads JSON files only if they are not package.json', async () => {
+  it(`reads JSON files only if they are not ${PACKAGE_NAME}`, async () => {
     const content = 'hello im main';
     const mockValues = {
       [MAIN_JS]: content,

--- a/tests/main/utils/read-fiddle-spec.ts
+++ b/tests/main/utils/read-fiddle-spec.ts
@@ -3,7 +3,12 @@ import * as path from 'node:path';
 import * as fs from 'fs-extra';
 import { mocked } from 'jest-mock';
 
-import { EditorId, EditorValues, MAIN_JS } from '../../../src/interfaces';
+import {
+  EditorId,
+  EditorValues,
+  MAIN_JS,
+  PACKAGE_NAME,
+} from '../../../src/interfaces';
 import { readFiddle } from '../../../src/main/utils/read-fiddle';
 import {
   ensureRequiredFiles,
@@ -47,8 +52,24 @@ describe('read-fiddle', () => {
     setupFSMocks(mockValues);
 
     const fiddle = await readFiddle(folder);
-
     expect(fiddle).toStrictEqual(mockValues);
+  });
+
+  it('reads JSON files only if they are not package.json', async () => {
+    const content = 'hello im main';
+    const mockValues = {
+      [MAIN_JS]: content,
+      'file.json': '{ "hello": "world" }',
+      [PACKAGE_NAME]: '{}',
+    };
+
+    setupFSMocks(mockValues);
+
+    const fiddle = await readFiddle(folder);
+    expect(fiddle).toStrictEqual({
+      [MAIN_JS]: content,
+      'file.json': '{ "hello": "world" }',
+    });
   });
 
   it('skips unsupported files', async () => {

--- a/tests/renderer/components/sidebar-file-tree-spec.tsx
+++ b/tests/renderer/components/sidebar-file-tree-spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EditorValues } from '../../../src/interfaces';
+import { EditorValues, PACKAGE_NAME } from '../../../src/interfaces';
 import { Editors } from '../../../src/renderer/components/editors';
 import { SidebarFileTree } from '../../../src/renderer/components/sidebar-file-tree';
 import {
@@ -95,6 +95,26 @@ describe('SidebarFileTree component', () => {
     expect(editorMosaic.files.get(EDITOR_NAME)).toBe(undefined);
     expect(editorMosaic.files.get(EDITOR_NEW_NAME)).toBe(
       EditorPresence.Pending,
+    );
+  });
+
+  it('fails if trying to rename an editor to an invalid value', async () => {
+    const wrapper = shallow(<SidebarFileTree appState={store} />);
+    const instance: any = wrapper.instance();
+
+    const EDITOR_NAME = 'data.json';
+    const EDITOR_NEW_NAME = PACKAGE_NAME;
+
+    editorValues[EDITOR_NAME] = '{}';
+    editorMosaic.set(editorValues);
+
+    store.showInputDialog = jest.fn().mockResolvedValueOnce(EDITOR_NEW_NAME);
+    store.showErrorDialog = jest.fn().mockResolvedValueOnce(true);
+
+    await instance.renameEditor(EDITOR_NAME);
+
+    expect(store.showErrorDialog).toHaveBeenCalledWith(
+      `Cannot add ${PACKAGE_NAME} or package-lock.json as custom files`,
     );
   });
 

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -256,10 +256,37 @@ describe('RemoteLoader', () => {
       expect(store.modules.has('electron')).toEqual(false);
     });
 
-    it('loads a fiddle with a new file', async () => {
+    it('loads a fiddle with a new JS file', async () => {
       // setup: adding a new supported file
       const filename = 'file.js';
       const content = '// hello!';
+      const gistId = 'customtestid';
+      expect(isKnownFile(filename)).toBe(false);
+      expect(isSupportedFile(filename)).toBe(true);
+
+      store.gistId = gistId;
+
+      editorValues[filename] = content;
+      mockGistFiles[filename] = { content };
+      mockRepos.push({
+        name: filename,
+        download_url: `https://${filename}`,
+      });
+
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
+      instance.confirmAddFile = jest.fn().mockResolvedValue(true);
+
+      const result = await instance.fetchGistAndLoad(gistId);
+
+      expect(result).toBe(true);
+      expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
+    });
+
+    it('loads a fiddle with a new JSON file', async () => {
+      const filename = 'data.json';
+      const content = '{"test": "hello!"}';
       const gistId = 'customtestid';
       expect(isKnownFile(filename)).toBe(false);
       expect(isSupportedFile(filename)).toBe(true);

--- a/tests/utils/editor-utils-spec.ts
+++ b/tests/utils/editor-utils-spec.ts
@@ -9,7 +9,11 @@ describe('editor-utils', () => {
   describe('getEmptyContent', () => {
     it('returns comments for known types', () => {
       expect(getEmptyContent('main.js')).toBe('// Empty');
+      expect(getEmptyContent('styles.css')).toBe('/* Empty */');
+      expect(getEmptyContent('index.html')).toBe('<!-- Empty -->');
+      expect(getEmptyContent('data.json')).toBe('{}');
     });
+
     it('returns an empty string for unknown types', () => {
       expect(getEmptyContent('main.foo')).toBe('');
     });


### PR DESCRIPTION
This PR adds support for JSON files. These can be used in Fiddle for data storage amongst other things - the impetus for this specifically is the ability to add `manifest.json` files for Chrome extensions.