### PR TITLE
ci: add missing perm to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
     environment: release
     permissions:
       contents: read
+      id-token: write
     steps:
       - run: git config --global core.autocrlf input
       - name: Checkout


### PR DESCRIPTION
Release workflow is getting to the final step now, but missing this perm.