### PR TITLE
build: clear lint warnings regarding test import

### DIFF
--- a/rtl-spec/components/commands-address-bar.spec.tsx
+++ b/rtl-spec/components/commands-address-bar.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { runInAction } from 'mobx';
 
 import { GistActionState } from '../../src/interfaces';

--- a/rtl-spec/components/commands-bisect.spec.tsx
+++ b/rtl-spec/components/commands-bisect.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { mocked } from 'jest-mock';
 
 import { InstallState, VersionSource } from '../../src/interfaces';

--- a/rtl-spec/components/commands-version-chooser.spec.tsx
+++ b/rtl-spec/components/commands-version-chooser.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import { VersionChooser } from '../../src/renderer/components/commands-version-chooser';
 import { AppState } from '../../src/renderer/state';

--- a/rtl-spec/components/editors-non-ideal-state.spec.tsx
+++ b/rtl-spec/components/editors-non-ideal-state.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import { RenderNonIdealState } from '../../src/renderer/components/editors-non-ideal-state';
 import { EditorMosaic } from '../../src/renderer/editor-mosaic';

--- a/rtl-spec/components/editors-toolbar-button.spec.tsx
+++ b/rtl-spec/components/editors-toolbar-button.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { MosaicContext, MosaicWindowContext } from 'react-mosaic-component';
 
 import { EditorId, MAIN_JS } from '../../src/interfaces';

--- a/rtl-spec/components/tour-welcome.spec.tsx
+++ b/rtl-spec/components/tour-welcome.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import {
   WelcomeTour,

--- a/rtl-spec/components/tour.spec.tsx
+++ b/rtl-spec/components/tour.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { mocked } from 'jest-mock';
 
 import { Tour, TourScriptStep } from '../../src/renderer/components/tour';

--- a/rtl-spec/components/version-select.spec.tsx
+++ b/rtl-spec/components/version-select.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { mocked } from 'jest-mock';
 
 import {


### PR DESCRIPTION
Clears these lint warnings on `yarn lint`:

```text
warning  Using exported name 'userEvent' as identifier for default export  import/no-named-as-default
```