### PR TITLE
test: cleanup RTL after each test

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,10 +1,11 @@
 import '@testing-library/jest-dom/vitest';
 
+import { cleanup } from '@testing-library/react';
 import { configure as enzymeConfigure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createSerializer } from 'enzyme-to-json';
 import { configure as mobxConfigure } from 'mobx';
-import { beforeEach, expect, vi } from 'vitest';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
 
 import { AppMock, ElectronFiddleMock, MonacoMock } from './mocks/mocks';
 
@@ -102,6 +103,10 @@ window.localStorage.removeItem = vi.fn();
 window.open = vi.fn();
 window.navigator.clipboard.readText = vi.fn();
 window.navigator.clipboard.writeText = vi.fn();
+
+afterEach(() => {
+  cleanup();
+});
 
 beforeEach(() => {
   vi.resetAllMocks();


### PR DESCRIPTION
[From the React Testing Library (RTL) docs](https://testing-library.com/docs/react-testing-library/api/#cleanup), we should be calling `cleanup` after each test. This was being done automatically under Jest, but I don't believe it's being done under Vitest - I threw an error in a component's `componentWillUnmount` and confirmed it only actually threw after this change.

Don't know that the lack of this is causing any problems with the tests currently, but it's recommended, so let's do it. We are seeing the occasional flake in tests with something async not being awaited, so this might help with that, or at least rule this out and we can look elsewhere.