### PR TITLE
build(deps): drop electron-default-menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@sentry/electron": "^7.12.0",
     "algoliasearch": "^4.12.0",
     "classnames": "^2.2.6",
-    "electron-default-menu": "^1.0.2",
     "electron-squirrel-startup": "^1.0.0",
     "extract-zip": "^2.0.1",
     "fs-extra": "^9.1.0",

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -23,6 +23,175 @@ import {
 import { IpcEvents } from '../ipc-events';
 import { SHOW_ME_TEMPLATES } from '../templates';
 
+function getDefaultMenu(): Array<MenuItemConstructorOptions> {
+  const template: MenuItemConstructorOptions[] = [
+    {
+      label: 'Edit',
+      submenu: [
+        {
+          label: 'Undo',
+          accelerator: 'CmdOrCtrl+Z',
+          role: 'undo',
+        },
+        {
+          label: 'Redo',
+          accelerator: 'Shift+CmdOrCtrl+Z',
+          role: 'redo',
+        },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Cut',
+          accelerator: 'CmdOrCtrl+X',
+          role: 'cut',
+        },
+        {
+          label: 'Copy',
+          accelerator: 'CmdOrCtrl+C',
+          role: 'copy',
+        },
+        {
+          label: 'Paste',
+          accelerator: 'CmdOrCtrl+V',
+          role: 'paste',
+        },
+        {
+          label: 'Select All',
+          accelerator: 'CmdOrCtrl+A',
+          role: 'selectAll',
+        },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Reload',
+          accelerator: 'CmdOrCtrl+R',
+          click: (_, focusedWindow) => {
+            if (focusedWindow) {
+              (focusedWindow as BrowserWindow).reload();
+            }
+          },
+        },
+        {
+          label: 'Toggle Full Screen',
+          accelerator: (() => {
+            if (process.platform === 'darwin') return 'Ctrl+Command+F';
+            else return 'F11';
+          })(),
+          click: (_, focusedWindow) => {
+            if (focusedWindow)
+              focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+          },
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: (() => {
+            if (process.platform === 'darwin') return 'Alt+Command+I';
+            else return 'Ctrl+Shift+I';
+          })(),
+          click: (_, focusedWindow) => {
+            if (focusedWindow)
+              (focusedWindow as BrowserWindow).webContents.toggleDevTools();
+          },
+        },
+      ],
+    },
+    {
+      label: 'Window',
+      role: 'window',
+      submenu: [
+        {
+          label: 'Minimize',
+          accelerator: 'CmdOrCtrl+M',
+          role: 'minimize',
+        },
+        {
+          label: 'Close',
+          accelerator: 'CmdOrCtrl+W',
+          role: 'close',
+        },
+      ],
+    },
+    {
+      label: 'Help',
+      role: 'help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: () => {
+            shell.openExternal('http://electron.atom.io');
+          },
+        },
+      ],
+    },
+  ];
+
+  if (process.platform === 'darwin') {
+    const { name } = app;
+    template.unshift({
+      label: name,
+      submenu: [
+        {
+          label: 'About ' + name,
+          role: 'about',
+        },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Services',
+          role: 'services',
+          submenu: [],
+        },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Hide ' + name,
+          accelerator: 'Command+H',
+          role: 'hide',
+        },
+        {
+          label: 'Hide Others',
+          accelerator: 'Command+Shift+H',
+          role: 'hideOthers',
+        },
+        {
+          label: 'Show All',
+          role: 'unhide',
+        },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Quit',
+          accelerator: 'Command+Q',
+          click: () => {
+            app.quit();
+          },
+        },
+      ],
+    });
+    const windowMenu = template.find((m) => m.role === 'window');
+    if (windowMenu && isSubmenu(windowMenu.submenu)) {
+      windowMenu.submenu.push(
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Bring All to Front',
+          role: 'front',
+        },
+      );
+    }
+  }
+
+  return template;
+}
+
 /**
  * Is the passed object a constructor for an Electron Menu?
  */
@@ -86,7 +255,7 @@ function getHelpItems(): Array<MenuItemConstructorOptions> {
   );
 
   // on macOS, there's already the About Electron Fiddle menu item
-  // under the first submenu set by the electron-default-menu package
+  // under the first submenu set by the default menus
   if (process.platform !== 'darwin') {
     items.push(
       {
@@ -312,10 +481,7 @@ export function setupMenu(options?: SetUpMenuOptions) {
   const activeTemplate = options?.activeTemplate || null;
 
   // Get template for default menu
-  const defaultMenu = require('electron-default-menu');
-  const menu = (
-    defaultMenu(app, shell) as Array<MenuItemConstructorOptions>
-  ).map((item) => {
+  const menu = getDefaultMenu().map((item) => {
     const { label } = item;
 
     // Append the "Settings" item

--- a/yarn.lock
+++ b/yarn.lock
@@ -5527,13 +5527,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-default-menu@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "electron-default-menu@npm:1.0.2"
-  checksum: 10c0/ee1c9c13006309d1b503e3765aadbd152519212901ff6e2d24abedcbbe6949338f2227770cb36ba9b84af73fb341d679ba50fb25e3747b6c310958a09e8c2625
-  languageName: node
-  linkType: hard
-
 "electron-devtools-installer@npm:^4.0.0":
   version: 4.0.0
   resolution: "electron-devtools-installer@npm:4.0.0"
@@ -5588,7 +5581,6 @@ __metadata:
     copy-webpack-plugin: "npm:^11.0.0"
     css-loader: "npm:^6.7.1"
     electron: "npm:^40.8.4"
-    electron-default-menu: "npm:^1.0.2"
     electron-devtools-installer: "npm:^4.0.0"
     electron-squirrel-startup: "npm:^1.0.0"
     eslint: "npm:^8.45.0"


### PR DESCRIPTION
This inlines the default menu that `electron-default-menu` was providing. We could probably now simplify some of the logic in this file since it's build around inserting menu items in an existing default menu, when we could instead put them in the correct spot from the start. But to keep this PR easy to review, I'm first just inlining the default menu as-is.