### PR TITLE
fix: some regressions in tooltip styling

### DIFF
--- a/src/less/blueprint.less
+++ b/src/less/blueprint.less
@@ -11,11 +11,11 @@
   }
 
   .bp3-menu,
-  .bp3-popover .bp3-popover-content {
+  .bp3-popover .bp3-popover-content, .bp3-popover2 .bp3-popover2-content {
     background-color: @background-1;
   }
 
-  .bp3-popover .bp3-popover-arrow-fill {
+  .bp3-popover .bp3-popover-arrow-fill, .bp3-popover2 .bp3-popover2-arrow-fill {
     fill: @background-1;
   }
 

--- a/src/less/components/commands.less
+++ b/src/less/components/commands.less
@@ -43,13 +43,8 @@ header {
   padding-right: 116px !important;
 }
 
-.disabled-menu-tooltip {
-  display: flex;
+.disabled-menu-tooltip.bp3-popover-target, .disabled-menu-tooltip.bp3-popover2-target {
   width: 100%;
-
-  .bp3-popover-target {
-    width: 100%;
-  }
 }
 
 .commands.is-mac {

--- a/src/less/components/settings.less
+++ b/src/less/components/settings.less
@@ -91,8 +91,8 @@
       }
     }
 
-    .bp3-popover-target {
-      display: inherit;
+    .bp3-popover-target, .bp3-popover2-target {
+      display: inline;
     }
 
     .disabled-version {

--- a/src/renderer/components/version-select.tsx
+++ b/src/renderer/components/version-select.tsx
@@ -185,6 +185,7 @@ export const renderItem: ItemRenderer<RunnableVersion> = (
           preventOverflow: { enabled: false },
           hide: { enabled: false },
         }}
+        position="bottom"
         intent={Intent.PRIMARY}
         content={`Version is not available on current OS`}
       >


### PR DESCRIPTION
Fixes some regressions introduced in #1667 which we didn't catch. I made the CSS changes target both `.bp3-popover2-*` and `.bp3-popover-*` since the `.bp3-popover2-*` name will go away again when we finally upgrade Blueprint.