### PR TITLE
build: Temporarily build with intermediate requirements

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -23,6 +23,8 @@ const commonLinuxConfig = {
   mimeType: ['x-scheme-handler/electron-fiddle'],
 };
 
+const requirements = path.resolve(__dirname, 'tools/certs/requirements.txt');
+
 const config: ForgeConfig = {
   hooks: {
     generateAssets: async () => {
@@ -95,15 +97,15 @@ const config: ForgeConfig = {
       OriginalFilename: 'Electron Fiddle',
     },
     osxSign: {
-      identity:
-        'Developer ID Application: OpenJS Foundation, Inc. (UY52UFTVTM)',
+      identity: 'Developer ID Application: Felix Rieseberg (LT94ZKYDCJ)',
       optionsForFile: (filePath) =>
         ['(Plugin).app', '(GPU).app', '(Renderer).app'].some((helper) =>
           filePath.includes(helper),
         )
-          ? {}
+          ? { requirements }
           : {
               entitlements: 'static/entitlements.plist',
+              requirements,
             },
     },
   },

--- a/tools/certs/requirements.txt
+++ b/tools/certs/requirements.txt
@@ -1,0 +1,1 @@
+designated => anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and ( certificate leaf[subject.OU] = LT94ZKYDCJ or certificate leaf[subject.OU] = UY52UFTVTM )


### PR DESCRIPTION
This enables us to build with intermediate designated requirements to move the codesigning certificate on macOS from me to OpenJS. 

Major downside: This will break CI as written, since CI currently only has the OpenJS certificate.