### PR TITLE
build: update @electron/lint-roller to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@electron-forge/plugin-webpack": "7.2.0",
     "@electron-forge/publisher-github": "7.2.0",
     "@electron/fuses": "^1.6.1",
-    "@electron/lint-roller": "^1.0.1",
+    "@electron/lint-roller": "^1.11.0",
     "@octokit/core": "^3.5.1",
     "@reforged/maker-appimage": "^3.3.0",
     "@testing-library/dom": "^9.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,10 +1249,10 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/lint-roller@^1.0.1":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.10.3.tgz#772ea0daf6e1f89a414276881b89f81a68454537"
-  integrity sha512-8vvDYQf7LCgH1wDQsT0KSjb/LKVE0lu60RBFQuJe3Dli4Q3O9g63JBZMxKJCpFknF1lSSSog6nK2eXmRnfitig==
+"@electron/lint-roller@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@electron/lint-roller/-/lint-roller-1.11.0.tgz#85492052ace3f9bcba478627f0f3ff4e407d7377"
+  integrity sha512-ogkoSsEnvp7bfoZ7DR3iWK64Z9CDXZugC8/70/dnu7uFi0ZbJVsCVlDPpGPLoUUAUr6HW+vzRFKPzyuF0G9hcw==
   dependencies:
     "@dsanders11/vscode-markdown-languageservice" "^0.3.0"
     balanced-match "^2.0.0"


### PR DESCRIPTION
Fixes the lint CI job which started failing last week due to GitHub server changes when it tries to verify a link in the docs.