### PR TITLE
feat: improve error dialog when gist publish is failing

### DIFF
--- a/src/renderer/components/commands-action-button.tsx
+++ b/src/renderer/components/commands-action-button.tsx
@@ -16,6 +16,7 @@ import { observer } from 'mobx-react';
 import {
   EditorId,
   EditorValues,
+  GenericDialogType,
   GistActionState,
   GistActionType,
   PACKAGE_NAME,
@@ -156,11 +157,24 @@ export const GistActionButton = observer(
       } catch (error: any) {
         console.warn(`Could not publish gist`, { error });
 
-        window.ElectronFiddle.showWarningDialog({
-          message:
-            'Publishing Fiddle to GitHub failed. Are you connected to the Internet?',
-          detail: `GitHub encountered the following error: ${error.message}`,
-        });
+        if (error.message.includes('Bad credentials')) {
+          const { confirm } = await this.props.appState.showGenericDialog({
+            label: `Publishing Fiddle to GitHub failed. Github encountered the following error: ${error.message}`,
+            ok: 'Update token',
+            cancel: 'Close',
+            type: GenericDialogType.warning,
+            wantsInput: false,
+          });
+
+          if (confirm) {
+            this.props.appState.toggleSettings();
+            this.props.appState.isTokenDialogShowing = true;
+          }
+        } else {
+          await this.props.appState.showErrorDialog(
+            `Publishing Fiddle to GitHub failed. Are you connected to the Internet? GitHub encountered the following error: ${error.message}`,
+          );
+        }
 
         return false;
       }

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -15,6 +15,7 @@ interface TokenDialogState {
   verifying: boolean;
   error: boolean;
   errorMessage?: string;
+  isTokenUpdateAction?: boolean;
 }
 
 const TOKEN_SCOPES = ['gist'].join();
@@ -40,6 +41,7 @@ export const TokenDialog = observer(
         error: false,
         errorMessage: undefined,
         tokenInput: '',
+        isTokenUpdateAction: props.appState.gitHubToken !== '',
       };
 
       this.onSubmitToken = this.onSubmitToken.bind(this);
@@ -101,7 +103,9 @@ export const TokenDialog = observer(
           errorMessage:
             'Invalid GitHub token. Please check your token and try again.',
         });
-        this.props.appState.gitHubToken = null;
+        if (!this.state.isTokenUpdateAction) {
+          this.props.appState.gitHubToken = null;
+        }
         return;
       }
 
@@ -113,7 +117,9 @@ export const TokenDialog = observer(
           errorMessage:
             'Token is missing the "gist" scope. Please generate a new token with gist permissions.',
         });
-        this.props.appState.gitHubToken = null;
+        if (!this.state.isTokenUpdateAction) {
+          this.props.appState.gitHubToken = null;
+        }
         return;
       }
 
@@ -144,6 +150,7 @@ export const TokenDialog = observer(
         error: false,
         errorMessage: undefined,
         tokenInput: '',
+        isTokenUpdateAction: false,
       });
     }
 

--- a/src/renderer/components/settings-general-github.tsx
+++ b/src/renderer/components/settings-general-github.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 
-import { Button, Callout, Checkbox, FormGroup } from '@blueprintjs/core';
+import {
+  Button,
+  ButtonGroup,
+  Callout,
+  Checkbox,
+  FormGroup,
+} from '@blueprintjs/core';
 import { observer } from 'mobx-react';
 
 import { AppState } from '../state';
@@ -55,7 +61,11 @@ export const GitHubSettings = observer(
             personal access token you gave us, we logged you into GitHub as{' '}
             <code>{gitHubLogin}</code>.
           </p>
-          <Button onClick={signOut} icon="log-out" text="Sign out" />
+
+          <ButtonGroup>
+            <Button onClick={this.signIn} icon="log-in" text="Update token" />
+            <Button onClick={signOut} icon="log-out" text="Sign out" />
+          </ButtonGroup>
         </Callout>
       );
     }

--- a/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
+++ b/tests/renderer/components/__snapshots__/settings-general-github-spec.tsx.snap
@@ -45,11 +45,18 @@ exports[`GitHubSettings component > renders when signed in 1`] = `
       </code>
       .
     </p>
-    <Blueprint3.Button
-      icon="log-out"
-      onClick={[MockFunction spy]}
-      text="Sign out"
-    />
+    <Blueprint3.ButtonGroup>
+      <Blueprint3.Button
+        icon="log-in"
+        onClick={[Function]}
+        text="Update token"
+      />
+      <Blueprint3.Button
+        icon="log-out"
+        onClick={[MockFunction spy]}
+        text="Sign out"
+      />
+    </Blueprint3.ButtonGroup>
   </Blueprint3.Callout>
   <Blueprint3.Callout>
     <Blueprint3.FormGroup>

--- a/tests/renderer/components/dialog-token-spec.tsx
+++ b/tests/renderer/components/dialog-token-spec.tsx
@@ -75,6 +75,7 @@ describe('TokenDialog component', () => {
     expect(wrapper.state()).toEqual({
       verifying: false,
       error: false,
+      isTokenUpdateAction: false,
       errorMessage: undefined,
       tokenInput: '',
     });
@@ -94,6 +95,7 @@ describe('TokenDialog component', () => {
     expect(wrapper.state()).toEqual({
       verifying: false,
       error: false,
+      isTokenUpdateAction: false,
       errorMessage: undefined,
       tokenInput: '',
     });
@@ -184,6 +186,22 @@ describe('TokenDialog component', () => {
         'Invalid GitHub token. Please check your token and try again.',
       );
       expect(store.gitHubToken).toEqual(null);
+    });
+
+    it('handles the invalid token update', async () => {
+      vi.mocked(mockOctokit.users.getAuthenticated).mockRejectedValue(
+        new Error('Bad credentials'),
+      );
+
+      store.gitHubToken = mockValidToken;
+      const wrapper = shallow(<TokenDialog appState={store} />);
+      wrapper.setState({ tokenInput: mockInvalidToken });
+      const instance: any = wrapper.instance();
+
+      expect(store.gitHubToken).toEqual(mockValidToken);
+      expect(wrapper.state('isTokenUpdateAction')).toBe(true);
+      await instance.onSubmitToken();
+      expect(store.gitHubToken).toEqual(mockValidToken);
     });
 
     it('handles missing gist scope', async () => {


### PR DESCRIPTION
Fixes #1549

This PR improves the UX of the error dialog that is showed when the user tries to publish a Gist with invalid credentials (or with some other error). This updates the dialog and adds the button that will move the user to the settings page and opens the token update window when the error is related to bad credentials and shows the standard error dialog if something other happened.

<img width="1386" height="893" alt="image" src="https://github.com/user-attachments/assets/07c7c7e4-9900-4863-9827-da042d36e83d" />
