### PR TITLE
ci: use macos-15-intel runner for Intel macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-15-intel
           - ubuntu-latest
           - windows-latest
         arch:
@@ -35,16 +35,12 @@ jobs:
     environment: release
     steps:
       - run: git config --global core.autocrlf input
-      - name: Install Rosetta
-        if: ${{ startsWith(matrix.os, 'macos-') && matrix.arch == 'x64' }}
-        run: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '22.17.x'
-          architecture: ${{ startsWith(matrix.os, 'macos-') && matrix.arch == 'x64' && 'x64' || env.RUNNER_ARCH }}
       - run: yarn install --immutable
       - run: yarn run contributors
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-15-intel
           - ubuntu-latest
           - windows-latest
         arch:
@@ -32,9 +32,6 @@ jobs:
     runs-on: "${{ matrix.os }}"
     steps:
       - run: git config --global core.autocrlf input
-      - name: Install Rosetta
-        if: ${{ matrix.os == 'macos-latest' && matrix.arch == 'x64' }}
-        run: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node.js
@@ -42,7 +39,6 @@ jobs:
         with:
           node-version: '22.17.x'
           cache: 'yarn'
-          architecture: ${{ matrix.os == 'macos-latest' && matrix.arch == 'x64' && 'x64' || env.RUNNER_ARCH }}
       - name: Install dependencies
         run: yarn --immutable
       - run: yarn run contributors


### PR DESCRIPTION
[GitHub is going to support this runner through 2027](https://github.com/actions/runner-images/issues/13045), so let's go ahead and use it instead of Rosetta since it will be more performant and we've been seeing a hang issue with the release job on macOS x64 that this might fix. 🤞