### PR TITLE
chore(deps): update Electron to v36.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@vercel/webpack-asset-relocator-loader": "^1.7.2",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
-    "electron": "33.3.0",
+    "electron": "36.5.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.7",
     "enzyme-to-json": "^3.6.1",

--- a/src/renderer/components/dialog-add-theme.tsx
+++ b/src/renderer/components/dialog-add-theme.tsx
@@ -40,9 +40,10 @@ export const AddThemeDialog = observer(
      */
     public async onChangeFile(event: React.FormEvent<HTMLInputElement>) {
       const { files } = event.target as HTMLInputElement;
-      const file = files?.[0];
 
-      this.setState({ file });
+      this.setState({
+        file: files?.[0],
+      });
     }
 
     /**
@@ -120,7 +121,7 @@ export const AddThemeDialog = observer(
       const inputProps = { accept: '.json' };
       const { file } = this.state;
 
-      const text = file && file.path ? file.path : `Select the Monaco file...`;
+      const text = file ? file.name : `Select the Monaco file...`;
       return (
         <Dialog
           isOpen={isThemeDialogShowing}

--- a/tests/renderer/components/__snapshots__/dialog-add-theme-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/dialog-add-theme-spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`AddThemeDialog component renders 1`] = `
         }
       }
       onInputChange={[Function]}
-      text="Select the Monaco file..."
+      text="Choose file..."
     />
     <br />
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,12 +2930,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.9.0":
-  version "20.11.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.20.tgz#f0a2aee575215149a62784210ad88b3a34843659"
-  integrity sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==
+"@types/node@^22.7.7":
+  version "22.15.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.33.tgz#5722ba32042fd547c113bc35ea92c1cc59ef68b1"
+  integrity sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -5221,13 +5221,13 @@ electron-winstaller@^5.3.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@33.3.0:
-  version "33.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-33.3.0.tgz#5ae603818820c2a29736ed924d32bf18d31a9f63"
-  integrity sha512-316ZlFUHJmzGrhRj87tVStxyYvknDqVR9eYSsGKAHY7auhVWFLIcPPGxcnbD/H1mez8CpDjXvEjcz76zpWxsXw==
+electron@36.5.0:
+  version "36.5.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-36.5.0.tgz#5cb2cc1c6b440a26fa97cb7792231ea920176317"
+  integrity sha512-ouVtHbHDFsRBHPGx9G6RDm4ccPaSCmrrR8tbUGZuqbJhqIClVBkVMz94Spjihag2Zo1eHtYD+KevALrc/94g1g==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^20.9.0"
+    "@types/node" "^22.7.7"
     extract-zip "^2.0.1"
 
 emittery@^0.13.1:
@@ -12356,6 +12356,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicorn-magic@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
As in title.

Remove usage of `file.path` - it's not particularly important to how custom theming works anyway.