### PR TITLE
ci: switch to new digicert action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: chmod +x tools/add-macos-cert.sh && . ./tools/add-macos-cert.sh
       - name: Signing Manager Setup (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
-        uses: digicert/ssm-code-signing@1d820463733701cf1484c7eb5d7d24a15ca2c454 # v1.2.1
+        uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # v1.2.1
       - name: Write authentication cert to disk (Windows)
         if: ${{ startsWith(matrix.os, 'windows-') }}
         shell: bash


### PR DESCRIPTION
The action we're currently using [is deprecated](https://github.com/digicert/ssm-code-signing#new-github-actions--deprecation-notice), and they suggest migrating to this new action. Their migration steps imply it's a drop-in replacement, so let's see how this goes next release.