### PR TITLE
fix: handle missing local Electron.app

### DIFF
--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button, ButtonProps, Spinner } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
-import { InstallState } from '../../interfaces';
+import { InstallState, VersionSource } from '../../interfaces';
 import { AppState } from '../state';
 
 interface RunnerProps {
@@ -29,7 +29,7 @@ export const Runner = observer(
         isOnline,
       } = this.props.appState;
 
-      const state = currentElectronVersion?.state;
+      const { downloadProgress, source, state } = currentElectronVersion;
       const props: ButtonProps = { disabled: true };
 
       if ([downloading, missing].includes(state) && !isOnline) {
@@ -41,12 +41,7 @@ export const Runner = observer(
       switch (state) {
         case downloading: {
           props.text = 'Downloading';
-          props.icon = (
-            <Spinner
-              size={16}
-              value={currentElectronVersion?.downloadProgress}
-            />
-          );
+          props.icon = <Spinner size={16} value={downloadProgress} />;
           break;
         }
         case installing: {
@@ -71,6 +66,13 @@ export const Runner = observer(
             props.icon = 'play';
           }
           break;
+        }
+        case missing: {
+          if (source === VersionSource.local) {
+            props.text = 'Unavailable';
+            props.icon = 'issue';
+            break;
+          }
         }
         default: {
           props.text = 'Checking status';

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -66,8 +66,9 @@ const itemListRenderer: ItemListRenderer<RunnableVersion> = ({
  * @returns {string}
  */
 export function getItemLabel({ source, state, name }: RunnableVersion): string {
+  // If a version is local, either it's there or it's not.
   if (source === VersionSource.local) {
-    return name || 'Local';
+    return state === 'missing' ? 'Unavailable' : name || 'Local';
   }
 
   const installStateLabels: Record<InstallState, string> = {
@@ -87,7 +88,12 @@ export function getItemLabel({ source, state, name }: RunnableVersion): string {
  * @param {RunnableVersion} { state }
  * @returns {IconName}
  */
-export function getItemIcon({ state }: RunnableVersion): IconName {
+export function getItemIcon({ source, state }: RunnableVersion): IconName {
+  // If a version is local, either it's there or it's not.
+  if (source === VersionSource.local) {
+    return state === InstallState.missing ? 'issue' : 'saved';
+  }
+
   const installStateIcons: Record<InstallState, IconName> = {
     missing: 'cloud',
     downloading: 'cloud-download',

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -68,7 +68,7 @@ const itemListRenderer: ItemListRenderer<RunnableVersion> = ({
 export function getItemLabel({ source, state, name }: RunnableVersion): string {
   // If a version is local, either it's there or it's not.
   if (source === VersionSource.local) {
-    return state === 'missing' ? 'Unavailable' : name || 'Local';
+    return state === InstallState.missing ? 'Unavailable' : name || 'Local';
   }
 
   const installStateLabels: Record<InstallState, string> = {

--- a/tests/renderer/components/version-select-spec.tsx
+++ b/tests/renderer/components/version-select-spec.tsx
@@ -125,14 +125,25 @@ describe('VersionSelect component', () => {
   });
 
   describe('getItemLabel()', () => {
-    it('returns the correct label for a local version', () => {
+    it('returns the correct label for an available local version', () => {
       const input: RunnableVersion = {
         ...mockVersion1,
+        state: installed,
         source: local,
       };
 
       expect(getItemLabel(input)).toBe('Local');
       expect(getItemLabel({ ...input, name: 'Hi' })).toBe('Hi');
+    });
+
+    it('returns the correct label for an unavailable local version', () => {
+      const input: RunnableVersion = {
+        ...mockVersion1,
+        state: missing,
+        source: local,
+      };
+
+      expect(getItemLabel(input)).toBe('Unavailable');
     });
 
     it('returns the correct label for a version not downloaded', () => {


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1529

Handles the case where a local Electron executable has moved or been deleted.

Before:

<img width="494" alt="Screenshot 2024-01-13 at 10 17 04 AM" src="https://github.com/electron/fiddle/assets/2036040/de361ba8-e375-41c0-8608-07d33783aea3">

After:

<img width="334" alt="Screenshot 2024-01-13 at 10 29 54 AM" src="https://github.com/electron/fiddle/assets/2036040/ef7a58d9-f732-4ee3-ab04-54aeb8e6e0e6">
