### PR TITLE
feat: Add Keyboard shortcut to Clear Console

### DIFF
--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -91,6 +91,23 @@ export const Output = observer(
             openerService: this.openerService(),
           },
         );
+        if (this.editor) {
+          // Register Command (⌘) + K to clear the console on MacOs,
+          // Ctrl + K on other systems, such as Windows and Linux
+          this.editor.addCommand(
+            MonacoType.KeyMod.CtrlCmd | MonacoType.KeyCode.KEY_K,
+            () => {
+              if (this.model || this.props.appState.output.length > 0) {
+                this.props.appState.clearConsole();
+                this.outputRef.current?.scrollTo(0, 0);
+                this.props.appState.output.push({
+                  timeString: new Date().toLocaleTimeString(),
+                  text: '',
+                });
+              }
+            },
+          );
+        }
       }
     }
 


### PR DESCRIPTION
### Closes #1557 

- Add Keyboard shortcut to clear the console on pressing the Command (⌘) + k option on MacOS.


## Preview:

https://github.com/user-attachments/assets/04f65036-6788-447d-86ca-5575f621f7fb


