### PR TITLE
build: add gha-done step to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,13 @@ jobs:
         run: yarn run lint && yarn run format
       - name: Test
         run: yarn tsc && yarn test:ci
+
+  gha-done:
+    name: GitHub Actions Completed
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always() && !contains(needs.*.result, 'failure')
+    steps: 
+    - name: GitHub Actions Jobs Done
+      run: |
+        echo "All GitHub Actions Jobs are done"


### PR DESCRIPTION
This PR adds a `gha-done` step in Actions to allow us to easily gate branch protection, similar to e/e