### PR TITLE
fix: limit usage of shell.openExternal to web URLs

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -24,6 +24,15 @@ export function mainIsReady() {
   mainIsReadyResolver();
 }
 
+export function safelyOpenWebURL(url: string) {
+  try {
+    const { protocol } = new URL(url);
+    if (['http:', 'https:'].includes(protocol)) {
+      shell.openExternal(url);
+    }
+  } catch {}
+}
+
 /**
  * Gets default options for the main window
  *
@@ -92,13 +101,13 @@ export function createMainWindow(): Electron.BrowserWindow {
   });
 
   browserWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url);
+    safelyOpenWebURL(details.url);
     return { action: 'deny' };
   });
 
   browserWindow.webContents.on('will-navigate', (event, url) => {
     event.preventDefault();
-    shell.openExternal(url);
+    safelyOpenWebURL(url);
   });
 
   ipcMainManager.on(IpcEvents.RELOAD_WINDOW, () => {

--- a/tests/main/windows-spec.ts
+++ b/tests/main/windows-spec.ts
@@ -4,6 +4,7 @@
 
 import * as path from 'node:path';
 
+import * as electron from 'electron';
 import { mocked } from 'jest-mock';
 
 import { createContextMenu } from '../../src/main/context-menu';
@@ -12,6 +13,7 @@ import {
   getMainWindowOptions,
   getOrCreateMainWindow,
   mainIsReady,
+  safelyOpenWebURL,
 } from '../../src/main/windows';
 import { overridePlatform, resetPlatform } from '../utils';
 
@@ -118,6 +120,19 @@ describe('windows', () => {
       expect(browserWindows[0]).toBeTruthy();
       (await getOrCreateMainWindow()).webContents.emit('will-navigate', e);
       expect(e.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe('safelyOpenWebURL()', () => {
+    it('opens web URLs', () => {
+      const url = 'https://github.com/electron/fiddle';
+      safelyOpenWebURL(url);
+      expect(electron.shell.openExternal).toHaveBeenCalledWith(url);
+    });
+
+    it('does not open file URLs', () => {
+      safelyOpenWebURL('file:///fake/path');
+      expect(electron.shell.openExternal).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Follow [our own security guidelines](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content) here and limit what we pass through to `shell.openExternal`.