### PR TITLE
chore: release v0.36.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-fiddle",
   "productName": "Electron Fiddle",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
   "homepage": "https://electronjs.org/fiddle",


### PR DESCRIPTION
v0.36.1 had a show stopper which was fixed in #1568, so going again.