### PR TITLE
fix: allows users to drag app when settings are open

### DIFF
--- a/src/less/components/settings.less
+++ b/src/less/components/settings.less
@@ -31,6 +31,12 @@
     font-weight: 200;
   }
 
+  button,
+  input,
+  select {
+    -webkit-app-region: no-drag;
+  }
+
   select {
     width: 250px;
   }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -127,9 +127,9 @@ export class App {
 
     const app = (
       <div className="container">
-        <Dialogs appState={this.state} />
         <Header appState={this.state} />
         <OutputEditorsWrapper appState={this.state} />
+        <Dialogs appState={this.state} />
       </div>
     );
 

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -36,15 +36,15 @@ export const Commands = observer(
 
     public render() {
       const { appState } = this.props;
-      const { isBisectCommandShowing, title } = appState;
+      const { isBisectCommandShowing, title, isSettingsShowing } = appState;
 
       return (
         <div
-          className={
+          className={`${
             window.ElectronFiddle.platform === 'darwin'
               ? 'commands is-mac'
               : 'commands'
-          }
+          }${isSettingsShowing ? ' tabbing-hidden' : ''}`}
           onDoubleClick={this.handleDoubleClick}
         >
           <div>

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Button, ControlGroup } from '@blueprintjs/core';
+import classNames from 'classnames';
 import { observer } from 'mobx-react';
 
 import { GistActionButton } from './commands-action-button';
@@ -40,11 +41,11 @@ export const Commands = observer(
 
       return (
         <div
-          className={`${
-            window.ElectronFiddle.platform === 'darwin'
-              ? 'commands is-mac'
-              : 'commands'
-          }${isSettingsShowing ? ' tabbing-hidden' : ''}`}
+          className={classNames(
+            'commands',
+            { 'is-mac': window.ElectronFiddle.platform === 'darwin' },
+            { 'tabbing-hidden': isSettingsShowing },
+          )}
           onDoubleClick={this.handleDoubleClick}
         >
           <div>

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { reaction } from 'mobx';
-
 import { Commands } from './commands';
 import { WelcomeTour } from './tour-welcome';
 import { AppState } from '../state';
@@ -23,21 +21,12 @@ interface HeaderState {
 export class Header extends React.Component<HeaderProps, HeaderState> {
   constructor(props: HeaderProps) {
     super(props);
-    this.state = {
-      focusable: true,
-    };
-    reaction(
-      () => this.props.appState.isSettingsShowing,
-      (isSettingsShowing) => this.setState({ focusable: !isSettingsShowing }),
-    );
   }
+
   public render() {
     return (
       <>
-        <header
-          id="header"
-          className={!this.state.focusable ? 'tabbing-hidden' : undefined}
-        >
+        <header id="header">
           <Commands key="commands" appState={this.props.appState} />
         </header>
         <WelcomeTour appState={this.props.appState} />

--- a/tests/renderer/app-spec.tsx
+++ b/tests/renderer/app-spec.tsx
@@ -61,7 +61,7 @@ describe('App component', () => {
       const result = (await app.setup()) as HTMLDivElement;
       jest.runAllTimers();
 
-      expect(result.innerHTML).toBe('Dialogs;Header;OutputEditorsWrapper;');
+      expect(result.innerHTML).toBe('Header;OutputEditorsWrapper;Dialogs;');
 
       jest.useRealTimers();
     });


### PR DESCRIPTION
This PR fixes an issue where the app is not draggable when a user is on the Settings page. This is because the `tabbing-hidden` style applied to the header also nullifies the header's `-webkit-app-region: drag;` style.

This PR:

1. Moves the `tabbing-hidden` style to the `commands` component. This ensures that tabbing on the settings page does not focus these hidden elements.
2. Moves the `Dialogs` component to be rendered after `Header` and `OutputEditorsWrapper`. This ensures that when elements in the Settings page scroll over the header area, the header's `-webkit-app-region: drag;` doesn't swallow click events. I think this also makes sense from a `z-index` perspective as dialogs are usually rendered over main content.
3. Adds the `-webkit-app-region: no-drag;` style to all focusable elements in the settings component, similar to how `commands` applies this style.

Testing:
1. Verified that focused elements cycle through elements on the settings page when tabbing.
2. Verified that inputs, buttons, and selects in the settings content can be clicked when they are in the header region.
3. Verified that the app can be dragged in the header region when settings are open.