### PR TITLE
chore: update to Electron 33.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@vercel/webpack-asset-relocator-loader": "^1.7.2",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
-    "electron": "31.1.0",
+    "electron": "33.3.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.7",
     "enzyme-to-json": "^3.6.1",

--- a/tests/main/protocol-spec.ts
+++ b/tests/main/protocol-spec.ts
@@ -16,6 +16,9 @@ import {
 import { getOrCreateMainWindow, mainIsReady } from '../../src/main/windows';
 import { overridePlatform, resetPlatform } from '../utils';
 
+type OpenUrlCallback = (event: object, url: string) => void;
+type SecondInstanceCallback = (event: object, argv: string[]) => void;
+
 jest.mock('node:fs');
 
 describe('protocol', () => {
@@ -49,7 +52,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[1][1];
+      const handler: SecondInstanceCallback = mocked(app.on).mock.calls[1][1];
 
       handler({}, ['electron-fiddle://gist/hi']);
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -63,7 +66,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/hi');
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -77,7 +80,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://gist/username/gistID');
       expect(ipcMainManager.send).toHaveBeenCalledWith(
@@ -91,7 +94,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://noop');
       handler({}, 'electron-fiddle://gist/noop/noop/null');
@@ -117,7 +120,7 @@ describe('protocol', () => {
 
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://gist/hi-ready');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -138,7 +141,7 @@ describe('protocol', () => {
       // electron-fiddle://electron/{tag}/{path}
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 
@@ -156,7 +159,7 @@ describe('protocol', () => {
     it('handles a flawed electron path url', () => {
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://electron/v4.0.0');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -165,7 +168,7 @@ describe('protocol', () => {
     it('handles a flawed url (unclear instruction)', () => {
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://noop/123');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -174,7 +177,7 @@ describe('protocol', () => {
     it('handles a flawed url (no instruction)', () => {
       listenForProtocolHandler();
 
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
       handler({}, 'electron-fiddle://');
 
       expect(ipcMainManager.send).toHaveBeenCalledTimes(0);
@@ -185,7 +188,7 @@ describe('protocol', () => {
       listenForProtocolHandler();
 
       const mainWindow = await getOrCreateMainWindow();
-      const handler = mocked(app.on).mock.calls[0][1];
+      const handler: OpenUrlCallback = mocked(app.on).mock.calls[0][1];
 
       handler({}, 'electron-fiddle://electron/v4.0.0/test/path');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,9 +1164,9 @@
     vscode-languageserver-textdocument "^1.0.8"
     vscode-uri "^3.0.7"
 
-"@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -5142,10 +5142,10 @@ electron-winstaller@^5.3.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@31.1.0:
-  version "31.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-31.1.0.tgz#2836dbeb8f80c9b278aa4563c8fc3a6e6afbe723"
-  integrity sha512-TBOwqLxSxnx6+pH6GMri7R3JPH2AkuGJHfWZS0p1HsmN+Qr1T9b0IRJnnehSd/3NZAmAre4ft9Ljec7zjyKFJA==
+electron@33.3.0:
+  version "33.3.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-33.3.0.tgz#5ae603818820c2a29736ed924d32bf18d31a9f63"
+  integrity sha512-316ZlFUHJmzGrhRj87tVStxyYvknDqVR9eYSsGKAHY7auhVWFLIcPPGxcnbD/H1mez8CpDjXvEjcz76zpWxsXw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Required fixing the types in a test, I believe due to the change upstream in https://github.com/electron/typescript-definitions/pull/273. Since `app.on` is overloaded, TypeScript ends up choosing the last signature, which used to be `Function` before that change (fully permissive when invoking), after which it became `() => void`. Unfortunately it appears there's no way to extract the callback signature of just the events we want, so I manually rolled the types to get this building cleanly again.

> [When inferring from a type with multiple call signatures (such as the type of an overloaded function), inferences are made from the _last_ signature (which, presumably, is the most permissive catch-all case). It is not possible to perform overload resolution based on a list of argument types.](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#inferring-within-conditional-types)