### PR TITLE
test: fix awaiting process.nextTick

### DIFF
--- a/tests/renderer/components/editors-spec.tsx
+++ b/tests/renderer/components/editors-spec.tsx
@@ -172,7 +172,7 @@ describe('Editors component', () => {
 
         emitEvent('select-all-in-editor');
 
-        await process.nextTick;
+        await new Promise(process.nextTick);
         expect(editor.setSelection).toHaveBeenCalledWith('range');
       });
 
@@ -185,7 +185,7 @@ describe('Editors component', () => {
 
         emitEvent('select-all-in-editor');
 
-        await process.nextTick;
+        await new Promise(process.nextTick);
         expect(editor.getModel).toHaveBeenCalledTimes(1);
         expect(editor.setSelection).not.toHaveBeenCalled();
       });
@@ -237,7 +237,7 @@ describe('Editors component', () => {
       editorMosaic.focusedEditor = jest.fn().mockReturnValue(editor);
 
       emitEvent('select-all-in-editor');
-      await process.nextTick;
+      await new Promise(process.nextTick);
 
       expect(editor.setSelection).toHaveBeenCalledWith(range);
     });

--- a/tests/renderer/components/settings-general-appearance-spec.tsx
+++ b/tests/renderer/components/settings-general-appearance-spec.tsx
@@ -53,7 +53,7 @@ describe('AppearanceSettings component', () => {
       />,
     );
 
-    await process.nextTick;
+    await new Promise(process.nextTick);
     expect((wrapper.state() as any).selectedTheme?.name).toBe('defaultDark');
   });
 

--- a/tests/renderer/runner-spec.tsx
+++ b/tests/renderer/runner-spec.tsx
@@ -215,7 +215,7 @@ describe('Runner component', () => {
       const result = await instance.run();
 
       expect(result).toBe(RunResult.SUCCESS);
-      await process.nextTick;
+      await new Promise(process.nextTick);
       expect(window.ElectronFiddle.cleanupDirectory).toHaveBeenCalledTimes(1);
       expect(window.ElectronFiddle.deleteUserData).toHaveBeenCalledTimes(1);
       expect(window.ElectronFiddle.deleteUserData).toHaveBeenCalledWith(
@@ -230,7 +230,7 @@ describe('Runner component', () => {
       const result = await instance.run();
 
       expect(result).toBe(RunResult.SUCCESS);
-      await process.nextTick;
+      await new Promise(process.nextTick);
       expect(window.ElectronFiddle.cleanupDirectory).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Noticed these when trying out converting to Vitest locally; them not actually awaiting the next tick was a problem there. Some of these may not be necessary but I'm just making them do what they intended to do.