### PR TITLE
fix: rename references to electron-quick-start repo

### DIFF
--- a/src/main/content.ts
+++ b/src/main/content.ts
@@ -21,19 +21,20 @@ const TEST_TEMPLATE_BRANCH = 'test-template';
 
 /**
  * Ensure we have a fiddle for the specified Electron branch.
- * If we don't have it already, download it from electron-quick-start.
+ * If we don't have it already, download it from the minimal-repro
+ * repository.
  *
  * @param branch - Electron branchname, e.g. `12-x-y` or `main`
  * @returns Path to the folder where the fiddle is kept
  */
 async function prepareTemplate(branch: string): Promise<string> {
-  let folder = path.join(TEMPLATES_DIR, `electron-quick-start-${branch}`);
+  let folder = path.join(TEMPLATES_DIR, `minimal-repro-${branch}`);
 
   try {
     // if we don't have it, download it
     if (!fs.existsSync(folder)) {
       console.log(`Content: ${branch} downloading template`);
-      const url = `https://github.com/electron/electron-quick-start/archive/${branch}.zip`;
+      const url = `https://github.com/electron/minimal-repro/archive/${branch}.zip`;
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`${url} ${response.status} ${response.statusText}`);

--- a/tests/main/content-spec.ts
+++ b/tests/main/content-spec.ts
@@ -97,7 +97,7 @@ describe('content', () => {
       await getTestTemplate();
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenLastCalledWith(
-        'https://github.com/electron/electron-quick-start/archive/test-template.zip',
+        'https://github.com/electron/minimal-repro/archive/test-template.zip',
       );
     });
   });


### PR DESCRIPTION
`electron/electron-quick-start` was renamed to `electron/minimal-repro` which has had an unintended consequence in how we handle templates for major versions. If you select an older version that we have a branch for on that repo (e.g. `v30.x.y`), you'll end up with a blank fiddle because Fiddle will download and extract a ZIP of that branch, which now unzips to `minimal-repro-N-x-y` when we are expecting `electron-quick-start-N-x-y`.