### PR TITLE
fix(show-me): use BrowserWindow.loadFile in dialog example

### DIFF
--- a/static/show-me/dialog/main.js
+++ b/static/show-me/dialog/main.js
@@ -18,7 +18,7 @@ app.whenReady().then(async () => {
       console.log('Dialog was canceled')
     } else {
       const file = filePaths[0]
-      mainWindow.loadURL(`file://${file}`)
+      mainWindow.loadFile(file)
     }
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
Current example doesn't handle the edge case where the filename has a `#` as it needs to be encoded, which the naive construction of `file://${file}` does not handle. Just pass the path directly to `loadFile` instead as it will do the right thing.