### PR TITLE
feat: add run from ASAR button

### DIFF
--- a/src/renderer/components/commands-runner.tsx
+++ b/src/renderer/components/commands-runner.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-import { Button, ButtonProps, Spinner } from '@blueprintjs/core';
+import { Button, ButtonGroup, ButtonProps, Spinner } from '@blueprintjs/core';
+import { Popover2 } from '@blueprintjs/popover2';
 import { observer } from 'mobx-react';
 
 import { InstallState, VersionSource } from '../../interfaces';
@@ -16,6 +17,30 @@ interface RunnerProps {
  */
 export const Runner = observer(
   class Runner extends React.Component<RunnerProps> {
+    private renderAsarButton = (disabled: boolean) => {
+      const asarButton = (
+        <Button
+          text="Run from ASAR"
+          icon="play"
+          disabled={disabled}
+          small
+          onClick={() => {
+            window.app.runner.run({ runFromAsar: true });
+          }}
+        />
+      );
+
+      return (
+        <Popover2 fill={true} content={asarButton} placement="bottom">
+          <Button
+            icon="caret-down"
+            style={{ minWidth: 20 }}
+            disabled={disabled}
+          />
+        </Popover2>
+      );
+    };
+
     public render() {
       const { downloaded, downloading, missing, installing, installed } =
         InstallState;
@@ -59,7 +84,9 @@ export const Runner = observer(
             props.icon = <Spinner size={16} />;
           } else {
             props.text = 'Run';
-            props.onClick = window.app.runner.run;
+            props.onClick = () => {
+              window.app.runner.run({ runFromAsar: false });
+            };
             props.icon = 'play';
           }
           break;
@@ -76,8 +103,15 @@ export const Runner = observer(
           props.icon = <Spinner size={16} />;
         }
       }
+      const isAsarDisabled: boolean =
+        props.disabled || isRunning || isInstallingModules;
 
-      return <Button id="button-run" {...props} type={undefined} />;
+      return (
+        <ButtonGroup>
+          <Button id="button-run" {...props} type={undefined} />
+          {this.renderAsarButton(isAsarDisabled)}
+        </ButtonGroup>
+      );
     }
   },
 );

--- a/src/renderer/components/commands.tsx
+++ b/src/renderer/components/commands.tsx
@@ -55,6 +55,8 @@ export const Commands = observer(
             </ControlGroup>
             <ControlGroup fill={true} vertical={false}>
               <VersionChooser appState={appState} />
+            </ControlGroup>
+            <ControlGroup fill={true} vertical={false}>
               <Runner appState={appState} />
             </ControlGroup>
             {isBisectCommandShowing && (

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -20,11 +20,16 @@ export enum ForgeCommands {
   MAKE = 'make',
 }
 
+interface runOptions {
+  runFromAsar: boolean;
+}
+
 interface RunFiddleParams {
   localPath: string | undefined;
   isValidBuild: boolean; // If the localPath is a valid Electron build
   version: string; // The user selected version
   dir: string;
+  runFromAsar: boolean;
 }
 
 const resultString: Record<RunResult, string> = Object.freeze({
@@ -139,8 +144,9 @@ export class Runner {
   /**
    * Actually run the fiddle.
    */
-  public async run(): Promise<RunResult> {
+  public async run(runOptions?: runOptions): Promise<RunResult> {
     const options = { includeDependencies: false, includeElectron: false };
+    const runFromAsar = runOptions?.runFromAsar ?? false;
 
     const { appState } = this;
     const currentRunnable = appState.currentElectronVersion;
@@ -220,6 +226,7 @@ export class Runner {
       isValidBuild,
       dir,
       version,
+      runFromAsar,
     });
   }
 
@@ -362,12 +369,15 @@ export class Runner {
    * or the user selected electron version
    */
   private async runFiddle(params: RunFiddleParams): Promise<RunResult> {
-    const { version, dir } = params;
+    const { version, dir, runFromAsar } = params;
     const { pushOutput, flushOutput, executionFlags } = this.appState;
     const env = this.buildChildEnvVars();
 
     // Add user-specified cli flags if any have been set.
     const options = [dir, '--inspect'].concat(executionFlags);
+    if (runFromAsar) {
+      options.push('runFromAsar');
+    }
 
     const cleanup = async () => {
       flushOutput();

--- a/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-runner-spec.tsx.snap
@@ -1,85 +1,372 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Runner component renders InstallState.downloading 1`] = `
-<Blueprint3.Button
-  disabled={true}
-  icon={
-    <Blueprint3.Spinner
-      size={16}
-      value={50}
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={true}
+    icon={
+      <Blueprint3.Spinner
+        size={16}
+        value={50}
+      />
+    }
+    id="button-run"
+    text="Downloading"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={true}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
     />
-  }
-  id="button-run"
-  text="Downloading"
-/>
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders InstallState.installed 1`] = `
-<Blueprint3.Button
-  disabled={false}
-  icon="play"
-  id="button-run"
-  onClick={[MockFunction]}
-  text="Run"
-/>
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={false}
+    icon="play"
+    id="button-run"
+    onClick={[Function]}
+    text="Run"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={false}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={false}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
+    />
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders InstallState.installing 1`] = `
-<Blueprint3.Button
-  disabled={true}
-  icon={
-    <Blueprint3.Spinner
-      size={16}
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={true}
+    icon={
+      <Blueprint3.Spinner
+        size={16}
+      />
+    }
+    id="button-run"
+    text="Unzipping"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={true}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
     />
-  }
-  id="button-run"
-  text="Unzipping"
-/>
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders InstallState.missing 1`] = `
-<Blueprint3.Button
-  disabled={true}
-  icon={
-    <Blueprint3.Spinner
-      size={16}
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={true}
+    icon={
+      <Blueprint3.Spinner
+        size={16}
+      />
+    }
+    id="button-run"
+    text="Checking status"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={true}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
     />
-  }
-  id="button-run"
-  text="Checking status"
-/>
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders idle 1`] = `
-<Blueprint3.Button
-  disabled={false}
-  icon="play"
-  id="button-run"
-  onClick={[MockFunction]}
-  text="Run"
-/>
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={false}
+    icon="play"
+    id="button-run"
+    onClick={[Function]}
+    text="Run"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={false}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={false}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
+    />
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders installing modules 1`] = `
-<Blueprint3.Button
-  disabled={false}
-  icon={
-    <Blueprint3.Spinner
-      size={16}
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    disabled={false}
+    icon={
+      <Blueprint3.Spinner
+        size={16}
+      />
+    }
+    id="button-run"
+    text="Installing modules"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={true}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
     />
-  }
-  id="button-run"
-  text="Installing modules"
-/>
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;
 
 exports[`Runner component renders running 1`] = `
-<Blueprint3.Button
-  active={true}
-  disabled={false}
-  icon="stop"
-  id="button-run"
-  onClick={[MockFunction]}
-  text="Stop"
-/>
+<Blueprint3.ButtonGroup>
+  <Blueprint3.Button
+    active={true}
+    disabled={false}
+    icon="stop"
+    id="button-run"
+    onClick={[MockFunction]}
+    text="Stop"
+  />
+  <Blueprint3.Popover2
+    boundary="clippingParents"
+    captureDismiss={false}
+    content={
+      <Blueprint3.Button
+        disabled={true}
+        icon="play"
+        onClick={[Function]}
+        small={true}
+        text="Run from ASAR"
+      />
+    }
+    defaultIsOpen={false}
+    disabled={false}
+    fill={true}
+    hasBackdrop={false}
+    hoverCloseDelay={300}
+    hoverOpenDelay={150}
+    inheritDarkTheme={true}
+    interactionKind="click"
+    minimal={false}
+    openOnTargetFocus={true}
+    placement="bottom"
+    positioningStrategy="absolute"
+    shouldReturnFocusOnClose={false}
+    targetTagName="span"
+    transitionDuration={300}
+    usePortal={true}
+  >
+    <Blueprint3.Button
+      disabled={true}
+      icon="caret-down"
+      style={
+        {
+          "minWidth": 20,
+        }
+      }
+    />
+  </Blueprint3.Popover2>
+</Blueprint3.ButtonGroup>
 `;

--- a/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/commands-spec.tsx.snap
@@ -23,6 +23,11 @@ exports[`Commands component renders when system is darwin 1`] = `
       <version-chooser
         appState={"default StateMock"}
       />
+    </Blueprint3.ControlGroup>
+    <Blueprint3.ControlGroup
+      fill={true}
+      vertical={false}
+    >
       <runner
         appState={"default StateMock"}
       />
@@ -77,6 +82,11 @@ exports[`Commands component renders when system not is darwin 1`] = `
       <version-chooser
         appState={"default StateMock"}
       />
+    </Blueprint3.ControlGroup>
+    <Blueprint3.ControlGroup
+      fill={true}
+      vertical={false}
+    >
       <runner
         appState={"default StateMock"}
       />


### PR DESCRIPTION
- Adds a dropdown to the right of the "Run" button, featuring a new button labeled "Run from ASAR"
- Introduces a new optional parameter `runOptions` in `Runner.run() method`.
- The `runOptions` parameter is defined as follows:
```
interface runOptions {
  runFromAsar: boolean;
}
```
- Updates test snapshots to reflect the new UI changes.

### Updated UI screenshots:
![Screenshot from 2025-03-20 23-48-01](https://github.com/user-attachments/assets/b0bca2fd-7bfc-47c2-8fa4-b4ec3c399f42)
![Screenshot from 2025-03-20 23-48-16](https://github.com/user-attachments/assets/0194b2cd-6190-4ed7-8536-2ecdaf8e0a99)

Closes #1551 

**This functionality requires an upstream change in `@electron/fiddle-core`.** 
- Issue: [fiddle-core/issues/100](https://github.com/electron/fiddle-core/issues/100)

I have already opened a PR to implement the required updates in fiddle-core:
- PR: [fiddle-core/pull/138](https://github.com/electron/fiddle-core/pull/138)

Please review both the PR's and let me know if any changes are needed.
