### PR TITLE
feat: add support to update github gist token without sign out

### DIFF
--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -15,6 +15,7 @@ interface TokenDialogState {
   verifying: boolean;
   error: boolean;
   errorMessage?: string;
+  isTokenUpdateAction?: boolean;
 }
 
 const TOKEN_SCOPES = ['gist'].join();
@@ -40,6 +41,7 @@ export const TokenDialog = observer(
         error: false,
         errorMessage: undefined,
         tokenInput: '',
+        isTokenUpdateAction: props.appState.gitHubToken !== '',
       };
 
       this.onSubmitToken = this.onSubmitToken.bind(this);
@@ -101,7 +103,9 @@ export const TokenDialog = observer(
           errorMessage:
             'Invalid GitHub token. Please check your token and try again.',
         });
-        this.props.appState.gitHubToken = null;
+        if (!this.state.isTokenUpdateAction) {
+          this.props.appState.gitHubToken = null;
+        }
         return;
       }
 
@@ -113,7 +117,9 @@ export const TokenDialog = observer(
           errorMessage:
             'Token is missing the "gist" scope. Please generate a new token with gist permissions.',
         });
-        this.props.appState.gitHubToken = null;
+        if (!this.state.isTokenUpdateAction) {
+          this.props.appState.gitHubToken = null;
+        }
         return;
       }
 
@@ -144,6 +150,7 @@ export const TokenDialog = observer(
         error: false,
         errorMessage: undefined,
         tokenInput: '',
+        isTokenUpdateAction: false,
       });
     }
 

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 
-import { Button, Callout, Checkbox, FormGroup } from '@blueprintjs/core';
+import {
+  Button,
+  ButtonGroup,
+  Callout,
+  Checkbox,
+  FormGroup,
+} from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
 import { AppState } from '../state';
@@ -55,7 +61,11 @@ export const GitHubSettings = observer(
             personal access token you gave us, we logged you into GitHub as{' '}
             <code>{gitHubLogin}</code>.
           </p>
-          <Button onClick={signOut} icon="log-out" text="Sign out" />
+
+          <ButtonGroup>
+            <Button onClick={this.signIn} icon="log-in" text="Update token" />
+            <Button onClick={signOut} icon="log-out" text="Sign out" />
+          </ButtonGroup>
         </Callout>
       );
     }

--- a/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
@@ -45,11 +45,18 @@ exports[`GitHubSettings component > renders when signed in 1`] = `
       </code>
       .
     </p>
-    <Blueprint3.Button
-      icon="log-out"
-      onClick={[MockFunction spy]}
-      text="Sign out"
-    />
+    <Blueprint3.ButtonGroup>
+      <Blueprint3.Button
+        icon="log-in"
+        onClick={[Function]}
+        text="Update token"
+      />
+      <Blueprint3.Button
+        icon="log-out"
+        onClick={[MockFunction spy]}
+        text="Sign out"
+      />
+    </Blueprint3.ButtonGroup>
   </Blueprint3.Callout>
   <Blueprint3.Callout>
     <Blueprint3.FormGroup>

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -75,6 +75,7 @@ describe('TokenDialog component', () => {
     expect(wrapper.state()).toEqual({
       verifying: false,
       error: false,
+      isTokenUpdateAction: false,
       errorMessage: undefined,
       tokenInput: '',
     });
@@ -94,6 +95,7 @@ describe('TokenDialog component', () => {
     expect(wrapper.state()).toEqual({
       verifying: false,
       error: false,
+      isTokenUpdateAction: false,
       errorMessage: undefined,
       tokenInput: '',
     });
@@ -184,6 +186,22 @@ describe('TokenDialog component', () => {
         'Invalid GitHub token. Please check your token and try again.',
       );
       expect(store.gitHubToken).toEqual(null);
+    });
+
+    it('handles the invalid token update', async () => {
+      vi.mocked(mockOctokit.users.getAuthenticated).mockRejectedValue(
+        new Error('Bad credentials'),
+      );
+
+      store.gitHubToken = mockValidToken;
+      const wrapper = shallow(<TokenDialog appState={store} />);
+      wrapper.setState({ tokenInput: mockInvalidToken });
+      const instance: any = wrapper.instance();
+
+      expect(store.gitHubToken).toEqual(mockValidToken);
+      expect(wrapper.state('isTokenUpdateAction')).toBe(true);
+      await instance.onSubmitToken();
+      expect(store.gitHubToken).toEqual(mockValidToken);
     });
 
     it('handles missing gist scope', async () => {


### PR DESCRIPTION
Fixes #407

This PR adds support to change the GitHub token without especially sign out from the previous one. The previous token is also not be removed until the new one is confirmed as valid.

<img width="1386" height="893" alt="image" src="https://github.com/user-attachments/assets/e433f684-490a-488f-8698-24041600ade9" />
