### PR TITLE
feat: add keyboard shortcut (ctrl/cmd-k) to clear console

### DIFF
--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -91,6 +91,13 @@ export const Output = observer(
             openerService: this.openerService(),
           },
         );
+
+        this.editor.addCommand(
+          monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_K,
+          () => {
+            this.props.appState.clearConsole();
+          },
+        );
       }
     }
 

--- a/src/renderer/components/output.tsx
+++ b/src/renderer/components/output.tsx
@@ -96,6 +96,10 @@ export const Output = observer(
           monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_K,
           () => {
             this.props.appState.clearConsole();
+            this.props.appState.output.push({
+              timeString: new Date().toLocaleTimeString(),
+              text: '',
+            });
           },
         );
       }

--- a/tests/mocks/monaco.ts
+++ b/tests/mocks/monaco.ts
@@ -44,6 +44,12 @@ export class MonacoMock {
       },
     },
   };
+  public KeyMod = {
+    CtrlCmd: jest.fn(),
+  };
+  public KeyCode = {
+    KEY_K: jest.fn(),
+  };
 }
 
 export class MonacoEditorMock {
@@ -55,6 +61,7 @@ export class MonacoEditorMock {
   private model = new MonacoModelMock('', 'javascript');
   private scrollHeight = 0;
 
+  public addCommand = jest.fn();
   public dispose = jest.fn();
   public getAction = jest.fn(() => this.action);
   public getModel = jest.fn(() => this.model);


### PR DESCRIPTION
Fixes #1557 

Add CTRL/CMD+k keyboard shortcut to clear the console.