### PR TITLE
ci: use large resource class for Linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
         type: enum
         enum: [ 'x64', 'arm64','armv7l' ]
     executor: node/linux
-    resource_class: medium+
+    resource_class: large
     steps:
       - run: sudo apt-get update && sudo apt install rpm squashfs-tools
       - install


### PR DESCRIPTION
It's the return of #1463. Kicking the can again instead of finding a proper solution.