### PR TITLE
chore: update show me examples

### DIFF
--- a/static/show-me/app/main.js
+++ b/static/show-me/app/main.js
@@ -5,7 +5,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/app
 
-const { app } = require('electron')
+const { app } = require('electron/main')
 
 app.whenReady().then(() => console.log('The app is now ready for action'))
 

--- a/static/show-me/autoupdater/main.js
+++ b/static/show-me/autoupdater/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/auto-updater
 
-const { app, autoUpdater } = require('electron')
+const { app, autoUpdater } = require('electron/main')
 
 app.whenReady().then(() => {
   const server = 'https://your-deployment-url.com'

--- a/static/show-me/browserview/main.js
+++ b/static/show-me/browserview/main.js
@@ -6,7 +6,7 @@
 // https://electronjs.org/docs/api/browser-view
 
 // In the main process.
-const { BrowserView, BrowserWindow, app } = require('electron')
+const { BrowserView, BrowserWindow, app } = require('electron/main')
 
 app.whenReady().then(() => {
   let win = new BrowserWindow({ width: 800, height: 600 })
@@ -14,11 +14,7 @@ app.whenReady().then(() => {
     win = null
   })
 
-  const view = new BrowserView({
-    webPreferences: {
-      nodeIntegration: false
-    }
-  })
+  const view = new BrowserView()
 
   win.setBrowserView(view)
   view.setBounds({ x: 0, y: 0, width: 300, height: 300 })

--- a/static/show-me/browserwindow/main.js
+++ b/static/show-me/browserwindow/main.js
@@ -4,7 +4,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/browser-window
 
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron/main')
 
 const windows = []
 

--- a/static/show-me/clipboard/main.js
+++ b/static/show-me/clipboard/main.js
@@ -3,8 +3,8 @@
 // For more info, see:
 // https://electronjs.org/docs/api/clipboard
 
-const { app, BrowserWindow, ipcMain, clipboard } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, ipcMain, clipboard } = require('electron/main')
+const path = require('node:path')
 
 ipcMain.handle('clipboard:readText', () => {
   return clipboard.readText()

--- a/static/show-me/clipboard/preload.js
+++ b/static/show-me/clipboard/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron')
+const { contextBridge, ipcRenderer } = require('electron/renderer')
 
 contextBridge.exposeInMainWorld('clipboard', {
   readText: () => ipcRenderer.invoke('clipboard:readText'),

--- a/static/show-me/contenttracing/main.js
+++ b/static/show-me/contenttracing/main.js
@@ -8,7 +8,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/content-tracing
 
-const { app, contentTracing } = require('electron')
+const { app, contentTracing } = require('electron/main')
 
 app.whenReady().then(() => {
   const options = {
@@ -16,13 +16,13 @@ app.whenReady().then(() => {
     traceOptions: 'record-until-full,enable-sampling'
   }
 
-  contentTracing.startRecording(options, () => {
+  contentTracing.startRecording(options).then(() => {
     console.log('Tracing started')
-
-    setTimeout(() => {
-      contentTracing.stopRecording('', (path) => {
-        console.log('Tracing data recorded to ' + path)
-      })
-    }, 5000)
   })
+
+  setTimeout(() => {
+    contentTracing.stopRecording().then((path) => {
+      console.log('Tracing data recorded to ' + path)
+    })
+  }, 5000)
 })

--- a/static/show-me/cookies/main.js
+++ b/static/show-me/cookies/main.js
@@ -3,36 +3,41 @@
 // For more info, see:
 // https://electronjs.org/docs/api/cookies
 
-const { app, BrowserWindow, session } = require('electron')
+const { app, BrowserWindow, session } = require('electron/main')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     height: 600,
-    width: 600,
-    webPreferences: {
-      nodeIntegration: false
-    }
+    width: 600
   })
 
   // Once the window has finished loading, let's check out
   // the cookies
-  mainWindow.webContents.on('did-finish-load', () => {
+  mainWindow.webContents.on('did-finish-load', async () => {
     // Query all cookies.
-    session.defaultSession.cookies.get({}, (error, cookies) => {
-      console.log(error, cookies)
-    })
+    try {
+      const cookies = await session.defaultSession.cookies.get({})
+      console.log(cookies)
+    } catch (error) {
+      console.error(error)
+    }
 
     // Query all cookies associated with a specific url.
-    session.defaultSession.cookies.get({ url: 'http://www.github.com' }, (error, cookies) => {
-      console.log(error, cookies)
-    })
+    try {
+      const cookies = await session.defaultSession.cookies.get({ url: 'http://www.github.com' })
+      console.log(cookies)
+    } catch (error) {
+      console.error(error)
+    }
 
     // Set a cookie with the given cookie data;
     // may overwrite equivalent cookies if they exist.
-    const cookie = { url: 'http://www.github.com', name: 'dummy_name', value: 'dummy' }
-    session.defaultSession.cookies.set(cookie, (error) => {
-      if (error) console.error(error)
-    })
+    try {
+      const cookie = { url: 'http://www.github.com', name: 'dummy_name', value: 'dummy' }
+      await session.defaultSession.cookies.set(cookie)
+    } catch (error) {
+      console.error(error)
+    }
   })
 
   mainWindow.loadURL('https://electronjs.org')

--- a/static/show-me/crashreporter/main.js
+++ b/static/show-me/crashreporter/main.js
@@ -3,12 +3,14 @@
 // For more info, see:
 // https://electronjs.org/docs/api/crash-reporter
 
-const { app, BrowserWindow, crashReporter } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, crashReporter } = require('electron/main')
+const path = require('node:path')
 
 crashReporter.start({
   productName: 'YourName',
-  companyName: 'YourCompany',
+  globalExtra: {
+    _companyName: 'YourCompany'
+  },
   submitURL: 'https://your-domain.com/url-to-submit',
   uploadToServer: true
 })
@@ -18,14 +20,12 @@ app.whenReady().then(() => {
     height: 600,
     width: 600,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })
   mainWindow.loadFile('index.html')
 
-  mainWindow.webContents.on('crashed', () => {
+  mainWindow.webContents.on('render-process-gone', () => {
     console.log('Window crashed!')
   })
 })

--- a/static/show-me/debugger/main.js
+++ b/static/show-me/debugger/main.js
@@ -6,7 +6,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/debugger
 
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron/main')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({ height: 600, width: 600 })

--- a/static/show-me/desktopcapturer/main.js
+++ b/static/show-me/desktopcapturer/main.js
@@ -4,16 +4,14 @@
 // For more info, see:
 // https://electronjs.org/docs/api/desktop-capturer
 
-const { app, BrowserWindow, desktopCapturer } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, desktopCapturer } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/static/show-me/desktopcapturer/preload.js
+++ b/static/show-me/desktopcapturer/preload.js
@@ -1,5 +1,4 @@
-const { desktopCapturer } = require('electron')
-const { ipcRenderer } = require('electron')
+const { desktopCapturer, ipcRenderer } = require('electron/renderer')
 
 // The following example shows how to capture video from
 // the screen. It also grabs each window, so you could

--- a/static/show-me/dialog/main.js
+++ b/static/show-me/dialog/main.js
@@ -3,23 +3,24 @@
 // For more info, see:
 // https://electronjs.org/docs/api/dialog
 
-const { app, BrowserWindow, dialog } = require('electron')
+const { app, BrowserWindow, dialog } = require('electron/main')
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   const mainWindow = new BrowserWindow({ height: 600, width: 600 })
 
   // Show an "Open File" dialog and attempt to open
   // the chosen file in our window.
-  dialog.showOpenDialog(mainWindow, {
-    properties: ['openFile']
-  }).then(result => {
-    if (result.canceled) {
+  try {
+    const { filePaths, canceled } = await dialog.showOpenDialog(mainWindow, {
+      properties: ['openFile']
+    })
+    if (canceled) {
       console.log('Dialog was canceled')
     } else {
-      const file = result.filePaths[0]
+      const file = filePaths[0]
       mainWindow.loadURL(`file://${file}`)
     }
-  }).catch(err => {
+  } catch (err) {
     console.log(err)
-  })
+  }
 })

--- a/static/show-me/globalshortcut/main.js
+++ b/static/show-me/globalshortcut/main.js
@@ -13,7 +13,7 @@
 // https://electronjs.org/docs/api/accelerator
 // https://electronjs.org/docs/api/global-shortcut
 
-const { app, globalShortcut } = require('electron')
+const { app, globalShortcut } = require('electron/main')
 
 app.whenReady().then(() => {
   // Register a 'CommandOrControl+Y' shortcut listener.

--- a/static/show-me/inapppurchase/main.js
+++ b/static/show-me/inapppurchase/main.js
@@ -6,7 +6,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/in-app-purchase
 
-const { app, inAppPurchase } = require('electron')
+const { app, inAppPurchase } = require('electron/main')
 
 app.whenReady().then(() => {
   // Can the user can make a payment?

--- a/static/show-me/ipc/main.js
+++ b/static/show-me/ipc/main.js
@@ -5,16 +5,14 @@
 // https://electronjs.org/docs/api/ipc-main
 // https://electronjs.org/docs/api/ipc-renderer
 
-const { app, BrowserWindow, ipcMain } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, ipcMain } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/static/show-me/ipc/preload.js
+++ b/static/show-me/ipc/preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer } = require('electron/renderer')
 
 // prints "pong"
 console.log(ipcRenderer.sendSync('synchronous-message', 'ping'))

--- a/static/show-me/menu/main.js
+++ b/static/show-me/menu/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/menu
 
-const { app, BrowserWindow, Menu } = require('electron')
+const { app, BrowserWindow, Menu } = require('electron/main')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({ height: 600, width: 600 })

--- a/static/show-me/nativeimage/main.js
+++ b/static/show-me/nativeimage/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/native-image
 
-const { app, Tray, nativeImage } = require('electron')
+const { app, Tray, nativeImage } = require('electron/main')
 
 let trayIcon = null
 

--- a/static/show-me/net/main.js
+++ b/static/show-me/net/main.js
@@ -8,7 +8,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/net
 
-const { app, net } = require('electron')
+const { app, net } = require('electron/main')
 
 app.whenReady().then(() => {
   const request = net.request('https://github.com')

--- a/static/show-me/notification/main.js
+++ b/static/show-me/notification/main.js
@@ -4,16 +4,14 @@
 // https://electronjs.org/docs/api/notification
 // https://electronjs.org/docs/tutorial/notifications
 
-const { app, BrowserWindow, Notification } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, Notification } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     height: 600,
     width: 600,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/static/show-me/powermonitor/main.js
+++ b/static/show-me/powermonitor/main.js
@@ -3,13 +3,9 @@
 // For more info, see:
 // https://electronjs.org/docs/api/power-monitor
 
-const { app } = require('electron')
+const { app, powerMonitor } = require('electron/main')
 
 app.whenReady().then(() => {
-  // We cannot require the "ready" module until
-  // the app is ready
-  const { powerMonitor } = require('electron')
-
   powerMonitor.on('suspend', () => {
     console.log('The system is going to sleep')
   })

--- a/static/show-me/powersaveblocker/main.js
+++ b/static/show-me/powersaveblocker/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/power-save-blocker
 
-const { app, powerSaveBlocker } = require('electron')
+const { app, powerSaveBlocker } = require('electron/main')
 
 app.whenReady().then(() => {
   const id = powerSaveBlocker.start('prevent-display-sleep')

--- a/static/show-me/screen/main.js
+++ b/static/show-me/screen/main.js
@@ -3,14 +3,10 @@
 // For more info, see:
 // https://electronjs.org/docs/api/screen
 
-const { app, BrowserWindow, ipcMain } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, ipcMain, screen } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
-  // We cannot require the screen module until the
-  // app is ready
-  const { screen } = require('electron')
-
   // Create a window that fills the screen's available
   // work area.
   const primaryDisplay = screen.getPrimaryDisplay()
@@ -20,8 +16,6 @@ app.whenReady().then(() => {
     width,
     height,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/static/show-me/screen/preload.js
+++ b/static/show-me/screen/preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer } = require('electron/renderer')
 
 window.addEventListener('DOMContentLoaded', () => {
   ipcRenderer

--- a/static/show-me/session/main.js
+++ b/static/show-me/session/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/session
 
-const { app, session } = require('electron')
+const { app, session } = require('electron/main')
 
 app.whenReady().then(() => {
   const { defaultSession } = session
@@ -16,7 +16,7 @@ app.whenReady().then(() => {
   console.log(defaultSession.getUserAgent())
 
   // Cache Size
-  defaultSession.getCacheSize((result) => {
+  defaultSession.getCacheSize().then((result) => {
     console.log(result)
   })
 })

--- a/static/show-me/shell/main.js
+++ b/static/show-me/shell/main.js
@@ -3,8 +3,8 @@
 // For more info, see:
 // https://electronjs.org/docs/api/shell
 
-const { app, BrowserWindow, ipcMain, shell } = require('electron')
-const path = require('path')
+const { app, BrowserWindow, ipcMain, shell } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({

--- a/static/show-me/shell/preload.js
+++ b/static/show-me/shell/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron')
+const { contextBridge, ipcRenderer } = require('electron/renderer')
 
 contextBridge.exposeInMainWorld(
   'electron',

--- a/static/show-me/systempreferences/main.js
+++ b/static/show-me/systempreferences/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/system-preferences#systempreferences
 
-const { app, systemPreferences } = require('electron')
+const { app, systemPreferences } = require('electron/main')
 
 app.whenReady().then(() => {
   // This module let's us access various system preferences.

--- a/static/show-me/touchbar/main.js
+++ b/static/show-me/touchbar/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/touch-bar
 
-const { app, BrowserWindow, TouchBar } = require('electron')
+const { app, BrowserWindow, TouchBar } = require('electron/main')
 const { TouchBarLabel, TouchBarButton, TouchBarSpacer } = TouchBar
 
 app.whenReady().then(() => {

--- a/static/show-me/tray/main.js
+++ b/static/show-me/tray/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/tray
 
-const { app, Tray, Menu, nativeImage } = require('electron')
+const { app, Tray, Menu, nativeImage } = require('electron.main')
 
 let tray
 

--- a/static/show-me/webcontents/main.js
+++ b/static/show-me/webcontents/main.js
@@ -3,7 +3,7 @@
 // For more info, see:
 // https://electronjs.org/docs/api/web-contents
 
-const { app, BrowserWindow, webContents } = require('electron')
+const { app, BrowserWindow, webContents } = require('electron/main')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({ height: 600, width: 600 })

--- a/static/show-me/webframe/main.js
+++ b/static/show-me/webframe/main.js
@@ -3,16 +3,14 @@
 // For more info, see:
 // https://electronjs.org/docs/api/web-frame
 
-const { app, BrowserWindow } = require('electron')
-const path = require('path')
+const { app, BrowserWindow } = require('electron/main')
+const path = require('node:path')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     width: 600,
     height: 600,
     webPreferences: {
-      nodeIntegration: false, // default in Electron >= 5
-      contextIsolation: true, // default in Electron >= 12
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/static/show-me/webframe/preload.js
+++ b/static/show-me/webframe/preload.js
@@ -1,4 +1,4 @@
-const { webFrame } = require('electron')
+const { webFrame } = require('electron/renderer')
 
 setInterval(() => {
   // A random number


### PR DESCRIPTION
Closes #1361 

Modernizes these example fiddles (dropping options which have long been the default) and fixes ones which were using defunct callback syntax.