### PR TITLE
chore: fix environment variable parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "node-watch": "^0.7.3",
     "p-debounce": "^2.0.0",
     "package-json": "^7.0.0",
+    "parse-env-string": "^1.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-mosaic-component": "^4.1.1",

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -41,6 +41,48 @@ describe('Runner component', () => {
     instance = new Runner(store as unknown as AppState);
   });
 
+  describe('buildChildEnvVars', () => {
+    it('fails when the environment variable is invalid', () => {
+      store.showErrorDialog = jest.fn().mockResolvedValueOnce(true);
+      store.environmentVariables = ['bwap bwap'];
+      const env = instance.buildChildEnvVars();
+      expect(env).toEqual({});
+
+      expect(store.showErrorDialog).toHaveBeenCalledWith(
+        expect.stringMatching(
+          `Could not parse environment variable: bwap bwap`,
+        ),
+      );
+    });
+
+    it('returns an empty object when there are no environment variables', () => {
+      store.environmentVariables = [];
+      const env = instance.buildChildEnvVars();
+      expect(env).toEqual({});
+    });
+
+    it('returns an object with the environment variables', () => {
+      store.environmentVariables = ['foo=bar', 'bar=baz'];
+      const env = instance.buildChildEnvVars();
+      expect(env).toEqual({ foo: 'bar', bar: 'baz' });
+    });
+
+    it('returns an object with complex environment variables', () => {
+      store.environmentVariables = [
+        'NODE_OPTIONS="--no-warnings --max-old-space-size=2048"',
+        'ELECTRON_TRASH=gvfs-trash',
+        'ELECTRON_OVERRIDE_DIST_PATH=/Users/user=nam=!e/projects/electron/out/Testing',
+      ];
+      const env = instance.buildChildEnvVars();
+      expect(env).toEqual({
+        NODE_OPTIONS: '--no-warnings --max-old-space-size=2048',
+        ELECTRON_TRASH: 'gvfs-trash',
+        ELECTRON_OVERRIDE_DIST_PATH:
+          '/Users/user=nam=!e/projects/electron/out/Testing',
+      });
+    });
+  });
+
   describe('run()', () => {
     it('runs', async () => {
       // wait for run() to get running

--- a/yarn.lock
+++ b/yarn.lock
@@ -9570,6 +9570,11 @@ parse-author@^2.0.0:
   dependencies:
     author-regex "^1.0.0"
 
+parse-env-string@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-env-string/-/parse-env-string-1.0.1.tgz#9e1d06a5e561237d3ca7d06f6178f86b54d5c610"
+  integrity sha512-nozPS2x3SzOI6K2TUeeK/KwxMcg22SpAYVY75JeOXHu0M33L+Zo38NkNBlvUqajGwBGKYEbVTI4WemZJFo/OAA==
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1504.

Fixes an issue where complex environment variables with multiple equal signs would be incorrectly parsed. This was happening because our env var parsing was [very simplistic](https://github.com/electron/fiddle/blob/main/src/renderer/runner.ts#L333-L343) and always split at equals signs.

We should use an existing env var parser instead, written and maintained by a Node.js maintainer. It has no dependencies.

