### PR TITLE
fix: include user data directory in show me

### DIFF
--- a/src/renderer/components/tour-welcome.tsx
+++ b/src/renderer/components/tour-welcome.tsx
@@ -60,7 +60,17 @@ export function getWelcomeTour(): Set<TourScriptStep> {
       name: 'button-run',
       selector: '#button-run',
       title: '🚀 Run Your Fiddle',
-      content: <p>Hit this button to give your Fiddle a try and start it.</p>,
+      content: (
+        <>
+          <p>Hit this button to give your Fiddle a try and start it.</p>
+          <p>
+            When your Fiddle starts, it will create a user data directory for
+            cookies, the cache, and a few other things. We delete this directory
+            by default when you exit the Fiddle, but you can change this in
+            Settings.
+          </p>
+        </>
+      ),
     },
     {
       name: 'button-action',


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1575.


<img width="1512" alt="Screenshot 2025-01-29 at 4 01 13 PM" src="https://github.com/user-attachments/assets/06f2a3ca-1d93-4d23-b7d0-2ab0ca866a10" />

