### PR TITLE
ci: run tests on arm64 Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - x64
         os:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+        arch:
+          - x64
         include:
           - os: macos-latest
             arch: arm64


### PR DESCRIPTION
We build for this platform, might as well test on it as well.