### PR TITLE
ci: set auth token for getsentry/action-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
           path: .webpack
       - uses: getsentry/action-release@128c5058bbbe93c8e02147fe0a9c713f166259a6 # v3.4.0
         env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: electronjs
           SENTRY_PROJECT: electron-fiddle
         with:


### PR DESCRIPTION
The secret `SENTRY_AUTH_TOKEN` has been populated.