### PR TITLE
chore: remove rogue backticks in comment

### DIFF
--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -107,7 +107,7 @@ export const GitHubSettings = observer(
     }
 
     /**
-     * Simply shows the GitHub Token dialog.``
+     * Simply shows the GitHub Token dialog.
      */
     private signIn() {
       this.props.appState.isTokenDialogShowing = true;


### PR DESCRIPTION
Just some rogue backticks that snuck into this comment somehow.