### PR TITLE
chore: add private to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "electron-fiddle",
+  "private": true,
   "productName": "Electron Fiddle",
   "version": "0.36.3",
   "description": "The easiest way to get started with Electron",


### PR DESCRIPTION
Historically we've added `private` to any `package.json` we don't intend to publish.