### PR TITLE
ci: grab GitHub app token when publishing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,15 @@ jobs:
           path: out
           pattern: build-artifacts-*
           merge-multiple: true
-      - run: yarn run publish --from-dry-run
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.FIDDLE_RELEASE_APP_CREDS }}
+      - name: Publish to GitHub
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: yarn run publish --from-dry-run
 
   notify-sentry-deploy:
     name: Notify Sentry Deploy


### PR DESCRIPTION
Forgot this in #1773.