### PR TITLE
feat: allow packaging a local electron version

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,10 @@ export type {
 
 export type Files = Map<string, string>;
 
-export type FileTransform = (files: Files) => Promise<Files>;
+export type FileTransform = (
+  files: Files,
+  version: RunnableVersion,
+) => Promise<Files>;
 
 export type FileTransformOperation = 'dotfiles' | 'forge';
 

--- a/src/renderer/file-manager.ts
+++ b/src/renderer/file-manager.ts
@@ -142,7 +142,7 @@ export class FileManager {
     )) {
       try {
         console.log(`getFiles: Applying ${transform.name}`);
-        output = await transform(output);
+        output = await transform(output, app.state.currentElectronVersion);
       } catch (error) {
         console.warn(`getFiles: Failed to apply transform`, {
           transform,

--- a/src/renderer/transforms/forge.ts
+++ b/src/renderer/transforms/forge.ts
@@ -1,11 +1,14 @@
-import { Files, PACKAGE_NAME } from '../../interfaces';
+import { Files, PACKAGE_NAME, RunnableVersion } from '../../interfaces';
 import { getForgeVersion } from '../utils/get-package';
 
 /**
  * This transform turns the files into an electron-forge
  * project.
  */
-export async function forgeTransform(files: Files): Promise<Files> {
+export async function forgeTransform(
+  files: Files,
+  version?: RunnableVersion,
+): Promise<Files> {
   if (files.get(PACKAGE_NAME)) {
     try {
       const parsed = JSON.parse(files.get(PACKAGE_NAME)!);
@@ -45,6 +48,26 @@ export async function forgeTransform(files: Files): Promise<Files> {
         config.forge.electronRebuildConfig = {
           forceABI: parseInt(modules.toString().trim()),
         };
+      }
+
+      // Package local version if available.
+      if (version?.localPath) {
+        devDependencies['@electron-forge/plugin-local-electron'] = forgeVersion;
+        config.forge.plugins = [
+          {
+            name: '@electron-forge/plugin-local-electron',
+            config: {
+              electronPath: version.localPath,
+            },
+          },
+        ];
+
+        // Replace electron dep in package.json with a legitimate
+        // released version so it doesn't error on npm install.
+        if (parsed.devDependencies.electron) {
+          const latest = await window.ElectronFiddle.getLatestStable();
+          parsed.devDependencies.electron = latest?.version;
+        }
       }
 
       // electron-forge makers


### PR DESCRIPTION
Allow packaging an app using forge with a local build of Electron using `@electron-forge/plugin-local-electron`.