### PR TITLE
fix: reload window button not working

### DIFF
--- a/src/renderer/components/settings-general-font.tsx
+++ b/src/renderer/components/settings-general-font.tsx
@@ -88,7 +88,7 @@ export class FontSettings extends React.Component<
               }
             />
             <Button
-              onClick={window.ElectronFiddle.reloadWindows}
+              onClick={() => window.ElectronFiddle.reloadWindows()}
               icon="repeat"
               text="Reload Window"
             />

--- a/tests/renderer/components/__snapshots__/settings-general-font-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-font-spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`FontSettings component renders 1`] = `
       />
       <Blueprint3.Button
         icon="repeat"
-        onClick={[MockFunction]}
+        onClick={[Function]}
         text="Reload Window"
       />
     </Blueprint3.FormGroup>


### PR DESCRIPTION
When clicking the reload window button, nothing happened. The console reported the error
<img width="690" alt="image" src="https://github.com/electron/fiddle/assets/88705855/913bf717-b2bd-40c3-8005-7594e1872ca2">
<img width="337" alt="errors occur when reload window button is clicked" src="https://github.com/electron/fiddle/assets/88705855/5cc9300a-6584-41d7-8057-f7301903da36">

I just changed one line and it works fine.
```
- onClick={window.ElectronFiddle.reloadWindows}
+ onClick={() => window.ElectronFiddle.reloadWindows()}
```