### PR TITLE
chore: improve preload comment

### DIFF
--- a/static/electron-quick-start/preload.js
+++ b/static/electron-quick-start/preload.js
@@ -1,7 +1,8 @@
 /**
- * The preload script runs before. It has access to web APIs
- * as well as Electron's renderer process modules and some
- * polyfilled Node.js functions.
+ * The preload script runs before `index.html` is loaded
+ * in the renderer. It has access to web APIs as well as
+ * Electron's renderer process modules and some polyfilled
+ * Node.js functions.
  *
  * https://www.electronjs.org/docs/latest/tutorial/sandbox
  */


### PR DESCRIPTION
Simple text change to the comment at the top of the the default `preload.js` file. Clarifies what the preload script runs before.

<img width="1438" alt="Screenshot 2024-02-23 at 12 16 11 PM" src="https://github.com/electron/fiddle/assets/14120490/400b0688-ecb0-4dd9-bafa-265905588329">
