### PR TITLE
feat(console): surface app name

### DIFF
--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -401,7 +401,8 @@ export class Runner {
 
       this.appState.isRunning = true;
 
-      pushOutput(`Electron v${version} started.`);
+      const name = await this.appState.getName();
+      pushOutput(`Electron v${version} started as "${name}".`);
 
       window.ElectronFiddle.removeAllListeners('fiddle-runner-output');
       window.ElectronFiddle.removeAllListeners('fiddle-stopped');

--- a/src/renderer/runner.ts
+++ b/src/renderer/runner.ts
@@ -401,7 +401,8 @@ export class Runner {
 
       this.appState.isRunning = true;
 
-      pushOutput(`Electron v${version} started.`);
+      const name = await this.appState.getName();
+      pushOutput(`Electron v${version} started as "${name}"`);
 
       window.ElectronFiddle.removeAllListeners('fiddle-runner-output');
       window.ElectronFiddle.removeAllListeners('fiddle-stopped');


### PR DESCRIPTION
Tiny update to the console that surfaces the actual name of the app that is in its `package.json`.

This matters so you can actually know where the current Fiddle's appData folder lives on your filesystem.