### PR TITLE
build: fix yarn:ci to show failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "electron-forge publish",
     "start": "ts-node ./tools/clean-webpack.ts && electron-forge start --",
     "test": "vitest run",
-    "test:ci": "vitest run --coverage --reporter=junit --outputFile=./reports/report.xml",
+    "test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=./reports/report.xml",
     "test:report": "vitest run --reporter=json --outputFile=report.json | true",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "node --unhandled-rejections=strict -r ts-node/register ./tools/fetch-releases.ts",


### PR DESCRIPTION
As of https://github.com/electron/fiddle/issues/1718 test failures don't show up due to redirection to output file:

<img width="720" height="384" alt="screenshot_2025-07-22_at_9 55 03___am_720" src="https://github.com/user-attachments/assets/30119879-9322-4f0b-9549-558d57ae1f6f" />

it's important that CI shows actual test failures, so this tweaks that to both show the failures in CI and also generate a report.