### PR TITLE
chore: Add WebContentsView API example

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -29,6 +29,7 @@ export const SHOW_ME_TEMPLATES: Templates = {
     Tray: 'Tray',
     utilityProcess: 'utilityProcess',
     WebContents: 'WebContents',
+    WebContentsView: 'WebContentsView',
     WebFrame: 'WebFrame',
   },
 };

--- a/static/show-me/webcontentsview/main.js
+++ b/static/show-me/webcontentsview/main.js
@@ -1,0 +1,21 @@
+// A View that displays a WebContents.
+//
+// For more info, see:
+// https://electronjs.org/docs/api/web-contents-view
+
+// In the main process.
+const { app, BaseWindow, WebContentsView } = require('electron')
+
+app.whenReady().then(() => {
+  const win = new BaseWindow({ width: 800, height: 400 })
+
+  const view1 = new WebContentsView()
+  win.contentView.addChildView(view1)
+  view1.setBounds({ x: 0, y: 0, width: 400, height: 400 })
+  view1.webContents.loadURL('https://www.electronjs.org')
+
+  const view2 = new WebContentsView()
+  win.contentView.addChildView(view2)
+  view2.setBounds({ x: 400, y: 0, width: 400, height: 400 })
+  view2.webContents.loadURL('https://www.electronjs.org/fiddle')
+})


### PR DESCRIPTION
Related #1648 

- Add `WebContentsView` API example to show-me examples.

![image](https://github.com/user-attachments/assets/9ebf2f6c-5367-4532-8380-c3a165f566ae)
![image](https://github.com/user-attachments/assets/07e1dfa5-dc77-4885-875c-9e2db36c5b8d)


