### PR TITLE
fix: better error message for bad `package.json`

### DIFF
--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -71,10 +71,10 @@ export class FileManager {
       if (name === PACKAGE_NAME) {
         const { remoteLoader } = window.app;
 
-        let deps: Record<string, string> = {};
+        const deps: Record<string, string> = {};
         try {
           const { dependencies, devDependencies } = JSON.parse(value);
-          deps = { ...dependencies, ...devDependencies };
+          Object.assign(deps, dependencies, devDependencies);
         } catch {
           await this.appState.showErrorDialog(
             'Could not open Fiddle - invalid JSON found in package.json',

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -70,11 +70,16 @@ export class FileManager {
     for (const [name, value] of Object.entries(files)) {
       if (name === PACKAGE_NAME) {
         const { remoteLoader } = window.app;
-        const { dependencies, devDependencies } = JSON.parse(value);
-        const deps: Record<string, string> = {
-          ...dependencies,
-          ...devDependencies,
-        };
+
+        let deps: Record<string, string> = {};
+        try {
+          const { dependencies, devDependencies } = JSON.parse(value);
+          deps = { ...dependencies, ...devDependencies };
+        } catch {
+          await this.appState.showErrorDialog(
+            'Could not open Fiddle - invalid JSON found in package.json',
+          );
+        }
 
         // If the project specifies an Electron version, we want to tell Fiddle to run
         // it with that version by default.

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -130,7 +130,7 @@ export class RemoteLoader {
           : data.content;
 
         if (id === PACKAGE_NAME) {
-          const deps: Record<string, string>;
+          const deps: Record<string, string> = {};
           try {
             const { dependencies, devDependencies } = JSON.parse(content);
             Object.assign(deps, dependencies, devDependencies);

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -130,11 +130,13 @@ export class RemoteLoader {
           : data.content;
 
         if (id === PACKAGE_NAME) {
-          const { dependencies, devDependencies } = JSON.parse(content);
-          const deps: Record<string, string> = {
-            ...dependencies,
-            ...devDependencies,
-          };
+          let deps: Record<string, string>;
+          try {
+            const { dependencies, devDependencies } = JSON.parse(content);
+            deps = { ...dependencies, ...devDependencies };
+          } catch (e) {
+            throw new Error('Invalid JSON found in package.json');
+          }
 
           // If the gist specifies an Electron version, we want to tell Fiddle to run
           // it with that version by default.

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -130,10 +130,10 @@ export class RemoteLoader {
           : data.content;
 
         if (id === PACKAGE_NAME) {
-          let deps: Record<string, string>;
+          const deps: Record<string, string>;
           try {
             const { dependencies, devDependencies } = JSON.parse(content);
-            deps = { ...dependencies, ...devDependencies };
+            Object.assign(deps, dependencies, devDependencies);
           } catch (e) {
             throw new Error('Invalid JSON found in package.json');
           }

--- a/tests/renderer/file-manager-spec.ts
+++ b/tests/renderer/file-manager-spec.ts
@@ -63,6 +63,19 @@ describe('FileManager', () => {
       });
     });
 
+    it('handles bad JSON in package.json', async () => {
+      const badPj =
+        '{"main":"main.js","devDependencies":{"electron":"17.0.0",}}';
+      const values = { ...editorValues, [PACKAGE_NAME]: badPj };
+
+      await fm.openFiddle(filePath, values);
+      expect(app.state.showErrorDialog).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Could not open Fiddle - invalid JSON found in package.json/i,
+        ),
+      );
+    });
+
     it('respects the Electron version specified in package.json', async () => {
       const pj = {
         main: MAIN_JS,

--- a/tests/renderer/remote-loader-spec.ts
+++ b/tests/renderer/remote-loader-spec.ts
@@ -83,6 +83,29 @@ describe('RemoteLoader', () => {
       expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
     });
 
+    it('handles bad JSON in package.json', async () => {
+      const gistId = 'badjsontestid';
+      const badPj =
+        '{"main":"main.js","devDependencies":{"electron":"17.0.0",}}';
+
+      store.gistId = gistId;
+      mockGistFiles[PACKAGE_NAME] = { content: badPj };
+      mockRepos.push({
+        name: PACKAGE_NAME,
+        download_url: `https://${PACKAGE_NAME}`,
+      });
+
+      mocked(getOctokit).mockResolvedValue({
+        gists: mockGetGists,
+      } as unknown as Octokit);
+
+      const result = await instance.fetchGistAndLoad(gistId);
+      expect(result).toBe(false);
+      expect(store.showErrorDialog).toHaveBeenCalledWith(
+        expect.stringMatching(/Invalid JSON found in package.json/i),
+      );
+    });
+
     it('handles gist fiddle devDependencies', async () => {
       const gistId = 'pjsontestid';
       const pj = {


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1546.

Fixes an issue I noticed whereby if a user tried to load a Gist containing invalid JSON in their package.json, a confusing error would be thrown.

<details><summary>Before</summary>
<p>

<img width="431" alt="Screenshot 2024-02-19 at 11 07 54 AM" src="https://github.com/electron/fiddle/assets/2036040/a0250a30-368e-4536-88fd-04ef844708e2">

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="420" alt="Screenshot 2024-02-19 at 11 13 28 AM" src="https://github.com/electron/fiddle/assets/2036040/98b4762c-59c6-459f-ba47-25ac9410f92d">

</p>
</details> 