### PR TITLE
fix: uncaught error when renaming file failed

### DIFF
--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -207,10 +207,14 @@ export const SidebarFileTree = observer(
       }
 
       const contents = appState.editorMosaic.value(editorId).trim();
-      appState.editorMosaic.remove(editorId);
-      appState.editorMosaic.addNewFile(id, contents);
+      try {
+        appState.editorMosaic.addNewFile(id, contents);
+        appState.editorMosaic.remove(editorId);
 
-      if (visible) appState.editorMosaic.show(id);
+        if (visible) appState.editorMosaic.show(id);
+      } catch (err) {
+        appState.showErrorDialog(err.message);
+      }
     };
 
     public removeEditor = (editorId: EditorId) => {


### PR DESCRIPTION
**Before**
```
appState.editorMosaic.remove(editorId);
appState.editorMosaic.addNewFile(id, contents);
if (visible) appState.editorMosaic.show(id);
```
If the new file name already existed or was another main entry point file, addNewFile() would throw error. Then, remove() would be executed but addNewFile() not, which means *renaming file failure would lead to the deletion of the file*.

**Now**
```
try {
    appState.editorMosaic.addNewFile(id, contents);
    appState.editorMosaic.remove(editorId);

    if (visible) appState.editorMosaic.show(id);
} catch (err) {
    appState.showErrorDialog(err.message);
}
```