### PR TITLE
build: use @electron/windows-sign

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -124,7 +124,9 @@ const config: ForgeConfig = {
         noMsi: true,
         setupExe: `electron-fiddle-${version}-win32-${arch}-setup.exe`,
         setupIcon: path.resolve(iconDir, 'fiddle.ico'),
-        signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
+        windowsSign: {
+          signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
+        },
       }),
     },
     {


### PR DESCRIPTION
Trying this out again now that we're migrating to GHA.