### PR TITLE
build: rollback change to use @electron/windows-sign

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -124,9 +124,7 @@ const config: ForgeConfig = {
         noMsi: true,
         setupExe: `electron-fiddle-${version}-win32-${arch}-setup.exe`,
         setupIcon: path.resolve(iconDir, 'fiddle.ico'),
-        windowsSign: {
-          signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
-        },
+        signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
       }),
     },
     {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
   },
   "resolutions": {
     "@electron-forge/maker-base": "7.8.1",
-    "@electron-forge/shared-types": "7.8.1",
-    "@electron/windows-sign": "github:electron/windows-sign#node-22"
+    "@electron-forge/shared-types": "7.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,12 +823,15 @@
     minimatch "^9.0.3"
     plist "^3.1.0"
 
-"@electron/windows-sign@^1.0.0", "@electron/windows-sign@^1.1.2", "@electron/windows-sign@github:electron/windows-sign#node-22":
-  version "0.0.0-development"
-  resolved "https://codeload.github.com/electron/windows-sign/tar.gz/48d6c4198afc5cf9d37e8a51b9797c246b0420a1"
+"@electron/windows-sign@^1.0.0", "@electron/windows-sign@^1.1.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@electron/windows-sign/-/windows-sign-1.2.2.tgz#8ceaad52d5c1eb18702f48103d5f3bc7c338fa9d"
+  integrity sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==
   dependencies:
+    cross-dirname "^0.1.0"
     debug "^4.3.4"
-    graceful-fs "^4.2.11"
+    fs-extra "^11.1.1"
+    minimist "^1.2.8"
     postject "^1.0.0-alpha.6"
 
 "@esbuild/aix-ppc64@0.25.6":
@@ -4228,6 +4231,11 @@ cosmiconfig@^8.2.0:
     js-yaml "^4.1.0"
     parse-json "^5.0.0"
     path-type "^4.0.0"
+
+cross-dirname@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cross-dirname/-/cross-dirname-0.1.0.tgz#b899599f30a5389f59e78c150e19f957ad16a37c"
+  integrity sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==
 
 cross-spawn@^6.0.0:
   version "6.0.6"
@@ -8458,7 +8466,7 @@ minimist@^1.2.0:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
This reverts #1728. We found various issues in the latest major of `@electron/windows-sign` and got fixes published, but in the end this still isn't working in our CI for some reason, but neither is the old v1.2.2 version of `@electron/windows-sign` that we know works for others. I suspect it might be some weirdness with CircleCI, but I don't have the cycles to keep digging into it currently so rolling this back for now so we can actually get a release out.