### PR TITLE
chore: fix TS compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ commands:
           curl -X POST "$FIDDLE_SECRETS_SERVICE_ENDPOINT?format=shell" -H "Content-Type: application/json" -d '{"token":"'$CIRCLE_OIDC_TOKEN'"}' >> $BASH_ENV
   test:
     steps:
+      - run: yarn contributors
+      - run: yarn tsc
       - run:
           command: yarn test:ci
       - store_test_results:

--- a/src/main/about-panel.ts
+++ b/src/main/about-panel.ts
@@ -12,7 +12,7 @@ import contributorsJSON from '../../static/contributors.json';
 export function setupAboutPanel(): void {
   const contributors: Array<string> = [];
   contributorsJSON.forEach((userData: Contributor) => {
-    if (userData.name !== null && userData.name !== undefined) {
+    if (userData.name !== null) {
       contributors.push(userData.name);
     }
   });

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -73,7 +73,7 @@ export const TokenDialog = observer(
           hasGistScope,
           user: response.data,
         };
-      } catch (error) {
+      } catch (error: any) {
         return {
           isValid: false,
           scopes: [],


### PR DESCRIPTION
This slipped in during #1722 but wasn't caught until the release jobs ran because our CI was never running `tsc`, and the error was just being logged as a warning during tests rather than a fatal error. This PR updates our CI to ensure we run `tsc`, and then fixes the error that slipped in.