### PR TITLE
build: Update identity to OpenJS

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -95,7 +95,8 @@ const config: ForgeConfig = {
       OriginalFilename: 'Electron Fiddle',
     },
     osxSign: {
-      identity: 'Developer ID Application: Felix Rieseberg (LT94ZKYDCJ)',
+      identity:
+        'Developer ID Application: OpenJS Foundation, Inc. (UY52UFTVTM)',
       optionsForFile: (filePath) =>
         ['(Plugin).app', '(GPU).app', '(Renderer).app'].some((helper) =>
           filePath.includes(helper),
@@ -168,8 +169,9 @@ function notarizeMaybe() {
     return;
   }
 
-  if (!process.env.CI) {
+  if (!process.env.CI && !process.env.FORCE_NOTARIZATION) {
     // Not in CI, skipping notarization
+    console.log('Not in CI, skipping notarization');
     return;
   }
 


### PR DESCRIPTION
This PR updates our macOS identity from me to OpenJS 🎉 I've verified locally that we can still notarize with my personal account. Once this PR is merged, I'll update our infra.

```
➜  arm64 git:(felixr-openjs-cert) ✗ spctl -a -vvvv -t install Electron\ Fiddle.app
Electron Fiddle.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenJS Foundation, Inc. (UY52UFTVTM)
```