### PR TITLE
fix: improve behavior with regard to sync with system theme

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -154,7 +154,7 @@ declare global {
       pathExists(path: string): boolean;
       platform: string;
       pushOutputEntry(entry: OutputEntry): void;
-      readThemeFile(name?: string): Promise<LoadedFiddleTheme | null>;
+      readThemeFile(name: string): Promise<LoadedFiddleTheme | null>;
       reloadWindows(): void;
       removeAllListeners(type: FiddleEvent): void;
       removeVersion(version: string): Promise<InstallState>;

--- a/src/main/themes.ts
+++ b/src/main/themes.ts
@@ -7,7 +7,6 @@ import * as namor from 'namor';
 import { ipcMainManager } from './ipc';
 import { IpcEvents } from '../ipc-events';
 import {
-  DefaultThemes,
   FiddleTheme,
   LoadedFiddleTheme,
   defaultDark,
@@ -21,11 +20,8 @@ export const THEMES_PATH = path.join(CONFIG_PATH, 'themes');
  * Read in a theme file.
  */
 export async function readThemeFile(
-  name?: string,
+  name: string,
 ): Promise<LoadedFiddleTheme | null> {
-  if (!name || name === DefaultThemes.DARK) return defaultDark;
-  if (name === DefaultThemes.LIGHT) return defaultLight;
-
   const file = name.endsWith('.json') ? name : `${name}.json`;
   const themePath = path.join(THEMES_PATH, file);
 
@@ -117,7 +113,7 @@ export async function openThemeFolder() {
 export function setupThemes() {
   ipcMainManager.handle(
     IpcEvents.READ_THEME_FILE,
-    (_: IpcMainEvent, name?: string) => readThemeFile(name),
+    (_: IpcMainEvent, name: string) => readThemeFile(name),
   );
   ipcMainManager.handle(IpcEvents.GET_AVAILABLE_THEMES, (_: IpcMainEvent) =>
     getAvailableThemes(),

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -4,7 +4,7 @@ import { Button, Dialog, FileInput } from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 import * as MonacoType from 'monaco-editor';
 
-import { FiddleTheme, defaultDark } from '../../themes-defaults';
+import { FiddleTheme } from '../../themes-defaults';
 import { AppState } from '../state';
 import { getTheme } from '../themes';
 
@@ -52,9 +52,7 @@ export const AddThemeDialog = observer(
       const { file } = this.state;
       const { appState } = this.props;
 
-      const defaultTheme = !!appState.theme
-        ? await getTheme(appState.theme)
-        : defaultDark;
+      const defaultTheme = await getTheme(appState, appState.theme);
 
       if (!file) return;
 

--- a/src/renderer/components/settings-general-appearance.tsx
+++ b/src/renderer/components/settings-general-appearance.tsx
@@ -13,7 +13,7 @@ import { observer } from 'mobx-react';
 
 import { LoadedFiddleTheme } from '../../themes-defaults';
 import { AppState } from '../state';
-import { getTheme } from '../themes';
+import { getCurrentTheme, getTheme } from '../themes';
 import { highlightText } from '../utils/highlight-text';
 
 const ThemeSelect = Select.ofType<LoadedFiddleTheme>();
@@ -86,7 +86,8 @@ export const AppearanceSettings = observer(
       window.ElectronFiddle.getAvailableThemes().then((themes) => {
         const { theme } = this.props.appState;
         const selectedTheme =
-          (theme && themes.find(({ file }) => file === theme)) || themes[0];
+          (theme && themes.find(({ file }) => file === theme)) ||
+          getCurrentTheme();
 
         this.setState({ themes, selectedTheme });
 
@@ -94,7 +95,10 @@ export const AppearanceSettings = observer(
         reaction(
           () => this.props.appState.theme,
           async () => {
-            const selectedTheme = await getTheme(this.props.appState.theme);
+            const selectedTheme = await getTheme(
+              this.props.appState,
+              this.props.appState.theme,
+            );
             this.setState({ selectedTheme });
           },
         );
@@ -119,7 +123,7 @@ export const AppearanceSettings = observer(
      */
     public async createNewThemeFromCurrent(): Promise<boolean> {
       const { appState } = this.props;
-      const theme = await getTheme(appState.theme);
+      const theme = await getTheme(appState, appState.theme);
 
       try {
         await window.ElectronFiddle.createThemeFile(theme);
@@ -172,8 +176,7 @@ export const AppearanceSettings = observer(
     public render() {
       const { selectedTheme } = this.state;
       const { isUsingSystemTheme } = this.props.appState;
-      const selectedName =
-        (selectedTheme && selectedTheme.name) || 'Select a theme';
+      const selectedName = selectedTheme?.name || 'Select a theme';
 
       return (
         <div className="settings-appearance">

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -2,3 +2,5 @@ export const ELECTRON_ORG = 'electron';
 export const ELECTRON_REPO = 'electron';
 
 export const FIDDLE_GIST_DESCRIPTION_PLACEHOLDER = 'Electron Fiddle Gist';
+
+export const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -737,8 +737,8 @@ export class AppState {
     this.resetView({ isTourShowing: true });
   }
 
-  public setTheme(fileName?: string) {
-    this.theme = fileName || '';
+  public setTheme(fileName: string | null) {
+    this.theme = fileName;
     window.app.loadTheme(this.theme);
   }
 

--- a/tests/main/themes-spec.ts
+++ b/tests/main/themes-spec.ts
@@ -11,7 +11,7 @@ import {
   openThemeFolder,
   readThemeFile,
 } from '../../src/main/themes';
-import { DefaultThemes, LoadedFiddleTheme } from '../../src/themes-defaults';
+import { LoadedFiddleTheme, defaultDark } from '../../src/themes-defaults';
 
 jest.mock('fs-extra');
 
@@ -82,21 +82,6 @@ describe('themes', () => {
   });
 
   describe('readThemeFile()', () => {
-    it('returns the default (light) theme', async () => {
-      const theme = await readThemeFile(DefaultThemes.LIGHT);
-      expect(theme!.name).toBe('Fiddle (Light)');
-    });
-
-    it('returns the default (Dark) theme', async () => {
-      const theme = await readThemeFile(DefaultThemes.DARK);
-      expect(theme!.name).toBe('Fiddle (Dark)');
-    });
-
-    it('returns the default (Dark) theme if no name provided', async () => {
-      const theme = await readThemeFile();
-      expect(theme!.name).toBe('Fiddle (Dark)');
-    });
-
     it('reads the right file if ends with .json', async () => {
       (fs.readJSON as jest.Mock).mockResolvedValueOnce({});
 
@@ -122,12 +107,7 @@ describe('themes', () => {
     let defaultTheme: LoadedFiddleTheme;
 
     beforeEach(async () => {
-      const theme = await readThemeFile();
-      if (theme) {
-        defaultTheme = theme;
-      } else {
-        fail('Error loading default theme');
-      }
+      defaultTheme = defaultDark;
     });
 
     it('filters out file and css keys', async () => {

--- a/tests/renderer/state-spec.ts
+++ b/tests/renderer/state-spec.ts
@@ -500,9 +500,9 @@ describe('AppState', () => {
     });
 
     it('handles a missing theme name', () => {
-      appState.setTheme();
+      appState.setTheme(null);
 
-      expect(appState.theme).toBe('');
+      expect(appState.theme).toBe(null);
       expect(window.app.loadTheme).toHaveBeenCalledTimes(1);
     });
   });

--- a/tests/renderer/themes-spec.tsx
+++ b/tests/renderer/themes-spec.tsx
@@ -4,11 +4,15 @@ import { activateTheme, getTheme } from '../../src/renderer/themes';
 import { LoadedFiddleTheme } from '../../src/themes-defaults';
 
 describe('themes', () => {
+  beforeEach(() => {
+    window.app.state.isUsingSystemTheme = false;
+  });
+
   describe('activateTheme()', () => {
     it('attempts to activate a theme', async () => {
       const { editor } = window.monaco;
 
-      activateTheme(await getTheme());
+      activateTheme(await getTheme(window.app.state, null));
 
       expect(editor.setTheme).toHaveBeenCalled();
       expect(editor.defineTheme).toHaveBeenCalledWith(
@@ -20,13 +24,30 @@ describe('themes', () => {
 
   describe('getTheme()', () => {
     it('returns a default theme', async () => {
-      const theme = await getTheme();
+      const theme = await getTheme(window.app.state, '');
       expect(theme.name).toBe('Fiddle (Dark)');
     });
 
     it('returns a default theme for null', async () => {
-      const theme = await getTheme(null);
+      const theme = await getTheme(window.app.state, null);
       expect(theme.name).toBe('Fiddle (Dark)');
+    });
+
+    it('returns default theme according to system when isUsingSystemTheme', async () => {
+      let theme: LoadedFiddleTheme;
+      window.app.state.isUsingSystemTheme = true;
+
+      mocked(window.matchMedia).mockReturnValueOnce({
+        matches: true,
+      } as MediaQueryList);
+      theme = await getTheme(window.app.state, null);
+      expect(theme.name).toBe('Fiddle (Dark)');
+
+      mocked(window.matchMedia).mockReturnValueOnce({
+        matches: false,
+      } as MediaQueryList);
+      theme = await getTheme(window.app.state, null);
+      expect(theme.name).toBe('Fiddle (Light)');
     });
 
     it('returns a named theme', async () => {
@@ -35,14 +56,14 @@ describe('themes', () => {
         common: { test: true },
       } as unknown as LoadedFiddleTheme);
 
-      const theme = await getTheme('test');
+      const theme = await getTheme(window.app.state, 'test');
       expect(theme.name).toBe('Test');
     });
 
     it('handles a read error', async () => {
       mocked(window.ElectronFiddle.readThemeFile).mockResolvedValue(null);
 
-      const theme = await getTheme('test');
+      const theme = await getTheme(window.app.state, 'test');
       expect(theme.name).toBe('Fiddle (Dark)');
     });
   });


### PR DESCRIPTION
Fixes #1658
Fixes #1657

This fixes a couple of issues, cleans up the relevant code, and improves the UX. See issues above for specifics of what is fixed here.

We had logic distributed in multiple places to fall back to `defaultDark` if no theme was set (like on initial install) so this PR refactors that to be at a higher level and avoids an unnecessary IPC call to the main process on initial install.

Improves UX by retaining the user's selected theme regardless of what state the "Sync theme with system setting" checkbox is in. Previously the theme selection dropdown would snap to whatever the system theme at the time was. Now the theme selection remains static and checking/unchecking the checkbox merely updates the theme to match the system, which is more intuitive than the theme selection changing by itself.