### PR TITLE
chore: convert JSDoc comments to TSDoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ const config = {
     'plugin:import/recommended', // Used along with eslint-plugin-import to sort imports with recommended standards
     'plugin:import/typescript', // To handle import order cases for typescript files
   ],
-  plugins: ['import'],
+  plugins: ['import', 'eslint-plugin-tsdoc'],
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
@@ -76,7 +76,16 @@ const config = {
         pathGroupsExcludedImportTypes: ['react'],
       },
     ],
+    'tsdoc/syntax': 'error',
   },
+  overrides: [
+    {
+      files: ['rtl-spec/**', 'tests/**'],
+      rules: {
+        'tsdoc/syntax': 'off',
+      },
+    },
+  ],
   // the static folder is linted by standard
   ignorePatterns: ['/out', '/.webpack', '/coverage', '/static'],
 };

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-tsdoc": "^0.3.0",
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "husky": "^9.0.11",
     "jest": "^29.6.2",

--- a/src/main/about-panel.ts
+++ b/src/main/about-panel.ts
@@ -8,8 +8,6 @@ import contributorsJSON from '../../static/contributors.json';
 
 /**
  * Sets Fiddle's About panel options on Linux and macOS
- *
- * @returns
  */
 export function setupAboutPanel(): void {
   const contributors: Array<string> = [];

--- a/src/main/content.ts
+++ b/src/main/content.ts
@@ -23,8 +23,8 @@ const TEST_TEMPLATE_BRANCH = 'test-template';
  * Ensure we have a fiddle for the specified Electron branch.
  * If we don't have it already, download it from electron-quick-start.
  *
- * @param {string} branch - Electron branchname, e.g. `12-x-y` or `main`
- * @returns {Promise<string>} Path to the folder where the fiddle is kept
+ * @param branch - Electron branchname, e.g. `12-x-y` or `main`
+ * @returns Path to the folder where the fiddle is kept
  */
 async function prepareTemplate(branch: string): Promise<string> {
   let folder = path.join(TEMPLATES_DIR, `electron-quick-start-${branch}`);
@@ -69,8 +69,7 @@ const templateCache: Record<string, Promise<EditorValues>> = {};
 /**
  * Get a cached copy of the Electron branch's fiddle.
  *
- * @param {string} branch - Electron branchname, e.g. `12-x-y` or `main`
- * @returns {Promise<EditorValues>}
+ * @param branch - Electron branchname, e.g. `12-x-y` or `main`
  */
 function getQuickStart(branch: string): Promise<EditorValues> {
   // Load the template for that branch.
@@ -86,8 +85,6 @@ function getQuickStart(branch: string): Promise<EditorValues> {
 
 /**
  * Get a cached copy of the Electron Test fiddle.
- *
- * @returns {Promise<EditorValues>}
  */
 export function getTestTemplate(): Promise<EditorValues> {
   return getQuickStart(TEST_TEMPLATE_BRANCH);
@@ -96,8 +93,7 @@ export function getTestTemplate(): Promise<EditorValues> {
 /**
  * Get a cached copy of the fiddle for the specified Electron version.
  *
- * @param {string} version - Electron version, e.g. 12.0.0
- * @returns {Promise<EditorValues>}
+ * @param version - Electron version, e.g. 12.0.0
  */
 export function getTemplate(version: string): Promise<EditorValues> {
   const major = Number.parseInt(version);

--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -11,8 +11,6 @@ import { IpcEvents } from '../ipc-events';
 
 /**
  * Returns items related to running the current fiddle.
- *
- * @returns {Array<MenuItemConstructorOptions>}
  */
 export function getRunItems(): Array<MenuItemConstructorOptions> {
   return [
@@ -36,9 +34,6 @@ export function getRunItems(): Array<MenuItemConstructorOptions> {
  * Possibly returns items interacting with the Monaco editor.
  * Our check for "are we in the Monaco editor" is pretty crude -
  * we just assume that we are if we can paste text.
- *
- * @param {ContextMenuParams} { pageURL, editFlags }
- * @returns {Array<MenuItemConstructorOptions>}
  */
 export function getMonacoItems({
   pageURL,
@@ -105,10 +100,6 @@ export function getMonacoItems({
 
 /**
  * Possibly returns the `Inspect Element` item.
- *
- * @param {BrowserWindow} browserWindow
- * @param {ContextMenuParams} { x, y }
- * @returns {Array<MenuItemConstructorOptions>}
  */
 export function getInspectItems(
   browserWindow: BrowserWindow,
@@ -137,8 +128,6 @@ export function getInspectItems(
 
 /**
  * Creates a context menu for a given BrowserWindow
- *
- * @param {BrowserWindow} browserWindow
  */
 export function createContextMenu(browserWindow: BrowserWindow) {
   browserWindow.webContents.on('context-menu', (_event, props) => {

--- a/src/main/devtools.ts
+++ b/src/main/devtools.ts
@@ -2,9 +2,6 @@ import { isDevMode } from './utils/devmode';
 
 /**
  * Installs developer tools if we're in dev mode.
- *
- * @export
- * @returns {Promise<void>}
  */
 export async function setupDevTools(): Promise<void> {
   if (!isDevMode()) return;

--- a/src/main/dialogs.ts
+++ b/src/main/dialogs.ts
@@ -11,9 +11,7 @@ import { IpcEvents } from '../ipc-events';
 /**
  * Build a default name for a local Electron version
  * from its dirname.
- *
- * @param {string} folderPath
- * @return {string} human-readable local build name
+ * @returns human-readable local build name
  */
 function makeLocalName(folderPath: string): string {
   // take a dirname like '/home/username/electron/gn/main/src/out/testing'
@@ -35,9 +33,6 @@ function makeLocalName(folderPath: string): string {
 
 /**
  * Verifies if the local electron path is valid
- *
- * @param {string} folderPath
- * @return {boolean}
  */
 function isValidElectronPath(folderPath: string): boolean {
   const execPath = Installer.getExecPath(folderPath);
@@ -46,8 +41,6 @@ function isValidElectronPath(folderPath: string): boolean {
 
 /**
  * Listens to IPC events related to dialogs and message boxes
- *
- * @export
  */
 export function setupDialogs() {
   ipcMainManager.on(IpcEvents.SHOW_WARNING_DIALOG, (event, args) => {
@@ -77,8 +70,6 @@ export function setupDialogs() {
 
 /**
  * Shows a warning dialog
- *
- * @param {Electron.MessageBoxOptions} args
  */
 function showWarningDialog(
   window: BrowserWindow,

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -81,9 +81,6 @@ export async function showSaveDialog(
 
 /**
  * Confirm it's OK to save files in `folder`
- *
- * @param {string} filePath
- * @returns {Promise<boolean>}
  */
 async function isOkToSaveAt(filePath: string): Promise<boolean> {
   return (
@@ -96,9 +93,6 @@ async function isOkToSaveAt(filePath: string): Promise<boolean> {
 /**
  * Pops open a confirmation dialog, asking the user if they really
  * want to overwrite an existing file
- *
- * @param {string} filePath
- * @returns {Promise<boolean>}
  */
 async function confirmFileOverwrite(filePath: string): Promise<boolean> {
   try {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,9 +13,6 @@ import {
  * The main purpose of this class is to be the central
  * gathering place for IPC calls the main process sends
  * or listens to.
- *
- * @class IpcManager
- * @extends {EventEmitter}
  */
 class IpcMainManager extends EventEmitter {
   public readyWebContents = new WeakSet<Electron.WebContents>();
@@ -50,10 +47,6 @@ class IpcMainManager extends EventEmitter {
   /**
    * Send an IPC message to an instance of Electron.WebContents.
    * If none is specified, we'll automatically go with the main window.
-   *
-   * @param {IpcEvents} channel
-   * @param {Array<any>} [args]
-   * @param {Electron.WebContents} [target]
    */
   public send(
     channel: IpcEvents,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -77,8 +77,6 @@ export async function onReady() {
 
 /**
  * Handle the "before-quit" event
- *
- * @export
  */
 export function onBeforeQuit() {
   ipcMainManager.send(IpcEvents.BEFORE_QUIT);

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -25,9 +25,6 @@ import { SHOW_ME_TEMPLATES } from '../templates';
 
 /**
  * Is the passed object a constructor for an Electron Menu?
- *
- * @param {(Array<Electron.MenuItemConstructorOptions> | Electron.Menu)} [submenu]
- * @returns {submenu is Array<Electron.MenuItemConstructorOptions>}
  */
 function isSubmenu(
   submenu?: Array<MenuItemConstructorOptions> | Menu,
@@ -37,8 +34,6 @@ function isSubmenu(
 
 /**
  * Returns additional items for the help menu
- *
- * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getHelpItems(): Array<MenuItemConstructorOptions> {
   const items: MenuItemConstructorOptions[] = [];
@@ -112,8 +107,6 @@ function getHelpItems(): Array<MenuItemConstructorOptions> {
 /**
  * Depending on the OS, the `Preferences` either go into the `Fiddle`
  * menu (macOS) or under `File` (Linux, Windows)
- *
- * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getPreferencesItems(): Array<MenuItemConstructorOptions> {
   return [
@@ -135,8 +128,6 @@ function getPreferencesItems(): Array<MenuItemConstructorOptions> {
 
 /**
  * Returns the Exit items
- *
- * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getQuitItems(): Array<MenuItemConstructorOptions> {
   return [
@@ -151,8 +142,6 @@ function getQuitItems(): Array<MenuItemConstructorOptions> {
 
 /**
  * Returns the top-level "File" menu
- *
- * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getTasksMenu(): MenuItemConstructorOptions {
   const tasksMenu: Array<MenuItemConstructorOptions> = [
@@ -219,8 +208,6 @@ function getShowMeMenu(
 
 /**
  * Returns the top-level "File" menu
- *
- * @returns {Array<Electron.MenuItemConstructorOptions>}
  */
 function getFileMenu(
   acceleratorsToBlock: BlockableAccelerator[] = [],

--- a/src/main/npm.ts
+++ b/src/main/npm.ts
@@ -49,10 +49,6 @@ export async function getIsPackageManagerInstalled(
 
 /**
  * Installs given modules to a given folder.
- *
- * @param {PMOperationOptions} { dir, packageManager }
- * @param {...Array<string>} names
- * @returns {Promise<string>}
  */
 export async function addModules(
   { dir, packageManager }: PMOperationOptions,
@@ -73,11 +69,7 @@ export async function addModules(
 }
 
 /**
- * Execute an "{packageManager} run" command
- *
- * @param {PMOperationOptions} { dir, packageManager }
- * @param {string} command
- * @returns {Promise<string>}
+ * Execute an "\{packageManager\} run" command
  */
 export async function packageRun(
   { dir, packageManager }: PMOperationOptions,

--- a/src/main/templates.ts
+++ b/src/main/templates.ts
@@ -10,9 +10,6 @@ import { IpcEvents } from '../ipc-events';
 
 /**
  * Returns expected content for a given name.
- *
- * @param {string} name
- * @returns {Promise<EditorValues>}
  */
 export function getTemplateValues(name: string): Promise<EditorValues> {
   const templatePath = path.join(STATIC_DIR, 'show-me', name.toLowerCase());

--- a/src/main/themes.ts
+++ b/src/main/themes.ts
@@ -19,10 +19,6 @@ export const THEMES_PATH = path.join(CONFIG_PATH, 'themes');
 
 /**
  * Read in a theme file.
- *
- * @export
- * @param {string} [name]
- * @returns {Promise<FiddleTheme | null>}
  */
 export async function readThemeFile(
   name?: string,
@@ -48,10 +44,6 @@ export async function readThemeFile(
 
 /**
  * Create theme file and show in folder.
- *
- * @param {FiddleTheme} theme
- * @param {string} [name]
- * @returns {Promise<LoadedFiddleTheme>}
  */
 export async function createThemeFile(
   theme: FiddleTheme | LoadedFiddleTheme,
@@ -87,8 +79,6 @@ export async function createThemeFile(
 
 /**
  * Reads and then returns all available themes.
- *
- * @returns {Promise<Array<LoadedFiddleTheme>>}
  */
 export async function getAvailableThemes(): Promise<Array<LoadedFiddleTheme>> {
   const themes: Array<LoadedFiddleTheme> = [defaultDark, defaultLight];

--- a/src/main/utils/check-first-run.ts
+++ b/src/main/utils/check-first-run.ts
@@ -11,8 +11,6 @@ const getConfigPath = () => {
 /**
  * Whether or not the app is being run for
  * the first time
- *
- * @returns {boolean}
  */
 export function isFirstRun(): boolean {
   const configPath = getConfigPath();

--- a/src/main/utils/devmode.ts
+++ b/src/main/utils/devmode.ts
@@ -1,7 +1,5 @@
 /**
  * Are we currently running in development mode?
- *
- * @returns {boolean}
  */
 export function isDevMode(): boolean {
   return !!process.defaultApp;

--- a/src/main/utils/exec.ts
+++ b/src/main/utils/exec.ts
@@ -6,8 +6,6 @@ import shellEnv from 'shell-env';
 /**
  * On macOS & Linux, we need to fix the $PATH environment variable
  * so that we can call `npm`.
- *
- * @returns {Promise<void>}
  */
 export const maybeFixPath = (() => {
   // Singleton: We don't want to do this more than once.
@@ -31,10 +29,6 @@ export const maybeFixPath = (() => {
 
 /**
  * Execute a command in a directory.
- *
- * @param {string} dir
- * @param {string} cliArgs
- * @returns {Promise<string>}
  */
 export async function exec(dir: string, cliArgs: string): Promise<string> {
   await maybeFixPath();

--- a/src/main/utils/get-project-name.ts
+++ b/src/main/utils/get-project-name.ts
@@ -4,9 +4,6 @@ import * as namor from 'namor';
 
 /**
  * Returns a name for this project
- *
- * @param {string} [localPath]
- * @returns {string}
  */
 export function getProjectName(localPath?: string): string {
   if (localPath) {

--- a/src/main/utils/get-username.ts
+++ b/src/main/utils/get-username.ts
@@ -2,9 +2,6 @@ import * as os from 'node:os';
 
 /**
  * Returns the current username
- *
- * @export
- * @returns {string}
  */
 export const getUsername = (() => {
   let username = '';

--- a/src/main/utils/read-fiddle.ts
+++ b/src/main/utils/read-fiddle.ts
@@ -8,9 +8,7 @@ import { ensureRequiredFiles, isSupportedFile } from '../../utils/editor-utils';
 /**
  * Reads a Fiddle from a directory.
  *
- * @param {string} folder
- * @param {boolean} includePackageJson
- * @returns {Promise<EditorValues>} the loaded Fiddle
+ * @returns the loaded Fiddle
  */
 export async function readFiddle(
   folder: string,

--- a/src/main/versions.ts
+++ b/src/main/versions.ts
@@ -17,8 +17,8 @@ let knownVersions: ElectronVersions;
  * This way when we have a local version of Electron like '999.0.0'
  * we'll know to not try & download 999-x-y.zip from GitHub :D
  *
- * @param {number} major - Electron major version number
- * @returns {boolean} true if there are releases with that major version
+ * @param major - Electron major version number
+ * @returns true if there are releases with that major version
  */
 export function isReleasedMajor(major: number): boolean {
   return knownVersions.inMajor(major).length > 0;
@@ -52,9 +52,6 @@ export function getReleasedVersions(): Array<Version> {
 /**
  * Gets the current state of a specific version
  * Valid local electron builds are marked as `installed`
- *
- * @param {Version} ver
- * @returns {InstallState}
  */
 export function getLocalVersionState(ver: Version): InstallState {
   const { localPath } = ver;

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -35,8 +35,6 @@ export function safelyOpenWebURL(url: string) {
 
 /**
  * Gets default options for the main window
- *
- * @returns {Electron.BrowserWindowConstructorOptions}
  */
 export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions {
   const HEADER_COMMANDS_HEIGHT = 50;
@@ -66,9 +64,6 @@ export function getMainWindowOptions(): Electron.BrowserWindowConstructorOptions
 
 /**
  * Creates a new main window.
- *
- * @export
- * @returns {Electron.BrowserWindow}
  */
 export function createMainWindow(): Electron.BrowserWindow {
   console.log(`Creating main window`);
@@ -121,8 +116,6 @@ export function createMainWindow(): Electron.BrowserWindow {
 
 /**
  * Gets or creates the main window, returning it in both cases.
- *
- * @returns {Promise<Electron.BrowserWindow>}
  */
 export async function getOrCreateMainWindow(): Promise<Electron.BrowserWindow> {
   await mainIsReadyPromise;

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -24,8 +24,6 @@ import '../less/root.less';
 /**
  * The top-level class controlling the whole app. This is *not* a React component,
  * but it does eventually render all components.
- *
- * @class App
  */
 export class App {
   public state = new AppState(getElectronVersions());
@@ -82,8 +80,6 @@ export class App {
 
   /**
    * Retrieves the contents of all editor panes.
-   *
-   * @returns {EditorValues}
    */
   public async getEditorValues(
     options?: PackageJsonOptions,
@@ -202,7 +198,7 @@ export class App {
   /**
    * Opens a fiddle from the specified location.
    *
-   * @param {SetFiddleOptions} fiddle The fiddle to open
+   * @param fiddle - The fiddle to open
    */
   public async openFiddle(fiddle: SetFiddleOptions) {
     const { localFiddle, gistId } = fiddle;
@@ -218,9 +214,6 @@ export class App {
 
   /**
    * Loads theme CSS into the HTML document.
-   *
-   * @param {string} name
-   * @returns {Promise<void>}
    */
   public async loadTheme(name: string): Promise<void> {
     const tag: HTMLStyleElement | null =

--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -36,10 +36,6 @@ interface IGistActionButtonState {
 
 /**
  * The "publish" button takes care of logging you in.
- *
- * @export
- * @class GistActionButton
- * @extends {React.Component<GistActionButtonProps, GistActionButtonState>}
  */
 export const GistActionButton = observer(
   class GistActionButton extends React.Component<
@@ -85,9 +81,6 @@ export const GistActionButton = observer(
      * If we're showing the authentication dialog, we wait for it
      * to be closed again (or a GitHub token to show up) before
      * we publish
-     *
-     * @returns {Promise<void>}
-     * @memberof GistActionButton
      */
     public async handleClick(): Promise<void> {
       const { appState } = this.props;
@@ -306,8 +299,6 @@ export const GistActionButton = observer(
 
     /**
      * Publish fiddles as private.
-     *
-     * @memberof GistActionButton
      */
     public setPrivate() {
       this.setPrivacy(false);
@@ -315,8 +306,6 @@ export const GistActionButton = observer(
 
     /**
      * Publish fiddles as public.
-     *
-     * @memberof GistActionButton
      */
     public setPublic() {
       this.setPrivacy(true);

--- a/src/renderer/components/commands-address-bar.tsx
+++ b/src/renderer/components/commands-address-bar.tsx
@@ -48,8 +48,6 @@ export const AddressBar = observer(
     /**
      * Handle the form's submit event, trying to load whatever
      * URL was entered.
-     *
-     * @param {React.SyntheticEvent<HTMLFormElement>} event
      */
     private handleSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
       event.preventDefault();
@@ -58,8 +56,6 @@ export const AddressBar = observer(
 
     /**
      * Commit the address bar's value to app state and load the fiddle.
-     *
-     * @memberof AddressBar
      */
     private submit() {
       const { remoteLoader } = window.app;
@@ -91,8 +87,6 @@ export const AddressBar = observer(
 
     /**
      * Handle the change event, which usually just updates the address bar's value
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
      */
     private handleChange(event: React.ChangeEvent<HTMLInputElement>) {
       this.setState({ value: event.target.value });

--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -13,9 +13,6 @@ interface RunnerProps {
 /**
  * The runner component is responsible for actually launching the fiddle
  * with Electron. It also renders the button that does so.
- *
- * @class Runner
- * @extends {React.Component<RunnerProps>}
  */
 export const Runner = observer(
   class Runner extends React.Component<RunnerProps> {

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -18,9 +18,6 @@ interface CommandsProps {
 /**
  * The command bar, containing all the buttons doing
  * all the things
- *
- * @class Commands
- * @extends {React.Component<CommandsProps>}
  */
 export const Commands = observer(
   class Commands extends React.Component<CommandsProps> {

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -18,9 +18,6 @@ interface AddThemeDialogState {
 
 /**
  * The "add monaco theme" dialog allows users to add custom editor themes.
- *
- * @class AddThemeDialog
- * @extends {React.Component<AddThemeDialogProps, AddThemeDialogState>}
  */
 export const AddThemeDialog = observer(
   class AddThemeDialog extends React.Component<
@@ -40,8 +37,6 @@ export const AddThemeDialog = observer(
 
     /**
      * Handles a change of the file input.
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
      */
     public async onChangeFile(event: React.FormEvent<HTMLInputElement>) {
       const { files } = event.target as HTMLInputElement;
@@ -52,8 +47,6 @@ export const AddThemeDialog = observer(
 
     /**
      * Handles the submission of the dialog.
-     *
-     * @returns {Promise<void>}
      */
     public async onSubmit(): Promise<void> {
       const { file } = this.state;

--- a/src/renderer/components/dialog-add-version.tsx
+++ b/src/renderer/components/dialog-add-version.tsx
@@ -31,9 +31,6 @@ interface AddVersionDialogState {
 
 /**
  * The "add version" dialog allows users to add custom builds of Electron.
- *
- * @class AddVersionDialog
- * @extends {React.Component<AddVersionDialogProps, AddVersionDialogState>}
  */
 export const AddVersionDialog = observer(
   class AddVersionDialog extends React.Component<
@@ -74,8 +71,6 @@ export const AddVersionDialog = observer(
 
     /**
      * Handles a change of the file input
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
      */
     public onChangeVersion(event: React.ChangeEvent<HTMLInputElement>) {
       const version = event.target.value || '';
@@ -89,8 +84,6 @@ export const AddVersionDialog = observer(
 
     /**
      * Handles the submission of the dialog
-     *
-     * @returns {Promise<void>}
      */
     public async onSubmit(): Promise<void> {
       const {

--- a/src/renderer/components/dialog-bisect.tsx
+++ b/src/renderer/components/dialog-bisect.tsx
@@ -21,9 +21,6 @@ interface BisectDialogState {
 
 /**
  * The "add version" dialog allows users to add custom builds of Electron.
- *
- * @class BisectDialog
- * @extends {React.Component<BisectDialogProps, BisectDialogState>}
  */
 export const BisectDialog = observer(
   class BisectDialog extends React.Component<
@@ -68,8 +65,6 @@ export const BisectDialog = observer(
 
     /**
      * Handles the submission of the dialog
-     *
-     * @returns {Promise<void>}
      */
     public async onSubmit(): Promise<void> {
       const range = this.getBisectRange();
@@ -239,9 +234,6 @@ export const BisectDialog = observer(
 
     /**
      * Should an item in the "earliest version" dropdown be disabled?
-     *
-     * @param {RunnableVersion} version
-     * @returns {boolean}
      */
     public isEarliestItemDisabled(version: RunnableVersion): boolean {
       const { allVersions, endIndex } = this.state;
@@ -256,9 +248,6 @@ export const BisectDialog = observer(
 
     /**
      * Should an item in the "latest version" dropdown be disabled?
-     *
-     * @param {RunnableVersion} version
-     * @returns {boolean}
      */
     public isLatestItemDisabled(version: RunnableVersion): boolean {
       const { allVersions, startIndex } = this.state;

--- a/src/renderer/components/dialog-generic.tsx
+++ b/src/renderer/components/dialog-generic.tsx
@@ -12,10 +12,6 @@ interface GenericDialogProps {
 
 /**
  * The token dialog prompts the user to either continue or cancel the operation.
- *
- * @export
- * @class GenericDialog
- * @extends {React.Component<GenericDialogProps, GenericDialogState>}
  */
 export const GenericDialog = observer(
   class GenericDialog extends React.Component<GenericDialogProps> {

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -25,10 +25,6 @@ const TOKEN_PATTERN =
 /**
  * The token dialog asks the user for a GitHub Personal Access Token.
  * It's also responsible for checking if the token is correct.
- *
- * @export
- * @class TokenDialog
- * @extends {React.Component<TokenDialogProps, TokenDialogState>}
  */
 export const TokenDialog = observer(
   class TokenDialog extends React.Component<
@@ -54,9 +50,6 @@ export const TokenDialog = observer(
 
     /**
      * Handles the submission of a token
-     *
-     * @returns {Promise<void>}
-     * @memberof TokenDialog
      */
     public async onSubmitToken(): Promise<void> {
       if (!this.state.tokenInput) return;
@@ -102,8 +95,6 @@ export const TokenDialog = observer(
 
     /**
      * Opens GitHub's page for token generation
-     *
-     * @memberof TokenDialog
      */
     public openGenerateTokenExternal() {
       window.open(GENERATE_TOKEN_URL);
@@ -112,9 +103,6 @@ export const TokenDialog = observer(
     /**
      * When the input field receives focus, we check the clipboard.
      * Maybe there's already something token-like there!
-     *
-     * @returns
-     * @memberof TokenDialog
      */
     public async onTokenInputFocused() {
       const text = ((await navigator.clipboard.readText()) || '').trim();
@@ -126,9 +114,6 @@ export const TokenDialog = observer(
 
     /**
      * Handle the change event, which usually just updates the address bar's value
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     * @memberof AddressBar
      */
     public handleChange(event: React.ChangeEvent<HTMLInputElement>) {
       this.setState({ tokenInput: event.target.value });

--- a/src/renderer/components/dialogs.tsx
+++ b/src/renderer/components/dialogs.tsx
@@ -16,9 +16,6 @@ interface DialogsProps {
 
 /**
  * Dialogs (like the GitHub PAT input).
- *
- * @class Dialogs
- * @extends {React.Component<DialogsProps, {}>}
  */
 export const Dialogs = observer(
   class Dialogs extends React.Component<DialogsProps> {

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -50,8 +50,6 @@ export class Editor extends React.Component<EditorProps> {
   /**
    * Handle the editor having been mounted. This refers to Monaco's
    * mount, not React's.
-   *
-   * @param {MonacoType.editor.IStandaloneCodeEditor} editor
    */
   public async editorDidMount(editor: MonacoType.editor.IStandaloneCodeEditor) {
     const { appState, editorDidMount, id } = this.props;
@@ -121,8 +119,6 @@ export class Editor extends React.Component<EditorProps> {
 
   /**
    * Implements external url handling for Monaco.
-   *
-   * @returns {MonacoType.editor.IOpenerService}
    */
   private openerService() {
     const { appState } = this.props;

--- a/src/renderer/components/editors.tsx
+++ b/src/renderer/components/editors.tsx
@@ -54,8 +54,6 @@ export const Editors = observer(
 
     /**
      * Executed right after the component mounts. We'll setup the IPC listeners here.
-     *
-     * @memberof Editors
      */
     public async componentDidMount() {
       this.stopListening();
@@ -135,9 +133,6 @@ export const Editors = observer(
 
     /**
      * Attempt to execute a given commandId on the currently focused editor
-     *
-     * @param {string} commandId
-     * @memberof Editors
      */
     public executeCommand(commandId: string) {
       const editor = this.props.appState.editorMosaic.focusedEditor();
@@ -179,10 +174,6 @@ export const Editors = observer(
 
     /**
      * Renders the little tool bar on top of each panel
-     *
-     * @param {MosaicWindowProps<EditorId>} { title }
-     * @param {EditorId} id
-     * @returns {JSX.Element}
      */
     public renderToolbar(
       { title }: MosaicWindowProps<EditorId>,
@@ -209,10 +200,6 @@ export const Editors = observer(
 
     /**
      * Renders a Mosaic tile
-     *
-     * @param {EditorId} id
-     * @param {Array<MosaicBranch>} path
-     * @returns {JSX.Element}
      */
     public renderTile(id: EditorId, path: Array<MosaicBranch>): JSX.Element {
       const content = this.renderEditor(id);
@@ -234,10 +221,6 @@ export const Editors = observer(
 
     /**
      * Render an editor
-     *
-     * @param {EditorId} id
-     * @returns {(JSX.Element | null)}
-     * @memberof Editors
      */
     public renderEditor(id: EditorId): JSX.Element | null {
       const { appState } = this.props;
@@ -270,8 +253,6 @@ export const Editors = observer(
 
     /**
      * Handles a change in the visible nodes
-     *
-     * @param {(MosaicNode<EditorId> | null)} currentNode
      */
     public onChange(currentNode: MosaicNode<EditorId> | null) {
       this.props.appState.editorMosaic.mosaic = currentNode;
@@ -281,7 +262,6 @@ export const Editors = observer(
      * Sets the currently-focused editor. This will impact the editor's
      * z-index, ensuring that its intellisense menus don't get clipped
      * by the other editor windows.
-     * @param {EditorId} id
      */
     public setFocused(id: EditorId): void {
       this.props.appState.editorMosaic.setFocusedFile(id);

--- a/src/renderer/components/header.tsx
+++ b/src/renderer/components/header.tsx
@@ -14,9 +14,6 @@ interface HeaderState {
 
 /**
  * Everything above the editors, so buttons and the address bar.
- *
- * @class Header
- * @extends {React.Component<HeaderProps>}
  */
 export class Header extends React.Component<HeaderProps, HeaderState> {
   constructor(props: HeaderProps) {

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -24,9 +24,6 @@ interface CommandsProps {
 /**
  * This component represents the "console" that is shown
  * whenever a Fiddle is launched in Electron.
- *
- * @class Output
- * @extends {React.Component<CommandsProps>}
  */
 export const Output = observer(
   class Output extends React.Component<CommandsProps> {
@@ -114,7 +111,7 @@ export const Output = observer(
        * or a leaf. Leaf nodes are represented by the string value of their ID,
        * whereas parent nodes are objects containing information about the nested
        * binary tree.
-       * @param node A react-mosaic node
+       * @param node - A react-mosaic node
        * @returns Whether that node is a MosaicParent or not
        */
       const isParentNode = (
@@ -158,9 +155,6 @@ export const Output = observer(
 
     /**
      * Sets the model and content on the editor
-     *
-     * @private
-     * @memberof Output
      */
     private async updateModel() {
       // set the lines
@@ -181,9 +175,8 @@ export const Output = observer(
      * An OutputEntry might span multiple lines.
      * Split it into individual lines to ensure each one has a timestamp.
      *
-     * @param {OutputEntry} entries that may include paragraphs
-     * @returns {OutputEntry} single-line entries
-     * @memberof Output
+     * @param entries - that may include paragraphs
+     * @returns single-line entries
      */
     private static getLines(paragraphs: OutputEntry[]): OutputEntry[] {
       const lines: OutputEntry[] = [];
@@ -201,8 +194,6 @@ export const Output = observer(
 
     /**
      * Implements external url handling for Monaco.
-     *
-     * @returns {MonacoType.editor.IOpenerService}
      */
     private openerService() {
       const { appState } = this.props;

--- a/src/renderer/components/settings-credits.tsx
+++ b/src/renderer/components/settings-credits.tsx
@@ -17,9 +17,6 @@ interface CreditsSettingsState {
 
 /**
  * Settings content to manage Credits-related preferences.
- *
- * @class CreditsSettings
- * @extends {React.Component<CreditsSettingsProps, CreditsSettingsState>}
  */
 export class CreditsSettings extends React.Component<
   CreditsSettingsProps,
@@ -35,8 +32,6 @@ export class CreditsSettings extends React.Component<
 
   /**
    * Renders a list of contributors of Electron Fiddle.
-   *
-   * @returns {Array<JSX.Element>}
    */
   public renderContributors(): Array<JSX.Element> {
     const { contributors } = this.state;

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -32,9 +32,6 @@ interface ElectronSettingsProps {
 
 /**
  * Settings content to manage Electron-related preferences.
- *
- * @class ElectronSettings
- * @extends {React.Component<ElectronSettingsProps, ElectronSettingsState>}
  */
 export const ElectronSettings = observer(
   class ElectronSettings extends React.Component<ElectronSettingsProps> {
@@ -58,8 +55,6 @@ export const ElectronSettings = observer(
 
     /**
      * Toggles visibility of non-downloaded versions
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleStateChange(event: React.FormEvent<HTMLInputElement>) {
       const { appState } = this.props;
@@ -69,8 +64,6 @@ export const ElectronSettings = observer(
 
     /**
      * Toggles visibility of obsolete versions
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleShowObsoleteChange(event: React.FormEvent<HTMLInputElement>) {
       const { appState } = this.props;
@@ -80,8 +73,6 @@ export const ElectronSettings = observer(
 
     /**
      * Handles a change in which channels should be displayed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleChannelChange(event: React.FormEvent<HTMLInputElement>) {
       const { id, checked } = event.currentTarget;
@@ -96,8 +87,6 @@ export const ElectronSettings = observer(
 
     /**
      * Download all visible versions of Electron.
-     *
-     * @returns {Promise<void>}
      */
     public async handleDownloadAll(): Promise<void> {
       const {
@@ -120,8 +109,6 @@ export const ElectronSettings = observer(
 
     /**
      * Delete all downloaded versions of Electron.
-     *
-     * @returns {Promise<void>}
      */
     public async handleDeleteAll(): Promise<void> {
       const { versions, removeVersion, startDeletingAll, stopDeletingAll } =
@@ -168,9 +155,6 @@ export const ElectronSettings = observer(
 
     /**
      * Renders the various buttons for advanced operations
-     *
-     * @private
-     * @returns {JSX.Element}
      */
     private renderAdvancedButtons(): JSX.Element {
       const { isUpdatingElectronVersions, isDownloadingAll, isDeletingAll } =
@@ -231,9 +215,6 @@ export const ElectronSettings = observer(
 
     /**
      * Renders the various options for which versions should be displayed
-     *
-     * @private
-     * @returns {JSX.Element}
      */
     private renderVersionShowOptions(): JSX.Element {
       const { appState } = this.props;
@@ -293,9 +274,6 @@ export const ElectronSettings = observer(
 
     /**
      * Renders the table with Electron versions.
-     *
-     * @private
-     * @returns {JSX.Element}
      */
     private renderTable(): JSX.Element {
       return (
@@ -314,9 +292,6 @@ export const ElectronSettings = observer(
 
     /**
      * Renders the rows with Electron version, returning an Array.
-     *
-     * @private
-     * @returns {Array<JSX.Element>}
      */
     private renderTableRows(): Array<JSX.Element | null> {
       return this.props.appState.versionsToShow.map((item) => (
@@ -330,9 +305,6 @@ export const ElectronSettings = observer(
 
     /**
      * Returns a human-readable state indicator for an Electron version.
-     *
-     * @param {RunnableVersion} item
-     * @returns {JSX.Element}
      */
     private renderHumanState(item: RunnableVersion): JSX.Element {
       const { state, source } = item;
@@ -359,10 +331,6 @@ export const ElectronSettings = observer(
 
     /**
      * Renders the action for a single Electron version.
-     *
-     * @private
-     * @param {RunnableVersion} ver
-     * @returns {JSX.Element}
      */
     private renderAction(ver: RunnableVersion): JSX.Element {
       const { state, source, version } = ver;

--- a/src/renderer/components/settings-execution.tsx
+++ b/src/renderer/components/settings-execution.tsx
@@ -30,9 +30,6 @@ interface ExecutionSettingsState {
 
 /**
  * Settings content to manage execution-related preferences.
- *
- * @class ExecutionSettings
- * @extends {React.Component<ExecutionSettingsProps, ExecutionSettingsState>}
  */
 export const ExecutionSettings = observer(
   class ExecutionSettings extends React.Component<
@@ -80,8 +77,6 @@ export const ExecutionSettings = observer(
     /**
      * Handles a change on whether or not the user data dir should be deleted
      * after a run.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleDeleteDataChange(event: React.FormEvent<HTMLInputElement>) {
       const { checked } = event.currentTarget;
@@ -90,8 +85,6 @@ export const ExecutionSettings = observer(
 
     /**
      * Handles a change on whether or not electron should log more things
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleElectronLoggingChange(
       event: React.FormEvent<HTMLInputElement>,
@@ -103,9 +96,6 @@ export const ExecutionSettings = observer(
     /**
      * Handles a change in the execution flags or environment variables
      * run with the Electron executable.
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
-     * @param {SettingItemType} type
      */
     public handleSettingsItemChange(
       event: React.ChangeEvent<HTMLInputElement>,
@@ -129,8 +119,6 @@ export const ExecutionSettings = observer(
 
     /**
      * Adds a new settings item input field.
-     *
-     * @param {SettingItemType} type
      */
     private addNewSettingsItem(type: SettingItemType) {
       const array = Object.entries(this.state[type]);
@@ -146,8 +134,6 @@ export const ExecutionSettings = observer(
     /**
      * Handle a change to the package manager used to install modules when running
      * Fiddles;
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     private handlePMChange = (event: React.FormEvent<HTMLInputElement>) => {
       const { appState } = this.props;

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -21,10 +21,6 @@ const ThemeSelect = Select.ofType<LoadedFiddleTheme>();
 /**
  * Helper method: Returns the <Select /> predicate for an Electron
  * version.
- *
- * @param {string} query
- * @param {RunnableVersion} { name }
- * @returns
  */
 export const filterItem: ItemPredicate<LoadedFiddleTheme> = (
   query,
@@ -36,10 +32,6 @@ export const filterItem: ItemPredicate<LoadedFiddleTheme> = (
 /**
  * Helper method: Returns the <Select /> <MenuItem /> for Electron
  * versions.
- *
- * @param {RunnableVersion} item
- * @param {IItemRendererProps} { handleClick, modifiers, query }
- * @returns
  */
 export const renderItem: ItemRenderer<LoadedFiddleTheme> = (
   item,
@@ -73,9 +65,6 @@ interface AppearanceSettingsState {
 
 /**
  * Settings content to manage appearance-related preferences.
- *
- * @class AppearanceSettings
- * @extends {React.Component<AppearanceSettingsProps, AppearanceSettingsState>}
  */
 export const AppearanceSettings = observer(
   class AppearanceSettings extends React.Component<
@@ -119,8 +108,6 @@ export const AppearanceSettings = observer(
     /**
      * Handle change, which usually means that we'd like update
      * the current theme.
-     *
-     * @param {LoadedFiddleTheme} theme
      */
     public handleChange(theme: LoadedFiddleTheme) {
       this.setState({ selectedTheme: theme });
@@ -129,9 +116,6 @@ export const AppearanceSettings = observer(
 
     /**
      * Creates a new theme from the current template.
-     *
-     * @returns {Promise<boolean>}
-     * @memberof AppearanceSettings
      */
     public async createNewThemeFromCurrent(): Promise<boolean> {
       const { appState } = this.props;
@@ -154,8 +138,6 @@ export const AppearanceSettings = observer(
     /**
      * Creates the themes folder in .electron-fiddle if one does not
      * exist yet, then shows that folder in the Finder/Explorer.
-     *
-     * @returns {Promise<boolean>}
      */
     public async openThemeFolder(): Promise<boolean> {
       try {

--- a/src/renderer/components/settings-general-block-accelerators.tsx
+++ b/src/renderer/components/settings-general-block-accelerators.tsx
@@ -12,9 +12,6 @@ interface BlockAcceleratorsSettingsProps {
 
 /**
  * Settings content to block keyboard accelerators.
- *
- * @class BlockAcceleratorsSettings
- * @extends {React.Component<BlockAcceleratorsSettingsProps>}
  */
 export const BlockAcceleratorsSettings = observer(
   class BlockAcceleratorsSettings extends React.Component<BlockAcceleratorsSettingsProps> {
@@ -28,8 +25,6 @@ export const BlockAcceleratorsSettings = observer(
     /**
      * Handles a change on whether a keyboard shortcut should be blocked
      * before fiddle is executed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleBlockAcceleratorChange(
       event: React.FormEvent<HTMLInputElement>,

--- a/src/renderer/components/settings-general-console.tsx
+++ b/src/renderer/components/settings-general-console.tsx
@@ -11,9 +11,6 @@ interface ConsoleSettingsProps {
 
 /**
  * Settings content to manage console-related preferences.
- *
- * @class ConsoleSettings
- * @extends {React.Component<ConsoleSettingsProps>}
  */
 export const ConsoleSettings = observer(
   class ConsoleSettings extends React.Component<ConsoleSettingsProps> {
@@ -26,8 +23,6 @@ export const ConsoleSettings = observer(
     /**
      * Handles a change on whether or not the console should be cleared
      * before fiddle is executed.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handleClearOnRunChange(event: React.FormEvent<HTMLInputElement>) {
       const { checked } = event.currentTarget;

--- a/src/renderer/components/settings-general-font.tsx
+++ b/src/renderer/components/settings-general-font.tsx
@@ -16,9 +16,6 @@ interface FontSettingsState {
 
 /**
  * Settings font family and size.
- *
- * @class FontSettings
- * @extends {React.Component<FontSettingsProps, FontSettingsState>}
  */
 @observer
 export class FontSettings extends React.Component<
@@ -39,8 +36,6 @@ export class FontSettings extends React.Component<
 
   /**
    * Handles a change in the editor font family.
-   *
-   * @param {React.FormEvent<HTMLInputElement>} event
    */
   public handleSetFontFamily(event: React.FormEvent<HTMLInputElement>): void {
     const { value: fontFamily } = event.currentTarget;
@@ -50,8 +45,6 @@ export class FontSettings extends React.Component<
 
   /**
    * Handles a change in the editor font size.
-   *
-   * @param {React.FormEvent<HTMLInputElement>} event
    */
   public handleSetFontSize(event: React.FormEvent<HTMLInputElement>): void {
     const parsedFontSize = parseInt(event.currentTarget.value, 10);

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -11,9 +11,6 @@ interface GitHubSettingsProps {
 
 /**
  * Settings content to manage GitHub-related preferences.
- *
- * @class GitHubSettings
- * @extends {React.Component<GitHubSettingsProps, {}>}
  */
 export const GitHubSettings = observer(
   class GitHubSettings extends React.Component<GitHubSettingsProps> {
@@ -31,8 +28,6 @@ export const GitHubSettings = observer(
 
     /**
      * Render the "logged out" settings experience.
-     *
-     * @returns {JSX.Element}
      */
     public renderNotSignedIn(): JSX.Element {
       return (
@@ -48,8 +43,6 @@ export const GitHubSettings = observer(
 
     /**
      * Render the "logged in" settings experience.
-     *
-     * @returns {JSX.Element}
      */
     public renderSignedIn(): JSX.Element {
       const { gitHubLogin } = this.props.appState;
@@ -70,8 +63,6 @@ export const GitHubSettings = observer(
     /**
      * Handles a change on whether or not the gist should be published
      * as a revision on top of the default fiddle gist.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} event
      */
     public handlePublishGistAsRevisionChange(
       event: React.FormEvent<HTMLInputElement>,

--- a/src/renderer/components/settings-general-mirror.tsx
+++ b/src/renderer/components/settings-general-mirror.tsx
@@ -15,9 +15,6 @@ type IMirrorSettingsState = Mirrors;
 
 /**
  * Settings electron mirror
- *
- * @class MirrorSettings
- * @extends {React.Component<MirrorSettingsProps, IMirrorSettingsState>}
  */
 export const MirrorSettings = observer(
   class MirrorSettings extends React.Component<

--- a/src/renderer/components/settings-general-package-author.tsx
+++ b/src/renderer/components/settings-general-package-author.tsx
@@ -15,9 +15,6 @@ interface IPackageAuthorSettingsState {
 
 /**
  * Settings package.json author info
- *
- * @class PackageAuthorSettings
- * @extends {React.Component<PackageAuthorSettingsProps, IPackageAuthorSettingsState>}
  */
 export const PackageAuthorSettings = observer(
   class PackageAuthorSettings extends React.Component<
@@ -37,8 +34,6 @@ export const PackageAuthorSettings = observer(
 
     /**
      * Set the author information in package.json when processing uploads to gist
-     *
-     * @param {React.ChangeEvent<HTMLInputElement>} event
      */
     public handlePackageAuthorChange(event: React.FormEvent<HTMLInputElement>) {
       const { value } = event.currentTarget;

--- a/src/renderer/components/settings-general.tsx
+++ b/src/renderer/components/settings-general.tsx
@@ -19,9 +19,6 @@ interface GeneralSettingsProps {
 
 /**
  * Settings content to manage GitHub-related preferences.
- *
- * @class GitHubSettings
- * @extends {React.Component<GeneralSettingsProps>}
  */
 export const GeneralSettings = observer(
   class GeneralSettings extends React.Component<GeneralSettingsProps> {

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -34,9 +34,6 @@ interface SettingsState {
 
 /**
  * Everything above the editors, so buttons and the address bar.
- *
- * @class Settings
- * @extends {React.Component<SettingsProps, SettingsState>}
  */
 export const Settings = observer(
   class Settings extends React.Component<SettingsProps, SettingsState> {
@@ -65,8 +62,6 @@ export const Settings = observer(
     /**
      * Renders the content of the settings, usually by simply
      * return the appropriate component.
-     *
-     * @returns {(JSX.Element | null)}
      */
     public renderContent(): JSX.Element | null {
       const { section } = this.state;
@@ -98,8 +93,6 @@ export const Settings = observer(
 
     /**
      * Renders the individual menu items
-     *
-     * @returns {Array<JSX.Element>}
      */
     public renderOptions(): Array<JSX.Element> {
       const { section } = this.state;
@@ -147,10 +140,6 @@ export const Settings = observer(
 
     /**
      * Get the settings icons
-     *
-     * @param {SettingsSections} section
-     * @returns {IconName}
-     * @memberof Settings
      */
     private getIconForSection(section: SettingsSections): IconName {
       if (section === SettingsSections.Credits) {
@@ -167,8 +156,6 @@ export const Settings = observer(
     /**
      * Trigger closing of the settings panel upon Esc
      * If hasPopoverOpen is set to true, settings will not close as only the popover should close
-     *
-     * @param {KeyboardEvent} event
      */
     private closeSettingsPanel(event: KeyboardEvent) {
       const { appState } = this.props;

--- a/src/renderer/components/sidebar-package-manager.tsx
+++ b/src/renderer/components/sidebar-package-manager.tsx
@@ -94,7 +94,6 @@ export class SidebarPackageManager extends React.Component<IProps, IState> {
   /**
    * Takes the module map and returns an object
    * conforming to the BlueprintJS tree schema.
-   * @returns TreeNodeInfo[]
    */
   private getModuleNodes = (): TreeNodeInfo[] => {
     const values: TreeNodeInfo[] = [];

--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -17,8 +17,6 @@ interface WelcomeTourState {
 /**
  * This is our "Welcome to Electron Fiddle" Tour. It includes both an intro to
  * the app and a short intro to Electron.
- *
- * @returns {Set<TourScriptStep>}
  */
 export function getWelcomeTour(): Set<TourScriptStep> {
   return new Set([
@@ -175,10 +173,6 @@ export function getWelcomeTour(): Set<TourScriptStep> {
 
 /**
  * The "Welcome to Electron Fiddle" Tour.
- *
- * @export
- * @class WelcomeTour
- * @extends {React.Component<WelcomeTourProps, WelcomeTourState>}
  */
 export const WelcomeTour = observer(
   class WelcomeTour extends React.Component<

--- a/src/renderer/components/tour.tsx
+++ b/src/renderer/components/tour.tsx
@@ -104,9 +104,6 @@ export class Tour extends React.Component<TourProps, TourState> {
    * Return buttons for the dialog for the current step
    * of the tour. By default, we just return a continue/stop
    * combo
-   *
-   * @param {TourScriptStep} { getButtons }
-   * @returns {Array<JSX.Element>}
    */
   private getButtons({ getButtons }: TourScriptStep): Array<JSX.Element> {
     // Did the step bring its own buttons?
@@ -145,10 +142,6 @@ export class Tour extends React.Component<TourProps, TourState> {
 
   /**
    * Renders the dialog for the current step of the tour.
-   *
-   * @param {TourScriptStep} step
-   * @param {ClientRect} rect
-   * @returns {JSX.Element}
    */
   private getDialogForStep(
     step: TourScriptStep,
@@ -188,9 +181,6 @@ export class Tour extends React.Component<TourProps, TourState> {
 
   /**
    * Returns the "mask" for a given step.
-   *
-   * @param {TourScriptStep} step
-   * @returns {(JSX.Element | null)}
    */
   private getStep(step: TourScriptStep): JSX.Element | null {
     const { selector } = step;

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -61,9 +61,6 @@ const itemListRenderer: ItemListRenderer<RunnableVersion> = ({
 /**
  * Helper method: Returns the <Select /> label for an Electron
  * version.
- *
- * @param {RunnableVersion} { source, state, name }
- * @returns {string}
  */
 export function getItemLabel({ source, state, name }: RunnableVersion): string {
   // If a version is local, either it's there or it's not.
@@ -84,9 +81,6 @@ export function getItemLabel({ source, state, name }: RunnableVersion): string {
 /**
  * Helper method: Returns the <Select /> icon for an Electron
  * version.
- *
- * @param {RunnableVersion} { state }
- * @returns {IconName}
  */
 export function getItemIcon({ source, state }: RunnableVersion): IconName {
   // If a version is local, either it's there or it's not.
@@ -114,10 +108,6 @@ export function getItemIcon({ source, state }: RunnableVersion): IconName {
  * [3.0.0, 14.3.0, 13.2.0, 12.0.0-nightly.20210301, 12.0.0-beta.3]
  * and a search query of '3', this method would sort them into:
  * [3.0.0, 13.2.0, 14.3.0, 12.0.0-beta.3, 12.0.0-nightly.20210301]
- *
- * @param {string} query
- * @param {RunnableVersion[]} versions
- * @returns
  */
 export const filterItems: ItemListPredicate<RunnableVersion> = (
   query,
@@ -153,8 +143,7 @@ export const filterItems: ItemListPredicate<RunnableVersion> = (
 /**
  * Renders a context menu to copy the current Electron version.
  *
- * @param {React.MouseEvent<HTMLButtonElement>} e
- * @param {string} version the Electron version number to copy.
+ * @param version - the Electron version number to copy.
  */
 export const renderVersionContextMenu = (
   e: React.MouseEvent<HTMLButtonElement>,
@@ -178,10 +167,6 @@ export const renderVersionContextMenu = (
 /**
  * Helper method: Returns the <Select /> <MenuItem /> for Electron
  * versions.
- *
- * @param {RunnableVersion} item
- * @param {IItemRendererProps} { handleClick, modifiers, query }
- * @returns
  */
 export const renderItem: ItemRenderer<RunnableVersion> = (
   item,
@@ -247,9 +232,6 @@ interface VersionSelectProps {
 /**
  * A dropdown allowing the selection of Electron versions. The actual
  * download is managed in the state.
- *
- * @class VersionSelect
- * @extends {React.Component<VersionSelectProps, VersionSelectState>}
  */
 export const VersionSelect = observer(
   class VersionSelect extends React.Component<

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -55,10 +55,6 @@ export class FileManager {
 
   /**
    * Tries to open a fiddle.
-   *
-   * @param {string} filePath
-   * @param {Record<string, string>} files
-   * @memberof FileManager
    */
   public async openFiddle(filePath: string, files: Record<string, string>) {
     const { app } = window;
@@ -122,11 +118,6 @@ export class FileManager {
 
   /**
    * Get files to save, but with a transform applied
-   *
-   * @param {PackageJsonOptions} [options]
-   * @param {Array<FileTransformOperation>} [transforms]
-   * @returns {Promise<{ localPath: string; files: Files }>}
-   * @memberof FileManager
    */
   public async getFiles(
     options?: PackageJsonOptions,
@@ -166,10 +157,6 @@ export class FileManager {
   /**
    * Save the current project to a temporary directory. Returns the
    * path to the temp directory.
-   *
-   * @param {PackageJsonOptions} options
-   * @param {Array<FileTransformOperation>} [transforms]
-   * @returns {Promise<string>}
    */
   public async saveToTemp(
     options: PackageJsonOptions,

--- a/src/renderer/npm-search.tsx
+++ b/src/renderer/npm-search.tsx
@@ -28,7 +28,6 @@ class NPMSearch {
   /**
    * Finds a list of packages Algolia's npm search index.
    * Naively caches all queries client-side.
-   * @param query Search query
    */
   async search(query: string) {
     if (this.searchCache.has(query)) {

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -251,7 +251,7 @@ export class RemoteLoader {
   /**
    * Verifies from the user that we should be loading this fiddle.
    *
-   * @param {string} what What are we loading from (gist, example, etc.)
+   * @param what - What are we loading from (gist, example, etc.)
    */
   public verifyRemoteLoad(what: string): Promise<boolean> {
     return this.appState.showConfirmDialog({
@@ -271,10 +271,6 @@ export class RemoteLoader {
 
   /**
    * Loading a fiddle from GitHub succeeded, let's move on.
-   *
-   * @param {EditorValues} values
-   * @param {string} gistId
-   * @returns {Promise<boolean>}
    */
   private async handleLoadingSuccess(
     values: EditorValues,
@@ -287,9 +283,6 @@ export class RemoteLoader {
   /**
    * Loading a fiddle from GitHub failed - this method handles this case
    * gracefully.
-   *
-   * @param {Error} error
-   * @returns {boolean}
    */
   private handleLoadingFailed(error: Error): false {
     const failedLabel = `Loading the fiddle failed: ${error.message}`;

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -54,9 +54,7 @@ export class Runner {
   /**
    * Bisect the current fiddle across the specified versions.
    *
-   * @param {Array<RunnableVersion>} versions - versions to bisect
-   * @returns {Promise<RunResult>}
-   * @memberof Runner
+   * @param versions - versions to bisect
    */
   public autobisect(versions: Array<RunnableVersion>): Promise<RunResult> {
     const { appState } = this;
@@ -68,9 +66,7 @@ export class Runner {
   /**
    * Bisect the current fiddle across the specified versions.
    *
-   * @param {Array<RunnableVersion>} versions - versions to bisect
-   * @returns {Promise<RunResult>}
-   * @memberof Runner
+   * @param versions - versions to bisect
    */
   public async autobisectImpl(
     versions: Array<RunnableVersion>,
@@ -142,9 +138,6 @@ export class Runner {
 
   /**
    * Actually run the fiddle.
-   *
-   * @returns {Promise<RunResult>}
-   * @memberof Runner
    */
   public async run(): Promise<RunResult> {
     const options = { includeDependencies: false, includeElectron: false };
@@ -232,8 +225,6 @@ export class Runner {
 
   /**
    * Stop a currently running Electron fiddle.
-   *
-   * @memberof Runner
    */
   public stop(): void {
     window.ElectronFiddle.stopFiddle();
@@ -241,10 +232,6 @@ export class Runner {
 
   /**
    * Uses electron-forge to either package or make the current fiddle
-   *
-   * @param {ForgeCommands} operation
-   * @returns {Promise<boolean>}
-   * @memberof Runner
    */
   public async performForgeOperation(
     operation: ForgeCommands,
@@ -300,10 +287,6 @@ export class Runner {
 
   /**
    * Installs the specified modules
-   *
-   * @param {PMOperationOptions} pmOptions
-   * @returns {Promise<void>}
-   * @memberof Runner
    */
   public async installModules(pmOptions: PMOperationOptions): Promise<void> {
     const modules = Array.from(this.appState.modules.entries()).map(
@@ -443,11 +426,6 @@ export class Runner {
 
   /**
    * Save files to temp, logging to the Fiddle terminal while doing so
-   *
-   * @param {PackageJsonOptions} options
-   * @param {Array<FileTransformOperation>} [transforms]
-   * @returns {(Promise<string | null>)}
-   * @memberof Runner
    */
   public async saveToTemp(
     options: PackageJsonOptions,
@@ -470,11 +448,7 @@ export class Runner {
 
   /**
    * Installs modules in a given directory (we're basically
-   * just running "{packageManager} install")
-   *
-   * @param {PMOperationOptions} options
-   * @returns {Promise<boolean>}
-   * @memberof Runner
+   * just running "\{packageManager\} install")
    */
   public async packageInstall(options: PMOperationOptions): Promise<boolean> {
     const pm = options.packageManager;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -46,9 +46,6 @@ import {
 
 /**
  * The application's state. Exported as a singleton below.
- *
- * @export
- * @class AppState
  */
 export class AppState {
   private readonly timeFmt = new Intl.DateTimeFormat([], {
@@ -566,7 +563,7 @@ export class AppState {
   }
 
   /**
-   * @returns {string} the title, e.g. appname, fiddle name, state
+   * @returns the title, e.g. appname, fiddle name, state
    */
   get title(): string {
     const { isEdited } = this.editorMosaic;
@@ -784,9 +781,6 @@ export class AppState {
 
   /**
    * Remove a version of Electron
-   *
-   * @param {RunnableVersion} ver
-   * @returns {Promise<void>}
    */
   public async removeVersion(ver: RunnableVersion): Promise<void> {
     const { version, state, source } = ver;
@@ -825,9 +819,6 @@ export class AppState {
 
   /**
    * Download a version of Electron.
-   *
-   * @param {RunnableVersion} ver
-   * @returns {Promise<void>}
    */
   public async downloadVersion(ver: RunnableVersion): Promise<void> {
     const { source, state, version } = ver;
@@ -926,9 +917,6 @@ export class AppState {
 
   /**
    * Select a version of Electron (and download it if necessary).
-   *
-   * @param {string} input
-   * @returns {Promise<void>}
    */
   public async setVersion(input: string): Promise<void> {
     const fallback = this.findUsableVersion();
@@ -976,8 +964,6 @@ export class AppState {
 
   /**
    * The equivalent of signing out.
-   *
-   * @returns {void}
    */
   public signOutGitHub(): void {
     this.gitHubAvatarUrl = null;
@@ -1050,8 +1036,6 @@ export class AppState {
   /**
    * Ensure that any buffered console output is
    * printed before a running Fiddle is stopped.
-   *
-   * @returns {void}
    */
   public flushOutput(): void {
     this.pushOutput('\n', { bypassBuffer: false });
@@ -1060,9 +1044,6 @@ export class AppState {
   /**
    * Push output to the application's state. Accepts a buffer or a string as input,
    * attaches a timestamp, and pushes into the store.
-   *
-   * @param {(string | Buffer)} data
-   * @param {OutputOptions} options
    */
   public pushOutput(
     data: string | Buffer,
@@ -1103,9 +1084,6 @@ export class AppState {
 
   /**
    * Little convenience method that pushes message and error.
-   *
-   * @param {string} message
-   * @param {Error} error
    */
   public pushError(message: string, error: Error) {
     this.pushOutput(`⚠️ ${message}. Error encountered:`);
@@ -1158,9 +1136,6 @@ export class AppState {
   /**
    * Updates the pages url with a hash element that allows the main
    * process to quickly determine if there's a view open.
-   *
-   * @private
-   * @memberof AppState
    */
   private setPageHash() {
     let hash = '';
@@ -1174,9 +1149,6 @@ export class AppState {
 
   /**
    * Returns the current state of version passed
-   *
-   * @param {string} version
-   * @returns {InstallState}
    */
   public getVersionState(version: string): InstallState {
     return window.ElectronFiddle.getVersionState(version);
@@ -1184,9 +1156,6 @@ export class AppState {
 
   /**
    * Save a key/value to localStorage.
-   *
-   * @param {GlobalSetting | WindowSpecificSetting} key
-   * @param {(string | number | Array<any> | Record<string, unknown> | null | boolean)} [value]
    */
   private save(
     key: GlobalSetting | WindowSpecificSetting,
@@ -1210,10 +1179,6 @@ export class AppState {
 
   /**
    * Fetch data from localStorage.
-   *
-   * @template T
-   * @param {GlobalSetting | WindowSpecificSetting} key
-   * @returns {(T | string | null)}
    */
   private retrieve<T>(
     key: GlobalSetting | WindowSpecificSetting,

--- a/src/renderer/themes.ts
+++ b/src/renderer/themes.ts
@@ -6,8 +6,6 @@ import {
 
 /**
  * Activate a given theme (or the default)
- *
- * @param {LoadedFiddleTheme} theme
  */
 export function activateTheme(theme: LoadedFiddleTheme) {
   const { monaco } = window;
@@ -18,10 +16,6 @@ export function activateTheme(theme: LoadedFiddleTheme) {
 /**
  * Returns a Fiddle theme, either a default one or by checking
  * the disk for a JSON file.
- *
- * @export
- * @param {string} [name]
- * @returns {Promise<LoadedFiddleTheme>}
  */
 export async function getTheme(
   name?: string | null,
@@ -36,9 +30,6 @@ export async function getTheme(
 
 /**
  * Get the CSS string for a theme.
- *
- * @param {FiddleTheme} theme
- * @returns {Promise<string>}
  */
 async function getCssStringForTheme(theme: FiddleTheme): Promise<string> {
   let cssContent = '';

--- a/src/renderer/transforms/dotfiles.ts
+++ b/src/renderer/transforms/dotfiles.ts
@@ -2,9 +2,6 @@ import { Files } from '../../interfaces';
 
 /**
  * This transform adds dotfiles (like .gitignore)
- *
- * @param {Files} files
- * @returns {Promise<Files>}
  */
 export async function dotfilesTransform(files: Files): Promise<Files> {
   files.set('.gitignore', 'node_modules\nout');

--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -4,9 +4,6 @@ import { getForgeVersion } from '../utils/get-package';
 /**
  * This transform turns the files into an electron-forge
  * project.
- *
- * @param {Files} files
- * @returns {Promise<Files>}
  */
 export async function forgeTransform(files: Files): Promise<Files> {
   if (files.get(PACKAGE_NAME)) {

--- a/src/renderer/utils/disable-download.ts
+++ b/src/renderer/utils/disable-download.ts
@@ -6,8 +6,7 @@ import semver from 'semver';
  * - below 6.0.8 and 7.0.0 on Windows arm64
  * Reference: {@link https://www.electronjs.org/blog/apple-silicon}
  *
- * @param {string} version - electron version
- * @returns {boolean}
+ * @param version - electron version
  */
 export function disableDownload(version: string): boolean {
   return (

--- a/src/renderer/utils/electron-name.ts
+++ b/src/renderer/utils/electron-name.ts
@@ -1,7 +1,5 @@
 /**
  * Returns the correct name of ELectron for the current platform
- *
- * @returns {string}
  */
 export function getElectronNameForPlatform(): string {
   switch (window.ElectronFiddle.platform) {

--- a/src/renderer/utils/get-package.ts
+++ b/src/renderer/utils/get-package.ts
@@ -13,10 +13,6 @@ export function getForgeVersion(): string {
 
 /**
  * Returns the package.json for the current Fiddle
- *
- * @param {AppState} appState
- * @param {PackageJsonOptions} [options]
- * @returns {string}
  */
 export async function getPackageJson(
   appState: AppState,

--- a/src/renderer/utils/get-version-range.ts
+++ b/src/renderer/utils/get-version-range.ts
@@ -4,11 +4,9 @@ import { RunnableVersion } from '../../interfaces';
 /**
  * An subset of `versions` sorted from oldest to newest and bounded in the range of [oldVersion..newVersion]
  *
- * @export
- * @param {string} oldVersion - first version to keep
- * @param {string} newVersion - last version to keep
- * @param {RunnableVersion[]} versions - the versions to make a subset of
- * @returns {RunnableVersion[]}
+ * @param oldVersion - first version to keep
+ * @param newVersion - last version to keep
+ * @param versions - the versions to make a subset of
  */
 export function getVersionRange(
   oldVersion: string,

--- a/src/renderer/utils/highlight-text.tsx
+++ b/src/renderer/utils/highlight-text.tsx
@@ -6,11 +6,6 @@ import * as React from 'react';
  * Inspired by https://github.com/palantir/blueprint/blob/develop/packages/docs-app/src/examples/select-examples/films.tsx
  * License: https://github.com/palantir/blueprint/blob/develop/LICENSE
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
- *
- * @export
- * @param {string} text
- * @param {string} query
- * @returns {(Array<React.ReactNode | string> | null)}
  */
 export function highlightText(
   text: string,

--- a/src/renderer/utils/js-path.ts
+++ b/src/renderer/utils/js-path.ts
@@ -1,9 +1,5 @@
 /**
  * Returns the value of an object's property at a given path.
- *
- * @param {string} input
- * @param {*} obj
- * @returns {any}
  */
 export function getAtPath(input: string, obj: any): any {
   return input.split('.').reduce((o, s) => o[s], obj);
@@ -11,10 +7,6 @@ export function getAtPath(input: string, obj: any): any {
 
 /**
  * Sets a value of a property of an object at a given path
- *
- * @param {string} input
- * @param {*} obj
- * @param {*} val
  */
 export function setAtPath(input: string, obj: any, val: any) {
   const pathValues = input.split('.');

--- a/src/renderer/utils/normalize-version.ts
+++ b/src/renderer/utils/normalize-version.ts
@@ -1,8 +1,5 @@
 /**
  * Removes a possible leading "v" from a version.
- *
- * @param {string} version
- * @returns {string}
  */
 export function normalizeVersion(version = ''): string {
   if (version.startsWith('v')) {

--- a/src/renderer/utils/octokit.ts
+++ b/src/renderer/utils/octokit.ts
@@ -7,9 +7,6 @@ let _octo: Octokit;
 /**
  * Returns a loaded Octokit. If state is passed and authentication
  * is available, we'll token-authenticate.
- *
- * @export
- * @returns {Promise<typeof Octokit>}
  */
 export async function getOctokit(appState?: AppState): Promise<Octokit> {
   // It's possible to load Gists without being authenticated,

--- a/src/renderer/utils/plural-maybe.ts
+++ b/src/renderer/utils/plural-maybe.ts
@@ -1,10 +1,6 @@
 /**
  * Takes a word and an array. If the array has more than one entry,
  * it attaches a plural "s".
- *
- * @param {string} word
- * @param {Array<any>} input
- * @returns {string}
  */
 export function maybePlural(word: string, input: Array<any>): string {
   if (input && input.length && input.length > 1) {

--- a/src/renderer/utils/position-for-rect.ts
+++ b/src/renderer/utils/position-for-rect.ts
@@ -11,11 +11,6 @@ interface PositionResult {
  * position for, say, a dialog, tooltip, or popover.
  *
  * TODO: Make this a lot smarter!
- *
- * @param {ClientRect} target
- * @param {number} margin
- * @param {{ width: number, height: number }} size
- * @returns {PositionResult}
  */
 export function positionForRect(
   target: ClientRect,
@@ -94,9 +89,6 @@ function isResultOkay(
 
 /**
  * Is the position too far up?
- *
- * @param {PositionResult} input
- * @returns {boolean}
  */
 function isTooFarUp(input: PositionResult): boolean {
   return input.top < 0;
@@ -104,10 +96,6 @@ function isTooFarUp(input: PositionResult): boolean {
 
 /**
  * Is the position too far below?
- *
- * @param {PositionResult} input
- * @param {{ width: number, height: number }} size
- * @returns {boolean}
  */
 function isTooFarBelow(
   input: PositionResult,
@@ -121,10 +109,6 @@ function isTooFarBelow(
 
 /**
  * Is the position too far right?
- *
- * @param {PositionResult} input
- * @param {{ width: number, height: number }} size
- * @returns {boolean}
  */
 function isTooFarRight(
   input: PositionResult,
@@ -138,9 +122,6 @@ function isTooFarRight(
 
 /**
  * Is the position too far left?
- *
- * @param {PositionResult} input
- * @returns {boolean}
  */
 function isTooFarLeft(input: PositionResult): boolean {
   return input.left < 0;

--- a/src/renderer/utils/sort-versions.ts
+++ b/src/renderer/utils/sort-versions.ts
@@ -5,10 +5,10 @@ import { RunnableVersion } from '../../interfaces';
 const preTags = ['nightly', 'alpha', 'beta'];
 
 /**
- * Sorts prerelease tags such that nightly -> alpha -> beta.
+ * Sorts prerelease tags such that nightly -\> alpha -\> beta.
  *
- * @param {Array<string>} a Prerelease tag data for the old version.
- * @param {Array<string>} b Prerelease tag data for the new version.
+ * @param a - Prerelease tag data for the old version.
+ * @param b - Prerelease tag data for the new version.
  * @returns 0 | 1 | -1
  */
 const preCompare = (a: string[], b: string[]) => {
@@ -30,8 +30,8 @@ const preCompare = (a: string[], b: string[]) => {
  *
  * Sorts in ascending order when passed to Array.sort().
  *
- * @param {(string | semver.SemVer)} a The old Electron version.
- * @param {(string | semver.SemVer)} b The new Electron version.
+ * @param a - The old Electron version.
+ * @param b - The new Electron version.
  * @returns 0 | 1 | -1
  */
 export function semverCompare(
@@ -60,9 +60,6 @@ export function semverCompare(
 
 /**
  * Inplace sorting of Versions
- *
- * @param {RunnableVersion[]} versions
- * @returns {RunnableVersion[]}
  */
 export function sortVersions(versions: RunnableVersion[]): RunnableVersion[] {
   type VerSemRun = [

--- a/src/renderer/utils/toggle-monaco.ts
+++ b/src/renderer/utils/toggle-monaco.ts
@@ -1,8 +1,5 @@
 /**
  * Returns the opposite of a Monaco-style boolean.
- *
- * @param {(boolean | string)} input
- * @returns {(boolean | string)}
  */
 export function toggleMonaco(input: boolean | string): boolean | string {
   if (input === 'off') return 'on';

--- a/src/renderer/versions.ts
+++ b/src/renderer/versions.ts
@@ -11,9 +11,6 @@ import {
 
 /**
  * Returns a sensible default version string.
- *
- * @param {Array<RunnableVersion>} versions
- * @returns {string}
  */
 export function getDefaultVersion(versions: RunnableVersion[]): string {
   const key = localStorage.getItem(WindowSpecificSetting.version);
@@ -31,9 +28,6 @@ export function getDefaultVersion(versions: RunnableVersion[]): string {
 /**
  * Return the release channel for a given input
  * version.
- *
- * @param {Version | string} input
- * @returns {ElectronReleaseChannel}
  */
 export function getReleaseChannel(
   input: Version | string,
@@ -68,8 +62,6 @@ export function makeRunnable(ver: Version): RunnableVersion {
 
 /**
  * Return both known as well as local versions.
- *
- * @returns {Array<RunnableVersion>}
  */
 export function getElectronVersions(): Array<RunnableVersion> {
   const versions = [...getReleasedVersions(), ...getLocalVersions()];
@@ -78,9 +70,6 @@ export function getElectronVersions(): Array<RunnableVersion> {
 
 /**
  * Add a version to the local versions
- *
- * @param {Version} input
- * @returns {Array<Version>}
  */
 export function addLocalVersion(input: Version): Array<Version> {
   const versions = getLocalVersions();
@@ -96,9 +85,6 @@ export function addLocalVersion(input: Version): Array<Version> {
 
 /**
  * Get the Version (if any) that is located at localPath.
- *
- * @param {string} folderPath
- * @returns {Version | undefined}
  */
 export function getLocalVersionForPath(
   folderPath: string,
@@ -108,8 +94,6 @@ export function getLocalVersionForPath(
 
 /**
  * Retrieves local Electron versions, configured by the user.
- *
- * @returns {Array<Version>}
  */
 export function getLocalVersions(): Array<Version> {
   const fromLs = window.localStorage.getItem(GlobalSetting.localVersion);
@@ -133,8 +117,6 @@ export function getLocalVersions(): Array<Version> {
 
 /**
  * Saves local versions to localStorage.
- *
- * @param {Array<Version | RunnableVersion>} versions
  */
 export function saveLocalVersions(
   versions: Array<Version | RunnableVersion>,
@@ -173,8 +155,6 @@ function getReleasedVersions(): Array<Version> {
 
 /**
  * Fetch a list of released versions from electronjs.org.
- *
- * @returns {Promise<Version[]>}
  */
 export async function fetchVersions(): Promise<Version[]> {
   const versions = await window.ElectronFiddle.fetchVersions();
@@ -189,9 +169,6 @@ export async function fetchVersions(): Promise<Version[]> {
 
 /**
  * Is the given array an array of versions?
- *
- * @param {Array<any>} input
- * @returns {boolean}
  */
 function isExpectedFormat(input: Array<any>): boolean {
   return input.every((entry) => !!entry.version);
@@ -199,9 +176,6 @@ function isExpectedFormat(input: Array<any>): boolean {
 
 /**
  * Migrates old versions, if necessary
- *
- * @param {Array<any>} input
- * @returns {Array<Version>}
  */
 function migrateVersions(input: Array<any>): Array<Version> {
   return input

--- a/src/utils/gist.ts
+++ b/src/utils/gist.ts
@@ -8,9 +8,6 @@
  *-  https://gist.github.com/8c5fc0c6a5153d49b5a4a56d3ed9da8f/
  *-  https://gist.github.com/ckerr/8c5fc0c6a5153d49b5a4a56d3ed9da8f
  *-  https://gist.github.com/ckerr/8c5fc0c6a5153d49b5a4a56d3ed9da8f/
- *
- * @param {string} rawInput
- * @returns {(string | null)}
  */
 export function getGistId(rawInput: string): string | null {
   const id = rawInput.trim().match(/[0-9A-Fa-f]{32}/);
@@ -20,9 +17,6 @@ export function getGistId(rawInput: string): string | null {
 
 /**
  * Get the id of a gist from a url
- *
- * @param {string} input
- * @returns {(string | null)}
  */
 export function idFromUrl(input: string): string | null {
   return getGistId(input);
@@ -30,9 +24,6 @@ export function idFromUrl(input: string): string | null {
 
 /**
  * Get the url for a gist id
- *
- * @param {string} [input]
- * @returns {string}
  */
 export function urlFromId(input?: string): string {
   return input ? `https://gist.github.com/${input}` : '';

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -97,18 +97,28 @@ export function objectDifference(a: any, b: any): Record<string, unknown> {
   return o;
 }
 
+interface WaitForOptions {
+  /**
+   * polling frequency, in msec
+   * @defaultValue 100
+   */
+  interval: number;
+  /**
+   * timeout interval, in msec
+   * @defaultValue 2000
+   */
+  timeout: number;
+}
+
 /**
  * Waits up to `timeout` msec for a test to pass.
  *
- * @return a promise that returns the test result on success, or rejects on timeout
- * @param {() => any} test - function to test
- * @param {Object} options
- * @param {Number} [options.interval=100] - polling frequency, in msec
- * @param {Number} [options.timeout=2000] - timeout interval, in msec
+ * @param test - function to test
+ * @returns a promise that returns the test result on success, or rejects on timeout
  */
 export async function waitFor(
   test: () => any,
-  options = {
+  options: WaitForOptions = {
     interval: 100,
     timeout: 2000,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,6 +1678,21 @@
   dependencies:
     cross-spawn "^7.0.1"
 
+"@microsoft/tsdoc-config@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz#82605152b3c1d3f5cd4a11697bc298437484d55d"
+  integrity sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==
+  dependencies:
+    "@microsoft/tsdoc" "0.15.0"
+    ajv "~8.12.0"
+    jju "~1.4.0"
+    resolve "~1.22.2"
+
+"@microsoft/tsdoc@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz#f29a55df17cb6e87cfbabce33ff6a14a9f85076d"
+  integrity sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -3011,7 +3026,7 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.8.0, ajv@~8.12.0:
   version "8.12.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -5220,6 +5235,14 @@ eslint-plugin-react@^7.32.2:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
+eslint-plugin-tsdoc@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.3.0.tgz#e4498070355cac2b9f38ea497ba83016bb7eda62"
+  integrity sha512-0MuFdBrrJVBjT/gyhkP2BqpD0np1NxNLfQ38xXDlSs/KVVpKI2A6vN7jx2Rve/CyUsvOsMGwp9KKrinv7q9g3A==
+  dependencies:
+    "@microsoft/tsdoc" "0.15.0"
+    "@microsoft/tsdoc-config" "0.17.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
@@ -5856,6 +5879,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 function.prototype.name@^1.1.2:
   version "1.1.4"
   resolved "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.4.tgz"
@@ -6361,6 +6389,13 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
@@ -6801,6 +6836,13 @@ is-core-module@^2.11.0, is-core-module@^2.5.0:
   integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
   dependencies:
     has "^1.0.3"
+
+is-core-module@^2.13.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.1.tgz#a7363a25bee942fefab0de13bf6aa372c82dcc37"
+  integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
+  dependencies:
+    hasown "^2.0.2"
 
 is-core-module@^2.9.0:
   version "2.11.0"
@@ -7559,6 +7601,11 @@ jest@^29.6.2:
     "@jest/types" "^29.6.1"
     import-local "^3.0.2"
     jest-cli "^29.6.2"
+
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -10378,6 +10425,15 @@ resolve@^2.0.0-next.4:
   integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@~1.22.2:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
Most of the "conversion" here is simply deleting `@param` and `@returns` which are only types, since they're redundant to the TS types, sometimes wrong, and TSDoc doesn't include types for obvious reasons.

`eslint-plugin-tsdoc` is disabled in test files due to usage of `@jest-environment` in some files, and it's unlikely there are going to be TSDoc comments in those files anyway.