### PR TITLE
fix: sidebar panel button sticking

### DIFF
--- a/src/renderer/components/sidebar-file-tree.tsx
+++ b/src/renderer/components/sidebar-file-tree.tsx
@@ -135,7 +135,7 @@ export const SidebarFileTree = observer(
           isExpanded: true,
           label: 'Editors',
           secondaryLabel: (
-            <ButtonGroup minimal>
+            <ButtonGroup minimal style={{ display: 'flex', gap: 4 }}>
               <Tooltip2
                 content="Add New File"
                 minimal={true}

--- a/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/sidebar-file-tree-spec.tsx.snap
@@ -305,6 +305,12 @@ exports[`SidebarFileTree component > can bring up the Add File input 1`] = `
           "label": "Editors",
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
+            style={
+              {
+                "display": "flex",
+                "gap": 4,
+              }
+            }
           >
             <Blueprint3.Tooltip2
               content="Add New File"
@@ -627,6 +633,12 @@ exports[`SidebarFileTree component > reflects the visibility state of all icons 
           "label": "Editors",
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
+            style={
+              {
+                "display": "flex",
+                "gap": 4,
+              }
+            }
           >
             <Blueprint3.Tooltip2
               content="Add New File"
@@ -949,6 +961,12 @@ exports[`SidebarFileTree component > renders 1`] = `
           "label": "Editors",
           "secondaryLabel": <Blueprint3.ButtonGroup
             minimal={true}
+            style={
+              {
+                "display": "flex",
+                "gap": 4,
+              }
+            }
           >
             <Blueprint3.Tooltip2
               content="Add New File"


### PR DESCRIPTION
This PR resolves a minor UI issue where the buttons in the sidebar panel lack spacing and appear merged, which is particularly noticeable in dark mode.

Before:
<img width="345" height="323" alt="image" src="https://github.com/user-attachments/assets/8a2ff23e-c12d-4f1a-be24-6541531a1304" />

After:
<img width="340" height="320" alt="image" src="https://github.com/user-attachments/assets/c96d8c89-a5f4-4b42-a1a8-5d8b167ae20b" />
