### PR TITLE
test: increase timeout in ElectronTypes watch test

### DIFF
--- a/tests/main/electron-types-spec.ts
+++ b/tests/main/electron-types-spec.ts
@@ -112,7 +112,11 @@ describe('ElectronTypes', () => {
 
       const newTypes = saveTypesFile('some changed types');
       expect(newTypes).not.toEqual(oldTypes);
-      await waitFor(() => mocked(ipcMainManager).send.mock.calls.length > 0);
+      // TODO(dsanders11) - Find a better fix for this flakiness under macOS Rosetta
+      await waitFor(() => mocked(ipcMainManager).send.mock.calls.length > 0, {
+        interval: 100,
+        timeout: 8000,
+      });
       expect(ipcMainManager.send).toHaveBeenCalledWith(
         IpcEvents.ELECTRON_TYPES_CHANGED,
         [newTypes, localVersion.version],


### PR DESCRIPTION
Noticing this test started flaking after #1533, I think the filesystem operations in that test is delayed when it's running under Rosetta, causing the flaky timeout. Doing a quick and dirty bump of the timeout to mitigate the flake for now.