### PR TITLE
docs: update SECURITY.md to match electron/electron

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,22 @@
 
 The Electron team and community take security bugs in Electron seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, email [security@electronjs.org](mailto:security@electronjs.org) and include the word "SECURITY" in the subject line.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/electron/fiddle/security/advisories/new) tab.
 
 The Electron team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
-Report security bugs in third-party modules to the person or team maintaining the module.
+Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
+
+## Escalation
+
+If you do not receive an acknowledgement of your report within 6 business days, or if you cannot find a private security contact for the project, you may escalate to the OpenJS Foundation CNA at `security@lists.openjsf.org`.
+
+If the project acknowledges your report but does not provide any further response or engagement within 14 days, escalation is also appropriate.
+
+## The Electron Security Notification Process
+
+For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md) Governance document.
 
 ## Learning More About Security
 
-To learn more about securing an Electron application, please see the [security tutorial](https://github.com/electron/electron/blob/main/docs/tutorial/security.md).
+To learn more about securing an Electron application, please see the [security tutorial](https://www.electronjs.org/docs/latest/tutorial/security).


### PR DESCRIPTION
As requested by @MarshallOfSound. GHSA should be preferred over the email address.

See https://electronhq.slack.com/archives/C3ANJ97H6/p1761782304643429?thread_ts=1761741484.257889&cid=C3ANJ97H6