### PR TITLE
build(dev-deps): bump @electron/fuses to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@electron-forge/plugin-webpack": "8.0.0-alpha.8",
     "@electron-forge/publisher-github": "8.0.0-alpha.8",
     "@electron/devtron": "^2.1.1",
-    "@electron/fuses": "^1.6.1",
+    "@electron/fuses": "^2.1.1",
     "@electron/lint-roller": "^3.1.3",
     "@octokit/core": "^3.5.1",
     "@reforged/maker-appimage": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,16 +730,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/fuses@npm:^1.6.1":
-  version: 1.7.0
-  resolution: "@electron/fuses@npm:1.7.0"
-  dependencies:
-    chalk: "npm:^4.1.1"
-    fs-extra: "npm:^9.0.1"
-    minimist: "npm:^1.2.5"
+"@electron/fuses@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@electron/fuses@npm:2.1.1"
   bin:
     electron-fuses: dist/bin.js
-  checksum: 10c0/c8d48085be5623a5a0f69ca0ab1769845fae4db14c430046d03c02e6cdd091991827db94847f7b647be9ebf66320ede7d25c3ef92ee70906f1d6e4be76a8a9e4
+  checksum: 10c0/b39d91bae1b24ac81ceb1edec63d7f3c9f741495be1e5977b0c31faede28cca9c030c603b14ba142e59ed6dac706c50f1d14579a4baabbebb66338eb2c653881
   languageName: node
   linkType: hard
 
@@ -4633,7 +4629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5753,7 +5749,7 @@ __metadata:
     "@electron-forge/publisher-github": "npm:8.0.0-alpha.8"
     "@electron/devtron": "npm:^2.1.1"
     "@electron/fiddle-core": "npm:^2.0.1"
-    "@electron/fuses": "npm:^1.6.1"
+    "@electron/fuses": "npm:^2.1.1"
     "@electron/lint-roller": "npm:^3.1.3"
     "@octokit/core": "npm:^3.5.1"
     "@octokit/rest": "npm:^17.0.0"
@@ -7159,7 +7155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1, fs-extra@npm:^9.1.0":
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -10243,7 +10239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6


### PR DESCRIPTION
The v8 line of `@electron-forge/plugin-fuses` requires `@electron/fuses@^2.0.0`, so bump this - no breaking changes that should affect us.