### PR TITLE
chore: release 0.37.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-fiddle",
   "private": true,
   "productName": "Electron Fiddle",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "The easiest way to get started with Electron",
   "repository": "https://github.com/electron/fiddle",
   "homepage": "https://electronjs.org/fiddle",


### PR DESCRIPTION
v0.37.0 didn't go out because of a blocker fixed by #1731, so let's try again.