### PR TITLE
fix: inconsistent outline color on focus when navigating using tab key

### DIFF
--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -6,6 +6,10 @@
 
 // Override some of the colors
 .fiddle.bp3-dark {
+  .bp3-control input:focus ~ .bp3-control-indicator {
+    outline: @blue3 solid 2px;
+  }
+
   .bp3-menu,
   .bp3-popover .bp3-popover-content {
     background-color: @background-1;
@@ -26,6 +30,10 @@
   .bp3-button:hover,
   .bp3-button.bp3-minimal:hover {
     background-color: rgba(138, 155, 168, 0.15);
+  }
+
+  .bp3-button:focus{
+    outline: @blue3 solid 2px;
   }
 
   .bp3-menu-item.bp3-active.bp3-intent-primary {


### PR DESCRIPTION
Fix #1085  by ensuring consistent focus outlines for input fields and buttons in dark mode.
Previously, input fields and buttons had inconsistent focus outlines, leading to a poor user experience.

**All elements are focused in the images below:**
### Before:  
![before1](https://github.com/user-attachments/assets/e5d85f49-f487-4c99-8edd-b9d7b409becf)

### After:
![after1](https://github.com/user-attachments/assets/2d51b500-e235-488b-884d-ea8d5a049f80)

### Before:
![before2](https://github.com/user-attachments/assets/ac52e517-d8f0-4226-8130-8c127705a7ea)

### After: 
![after2](https://github.com/user-attachments/assets/34711d50-2867-4f03-88f4-e95d654fbb67)

### Changes
Added `outline: @blue3 solid 2px;` to following classes in dark mode:

_.bp3-control input:focus ~ .bp3-control-indicator_

 _.bp3-button:focus_