### PR TITLE
chore: bump update-electron-app from 2.0.1 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "shell-env": "^3.0.1",
     "tmp": "0.2.1",
     "tslib": "^2.6.0",
-    "update-electron-app": "^2.0.1"
+    "update-electron-app": "^3.0.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.3.1",

--- a/src/main/update.ts
+++ b/src/main/update.ts
@@ -5,9 +5,9 @@ export function setupUpdates() {
   // We delay this work by 10s to ensure that the
   // app doesn't have to worry about updating during launch
   setTimeout(() => {
-    const updateApp = require('update-electron-app');
+    const { updateElectronApp } = require('update-electron-app');
 
-    updateApp({
+    updateElectronApp({
       repo: 'electron/fiddle',
       updateInterval: '1 hour',
     });

--- a/tests/main/update-spec.ts
+++ b/tests/main/update-spec.ts
@@ -7,11 +7,11 @@ jest.useFakeTimers();
 jest.spyOn(global, 'setTimeout');
 
 const mockUpdateApp = jest.fn();
-jest.mock('update-electron-app', () => mockUpdateApp);
+jest.mock('update-electron-app', () => ({ updateElectronApp: mockUpdateApp }));
 
 describe('update', () => {
   const { setupUpdates } = require('../../src/main/update');
-  const updateElectronApp = require('update-electron-app');
+  const { updateElectronApp } = require('update-electron-app');
 
   it('schedules an update check', () => {
     setupUpdates();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4862,11 +4862,6 @@ electron-installer-redhat@^3.2.0:
     word-wrap "^1.2.3"
     yargs "^16.0.2"
 
-electron-is-dev@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz"
-  integrity sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4=
-
 electron-squirrel-startup@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz"
@@ -12074,12 +12069,11 @@ update-browserslist-db@^1.0.11:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
-update-electron-app@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/update-electron-app/-/update-electron-app-2.0.1.tgz"
-  integrity sha512-e4xEner89UZZaBGYJbYlMdL1uUrC0VjOsTAL2N4opPjzFtn+j7mdsJJsnyXZzUVeLY+8tuCX4XEsUM98oBHmZg==
+update-electron-app@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/update-electron-app/-/update-electron-app-3.0.0.tgz#d705889e5bd86939f22e144c0c8b5f919a90f954"
+  integrity sha512-Ccs46fgUEcMpSRPMNw82DFMux2MGi5tkKkEpV723JmtPNI3qAtxvTeiYkKczN2/LehA3U7JGrGr4MhraxGdRTw==
   dependencies:
-    electron-is-dev "^0.3.0"
     github-url-to-object "^4.0.4"
     is-url "^1.2.4"
     ms "^2.1.1"


### PR DESCRIPTION
Just keeping this update-to-date.