### PR TITLE
build: fix contributors fetch script silently failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ commands:
           curl -X POST "$FIDDLE_SECRETS_SERVICE_ENDPOINT?format=shell" -H "Content-Type: application/json" -d '{"token":"'$CIRCLE_OIDC_TOKEN'"}' >> $BASH_ENV
   test:
     steps:
-      - run: yarn contributors
       - run: yarn tsc
       - run:
           command: yarn test:ci

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Install
         run: yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000 || yarn --frozen-lockfile --network-timeout 100000
       - run: yarn run contributors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn run electron-releases
       - name: test
         run: yarn test:ci

--- a/tools/contributors.ts
+++ b/tools/contributors.ts
@@ -106,19 +106,23 @@ async function fetchDetailsContributor(contributor: {
  *
  * @param contributors - Array of contributors
  */
-async function fetchDetailsContributors(contributors: ContributorInfo[]) {
-  return Promise.all(
-    contributors.map(async (contributor) => {
-      const details = await fetchDetailsContributor(contributor);
+async function fetchDetailsContributors(
+  contributors: ContributorInfo[],
+): Promise<ContributorInfo[]> {
+  const detailedContributors: ContributorInfo[] = [];
 
-      return {
-        ...contributor,
-        name: details.name,
-        bio: details.bio,
-        location: details.location,
-      };
-    }),
-  );
+  for (const contributor of contributors) {
+    const details = await fetchDetailsContributor(contributor);
+
+    detailedContributors.push({
+      ...contributor,
+      name: details.name,
+      bio: details.bio,
+      location: details.location,
+    });
+  }
+
+  return detailedContributors;
 }
 
 async function fetchContributors() {


### PR DESCRIPTION
This has been intermittently biting us in CI and now manifests in a TypeScript error after recent changes that are doing better typing for the imported JSON file.

The existing script wasn't checking if the fetch response was good before using it, which led to a situation where the initial fetch of contributors would succeed, but then fetching further details on each contributor would get rate limited and silently fail causing partial data.

I took the opportunity to clean up the script in general, and made some tweaks to the CI workflows to minimize the odds of being rate limited by GitHub. The CircleCI jobs are still at risk since it's non-trivial to give them a token to avoid it, but when we one day migrate to GHA that should go away.