### PR TITLE
fix: Replace deprecated Tooltip and Popover components with Tooltip2 …

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -6,10 +6,10 @@ import {
   IToastProps,
   Menu,
   MenuItem,
-  Popover,
   Position,
   Toaster,
 } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
 import { when } from 'mobx';
 import { observer } from 'mobx-react';
 
@@ -396,9 +396,9 @@ export const GistActionButton = observer(
       );
 
       return (
-        <Popover content={menu} position={Position.BOTTOM}>
+        <Popover2 content={menu} position={Position.BOTTOM}>
           <Button icon="wrench" />
-        </Popover>
+        </Popover2>
       );
     };
 
@@ -429,9 +429,9 @@ export const GistActionButton = observer(
       );
 
       return (
-        <Popover content={privacyMenu} position={Position.BOTTOM}>
+        <Popover2 content={privacyMenu} position={Position.BOTTOM}>
           <Button icon={privacyIcon} />
-        </Popover>
+        </Popover2>
       );
     };
 

--- a/src/renderer/components/settings-electron.tsx
+++ b/src/renderer/components/settings-electron.tsx
@@ -12,8 +12,8 @@ import {
   Icon,
   IconName,
   Spinner,
-  Tooltip,
 } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { observer } from 'mobx-react';
 
 import {
@@ -238,7 +238,7 @@ export const ElectronSettings = observer(
       return (
         <FormGroup label="Channels:">
           {Object.values(channels).map((channel) => (
-            <Tooltip
+            <Tooltip2
               content={`Can't disable channel of selected version (${appState.version})`}
               disabled={!getIsCurrentVersionReleaseChannel(channel)}
               position="bottom"
@@ -253,9 +253,9 @@ export const ElectronSettings = observer(
                 disabled={getIsCurrentVersionReleaseChannel(channel)}
                 inline={true}
               />
-            </Tooltip>
+            </Tooltip2>
           ))}
-          <Tooltip
+          <Tooltip2
             content={`Include versions that have reached end-of-life (older than ${window.ElectronFiddle.getOldestSupportedMajor()}.0.0)`}
             position="bottom"
             intent="primary"
@@ -267,7 +267,7 @@ export const ElectronSettings = observer(
               label="Obsolete"
               onChange={this.handleShowObsoleteChange}
             />
-          </Tooltip>
+          </Tooltip2>
         </FormGroup>
       );
     }
@@ -371,7 +371,7 @@ export const ElectronSettings = observer(
 
       if (version === appState.currentElectronVersion.version) {
         return (
-          <Tooltip
+          <Tooltip2
             position="auto"
             intent="primary"
             content={`Can't remove currently active Electron version (${version})`}
@@ -382,11 +382,11 @@ export const ElectronSettings = observer(
               text={buttonProps.text}
               icon={buttonProps.icon}
             />
-          </Tooltip>
+          </Tooltip2>
         );
       } else if (disableDownload(version)) {
         return (
-          <Tooltip
+          <Tooltip2
             position="auto"
             intent="primary"
             content={`Version is not available on your current OS`}
@@ -397,7 +397,7 @@ export const ElectronSettings = observer(
               text={buttonProps.text}
               icon={buttonProps.icon}
             />
-          </Tooltip>
+          </Tooltip2>
         );
       }
 

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -8,8 +8,8 @@ import {
   Intent,
   Menu,
   MenuItem,
-  Tooltip,
 } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import {
   ItemListPredicate,
   ItemListRenderer,
@@ -178,7 +178,7 @@ export const renderItem: ItemRenderer<RunnableVersion> = (
 
   if (disableDownload(item.version)) {
     return (
-      <Tooltip
+      <Tooltip2
         className="disabled-menu-tooltip"
         modifiers={{
           flip: { enabled: false },
@@ -197,7 +197,7 @@ export const renderItem: ItemRenderer<RunnableVersion> = (
           label={getItemLabel(item)}
           icon={getItemIcon(item)}
         />
-      </Tooltip>
+      </Tooltip2>
     );
   }
 

--- a/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-electron-spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`ElectronSettings component renders 1`] = `
     <Blueprint3.FormGroup
       label="Channels:"
     >
-      <Blueprint3.Tooltip
+      <Blueprint3.Tooltip2
         content="Can't disable channel of selected version (2.0.1)"
         disabled={false}
         hoverCloseDelay={0}
@@ -30,8 +30,8 @@ exports[`ElectronSettings component renders 1`] = `
           label="Stable"
           onChange={[Function]}
         />
-      </Blueprint3.Tooltip>
-      <Blueprint3.Tooltip
+      </Blueprint3.Tooltip2>
+      <Blueprint3.Tooltip2
         content="Can't disable channel of selected version (2.0.1)"
         disabled={true}
         hoverCloseDelay={0}
@@ -50,8 +50,8 @@ exports[`ElectronSettings component renders 1`] = `
           label="Beta"
           onChange={[Function]}
         />
-      </Blueprint3.Tooltip>
-      <Blueprint3.Tooltip
+      </Blueprint3.Tooltip2>
+      <Blueprint3.Tooltip2
         content="Can't disable channel of selected version (2.0.1)"
         disabled={true}
         hoverCloseDelay={0}
@@ -70,8 +70,8 @@ exports[`ElectronSettings component renders 1`] = `
           label="Nightly"
           onChange={[Function]}
         />
-      </Blueprint3.Tooltip>
-      <Blueprint3.Tooltip
+      </Blueprint3.Tooltip2>
+      <Blueprint3.Tooltip2
         content="Include versions that have reached end-of-life (older than 9.0.0)"
         hoverCloseDelay={0}
         hoverOpenDelay={100}
@@ -87,7 +87,7 @@ exports[`ElectronSettings component renders 1`] = `
           label="Obsolete"
           onChange={[Function]}
         />
-      </Blueprint3.Tooltip>
+      </Blueprint3.Tooltip2>
     </Blueprint3.FormGroup>
   </Blueprint3.Callout>
   <br />
@@ -281,7 +281,7 @@ exports[`ElectronSettings component renders 1`] = `
           <td
             className="action"
           >
-            <Blueprint3.Tooltip
+            <Blueprint3.Tooltip2
               content="Can't remove currently active Electron version (2.0.1)"
               hoverCloseDelay={0}
               hoverOpenDelay={100}
@@ -296,7 +296,7 @@ exports[`ElectronSettings component renders 1`] = `
                 icon="cloud-download"
                 text="Download"
               />
-            </Blueprint3.Tooltip>
+            </Blueprint3.Tooltip2>
           </td>
         </tr>
         <tr


### PR DESCRIPTION
# Closes #1095 

## fix: Replace deprecated Tooltip and Popover components with Tooltip2

- Replaced the `Popover` component in the `src/renderer/components/commands-action-button.tsx`to `Popover2` and
- `Tooltip` components in the `src/renderer/components/settings-electron.tsx` & `src/renderer/components/version-select.tsx` to `Tooltip2`.