### PR TITLE
build(deps): drop tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "sfw": "^2.0.4",
     "shell-env": "^4.0.3",
     "tmp": "0.2.5",
-    "tslib": "^2.6.0",
     "update-electron-app": "^3.0.0"
   },
   "devDependencies": {

--- a/src/renderer/components/history-wrapper.tsx
+++ b/src/renderer/components/history-wrapper.tsx
@@ -16,64 +16,65 @@ interface HistoryWrapperProps {
  * A component that observes the appState and manages the history dialog.
  * Can be rendered as just a button or as a button with a dialog.
  */
-@observer
-export class HistoryWrapper extends React.Component<HistoryWrapperProps> {
-  private toggleHistory = () => {
-    const { appState } = this.props;
-    appState.toggleHistory();
-  };
+export const HistoryWrapper = observer(
+  class HistoryWrapper extends React.Component<HistoryWrapperProps> {
+    private toggleHistory = () => {
+      const { appState } = this.props;
+      appState.toggleHistory();
+    };
 
-  private handleRevisionSelect = async (revisionId: string) => {
-    const { remoteLoader } = window.app;
-    try {
-      await remoteLoader.fetchGistAndLoad(
-        this.props.appState.gistId!,
-        revisionId,
-      );
-    } catch (error: any) {
-      console.error('Failed to load revision', error);
-      this.props.appState.showErrorDialog(
-        `Failed to load revision: ${error.message || 'Unknown error'}`,
+    private handleRevisionSelect = async (revisionId: string) => {
+      const { remoteLoader } = window.app;
+      try {
+        await remoteLoader.fetchGistAndLoad(
+          this.props.appState.gistId!,
+          revisionId,
+        );
+      } catch (error: any) {
+        console.error('Failed to load revision', error);
+        this.props.appState.showErrorDialog(
+          `Failed to load revision: ${error.message || 'Unknown error'}`,
+        );
+      }
+    };
+
+    public renderHistoryButton() {
+      const { className } = this.props;
+
+      return (
+        <Button
+          icon="history"
+          onClick={this.toggleHistory}
+          className={className}
+          aria-label="View revision history"
+          data-testid="history-button"
+        />
       );
     }
-  };
 
-  public renderHistoryButton() {
-    const { className } = this.props;
+    public render() {
+      const { appState, buttonOnly } = this.props;
+      const dialogKey = 'history-dialog';
 
-    return (
-      <Button
-        icon="history"
-        onClick={this.toggleHistory}
-        className={className}
-        aria-label="View revision history"
-        data-testid="history-button"
-      />
-    );
-  }
-
-  public render() {
-    const { appState, buttonOnly } = this.props;
-    const dialogKey = 'history-dialog';
-
-    return (
-      <>
-        {buttonOnly ? (
-          this.renderHistoryButton()
-        ) : (
-          <>
-            {this.renderHistoryButton()}
-            <GistHistoryDialog
-              key={dialogKey}
-              appState={appState}
-              isOpen={appState.isHistoryShowing}
-              onClose={this.toggleHistory}
-              onRevisionSelect={this.handleRevisionSelect}
-              activeRevision={appState.activeGistRevision}
-            />
-          </>
-        )}
-      </>
-    );
-  }
-}
+      return (
+        <>
+          {buttonOnly ? (
+            this.renderHistoryButton()
+          ) : (
+            <>
+              {this.renderHistoryButton()}
+              <GistHistoryDialog
+                key={dialogKey}
+                appState={appState}
+                isOpen={appState.isHistoryShowing}
+                onClose={this.toggleHistory}
+                onRevisionSelect={this.handleRevisionSelect}
+                activeRevision={appState.activeGistRevision}
+              />
+            </>
+          )}
+        </>
+      );
+    }
+  },
+);

--- a/src/renderer/components/history.tsx
+++ b/src/renderer/components/history.tsx
@@ -29,205 +29,203 @@ interface HistoryState {
   error: string | null;
 }
 
-@observer
-export class GistHistoryDialog extends React.Component<
-  HistoryProps,
-  HistoryState
-> {
-  private disposeReaction: IReactionDisposer | null = null;
+export const GistHistoryDialog = observer(
+  class GistHistoryDialog extends React.Component<HistoryProps, HistoryState> {
+    private disposeReaction: IReactionDisposer | null = null;
 
-  constructor(props: HistoryProps) {
-    super(props);
-    this.state = {
-      isLoading: true,
-      revisions: [],
-      error: null,
-    };
-  }
-
-  public componentDidMount() {
-    // Reload revisions when gistId changes while dialog is open
-    this.disposeReaction = reaction(
-      () => this.props.appState.gistId,
-      () => {
-        if (this.props.isOpen) {
-          this.loadRevisions();
-        }
-      },
-    );
-
-    if (this.props.isOpen) {
-      this.loadRevisions();
-    }
-  }
-
-  public componentDidUpdate(prevProps: HistoryProps) {
-    const dialogJustOpened = this.props.isOpen && !prevProps.isOpen;
-    const revisionChanged =
-      this.props.activeRevision !== prevProps.activeRevision;
-
-    if (dialogJustOpened) {
-      this.loadRevisions();
-    } else if (this.props.isOpen && revisionChanged) {
-      this.loadRevisions(false);
-    }
-  }
-
-  public componentWillUnmount() {
-    this.disposeReaction?.();
-  }
-
-  private async loadRevisions(showLoading = true) {
-    const { appState, isOpen } = this.props;
-    const { remoteLoader } = window.app;
-
-    if (!isOpen) return;
-
-    if (!appState.gistId) {
-      this.setState({ isLoading: false, error: 'No Gist ID available' });
-      return;
+    constructor(props: HistoryProps) {
+      super(props);
+      this.state = {
+        isLoading: true,
+        revisions: [],
+        error: null,
+      };
     }
 
-    if (showLoading) {
-      this.setState({ isLoading: true, error: null });
+    public componentDidMount() {
+      // Reload revisions when gistId changes while dialog is open
+      this.disposeReaction = reaction(
+        () => this.props.appState.gistId,
+        () => {
+          if (this.props.isOpen) {
+            this.loadRevisions();
+          }
+        },
+      );
+
+      if (this.props.isOpen) {
+        this.loadRevisions();
+      }
     }
 
-    try {
-      const revisions = await remoteLoader.getGistRevisions(appState.gistId);
+    public componentDidUpdate(prevProps: HistoryProps) {
+      const dialogJustOpened = this.props.isOpen && !prevProps.isOpen;
+      const revisionChanged =
+        this.props.activeRevision !== prevProps.activeRevision;
 
-      const { activeGistRevision } = appState;
-      if (
-        activeGistRevision &&
-        !revisions.some((r) => r.sha === activeGistRevision)
-      ) {
-        revisions.push({
-          sha: activeGistRevision,
-          date: new Date().toISOString(),
-          title: `Revision ${revisions.length}`,
-          changes: { additions: 0, deletions: 0, total: 0 },
-        });
+      if (dialogJustOpened) {
+        this.loadRevisions();
+      } else if (this.props.isOpen && revisionChanged) {
+        this.loadRevisions(false);
+      }
+    }
+
+    public componentWillUnmount() {
+      this.disposeReaction?.();
+    }
+
+    private async loadRevisions(showLoading = true) {
+      const { appState, isOpen } = this.props;
+      const { remoteLoader } = window.app;
+
+      if (!isOpen) return;
+
+      if (!appState.gistId) {
+        this.setState({ isLoading: false, error: 'No Gist ID available' });
+        return;
       }
 
-      this.setState({ revisions, isLoading: false });
-    } catch (error) {
-      console.error('Failed to load gist revisions', error);
-      this.setState({
-        isLoading: false,
-        error: 'Failed to load revision history',
-      });
-    }
-  }
+      if (showLoading) {
+        this.setState({ isLoading: true, error: null });
+      }
 
-  private handleRevisionSelect = async (revision: GistRevision) => {
-    try {
-      await this.props.onRevisionSelect(revision.sha);
-      this.props.onClose();
-    } catch (error: any) {
-      console.error('Failed to load revision', error);
-      this.props.appState.showErrorDialog(
-        `Failed to load revision: ${error.message || 'Unknown error'}`,
+      try {
+        const revisions = await remoteLoader.getGistRevisions(appState.gistId);
+
+        const { activeGistRevision } = appState;
+        if (
+          activeGistRevision &&
+          !revisions.some((r) => r.sha === activeGistRevision)
+        ) {
+          revisions.push({
+            sha: activeGistRevision,
+            date: new Date().toISOString(),
+            title: `Revision ${revisions.length}`,
+            changes: { additions: 0, deletions: 0, total: 0 },
+          });
+        }
+
+        this.setState({ revisions, isLoading: false });
+      } catch (error) {
+        console.error('Failed to load gist revisions', error);
+        this.setState({
+          isLoading: false,
+          error: 'Failed to load revision history',
+        });
+      }
+    }
+
+    private handleRevisionSelect = async (revision: GistRevision) => {
+      try {
+        await this.props.onRevisionSelect(revision.sha);
+        this.props.onClose();
+      } catch (error: any) {
+        console.error('Failed to load revision', error);
+        this.props.appState.showErrorDialog(
+          `Failed to load revision: ${error.message || 'Unknown error'}`,
+        );
+        this.props.onClose();
+      }
+    };
+
+    private renderChangeStats(changes: GistRevision['changes']) {
+      return (
+        <div className="revision-changes">
+          <Tag intent="success" minimal>
+            +{changes.additions}
+          </Tag>
+          <Tag intent="danger" minimal>
+            -{changes.deletions}
+          </Tag>
+          <Tag minimal>{changes.total} total</Tag>
+        </div>
       );
-      this.props.onClose();
     }
-  };
 
-  private renderChangeStats(changes: GistRevision['changes']) {
-    return (
-      <div className="revision-changes">
-        <Tag intent="success" minimal>
-          +{changes.additions}
-        </Tag>
-        <Tag intent="danger" minimal>
-          -{changes.deletions}
-        </Tag>
-        <Tag minimal>{changes.total} total</Tag>
-      </div>
-    );
-  }
+    private renderRevisionItem = (revision: GistRevision) => {
+      const date = new Date(revision.date).toLocaleString();
+      const shortSha = revision.sha.substring(0, 7);
+      const isActive = this.props.activeRevision === revision.sha;
 
-  private renderRevisionItem = (revision: GistRevision) => {
-    const date = new Date(revision.date).toLocaleString();
-    const shortSha = revision.sha.substring(0, 7);
-    const isActive = this.props.activeRevision === revision.sha;
-
-    return (
-      <li
-        key={revision.sha}
-        className={`revision-item${isActive ? ' active' : ''}`}
-        onClick={() => this.handleRevisionSelect(revision)}
-      >
-        <div className="revision-content">
-          <h4>
-            <Icon icon="history" className="revision-icon" />
-            {revision.title}
-            <span className="sha-label">{shortSha}</span>
-            {isActive && (
-              <Tag intent="primary" minimal className="active-tag">
-                Active
-              </Tag>
-            )}
-          </h4>
-          <div className="revision-details">
-            <span className="revision-date">{date}</span>
-            {this.renderChangeStats(revision.changes)}
+      return (
+        <li
+          key={revision.sha}
+          className={`revision-item${isActive ? ' active' : ''}`}
+          onClick={() => this.handleRevisionSelect(revision)}
+        >
+          <div className="revision-content">
+            <h4>
+              <Icon icon="history" className="revision-icon" />
+              {revision.title}
+              <span className="sha-label">{shortSha}</span>
+              {isActive && (
+                <Tag intent="primary" minimal className="active-tag">
+                  Active
+                </Tag>
+              )}
+            </h4>
+            <div className="revision-details">
+              <span className="revision-date">{date}</span>
+              {this.renderChangeStats(revision.changes)}
+            </div>
           </div>
-        </div>
-      </li>
-    );
-  };
+        </li>
+      );
+    };
 
-  private renderContent() {
-    const { isLoading, revisions, error } = this.state;
+    private renderContent() {
+      const { isLoading, revisions, error } = this.state;
 
-    if (isLoading) {
+      if (isLoading) {
+        return (
+          <div className="history-loading">
+            <Spinner />
+            <p>Loading revision history...</p>
+          </div>
+        );
+      }
+
+      if (error) {
+        return (
+          <NonIdealState
+            icon="error"
+            title="Error Loading History"
+            description={error}
+          />
+        );
+      }
+
+      if (revisions.length === 0) {
+        return (
+          <NonIdealState
+            icon="history"
+            title="No Revision History"
+            description="This Gist doesn't have any revisions"
+          />
+        );
+      }
+
       return (
-        <div className="history-loading">
-          <Spinner />
-          <p>Loading revision history...</p>
+        <div className="revision-list">
+          <ul>{[...revisions].reverse().map(this.renderRevisionItem)}</ul>
         </div>
       );
     }
 
-    if (error) {
-      return (
-        <NonIdealState
-          icon="error"
-          title="Error Loading History"
-          description={error}
-        />
-      );
-    }
+    public render() {
+      const { isOpen, onClose } = this.props;
 
-    if (revisions.length === 0) {
       return (
-        <NonIdealState
+        <Dialog
+          isOpen={isOpen}
+          onClose={onClose}
+          title="Revision History"
+          className="gist-history-dialog"
           icon="history"
-          title="No Revision History"
-          description="This Gist doesn't have any revisions"
-        />
+        >
+          <div className={Classes.DIALOG_BODY}>{this.renderContent()}</div>
+        </Dialog>
       );
     }
-
-    return (
-      <div className="revision-list">
-        <ul>{[...revisions].reverse().map(this.renderRevisionItem)}</ul>
-      </div>
-    );
-  }
-
-  public render() {
-    const { isOpen, onClose } = this.props;
-
-    return (
-      <Dialog
-        isOpen={isOpen}
-        onClose={onClose}
-        title="Revision History"
-        className="gist-history-dialog"
-        icon="history"
-      >
-        <div className={Classes.DIALOG_BODY}>{this.renderContent()}</div>
-      </Dialog>
-    );
-  }
-}
+  },
+);

--- a/src/renderer/components/settings-general-font.tsx
+++ b/src/renderer/components/settings-general-font.tsx
@@ -17,77 +17,80 @@ interface FontSettingsState {
 /**
  * Settings font family and size.
  */
-@observer
-export class FontSettings extends React.Component<
-  FontSettingsProps,
-  FontSettingsState
-> {
-  public constructor(props: FontSettingsProps) {
-    super(props);
+export const FontSettings = observer(
+  class FontSettings extends React.Component<
+    FontSettingsProps,
+    FontSettingsState
+  > {
+    public constructor(props: FontSettingsProps) {
+      super(props);
 
-    this.state = {
-      fontSize: this.props.appState.fontSize,
-      fontFamily: this.props.appState.fontFamily,
-    };
+      this.state = {
+        fontSize: this.props.appState.fontSize,
+        fontFamily: this.props.appState.fontFamily,
+      };
 
-    this.handleSetFontFamily = this.handleSetFontFamily.bind(this);
-    this.handleSetFontSize = this.handleSetFontSize.bind(this);
-  }
+      this.handleSetFontFamily = this.handleSetFontFamily.bind(this);
+      this.handleSetFontSize = this.handleSetFontSize.bind(this);
+    }
 
-  /**
-   * Handles a change in the editor font family.
-   */
-  public handleSetFontFamily(event: React.FormEvent<HTMLInputElement>): void {
-    const { value: fontFamily } = event.currentTarget;
-    this.setState({ fontFamily });
-    this.props.appState.fontFamily = fontFamily;
-  }
+    /**
+     * Handles a change in the editor font family.
+     */
+    public handleSetFontFamily(event: React.FormEvent<HTMLInputElement>): void {
+      const { value: fontFamily } = event.currentTarget;
+      this.setState({ fontFamily });
+      this.props.appState.fontFamily = fontFamily;
+    }
 
-  /**
-   * Handles a change in the editor font size.
-   */
-  public handleSetFontSize(event: React.FormEvent<HTMLInputElement>): void {
-    const parsedFontSize = parseInt(event.currentTarget.value, 10);
-    const fontSize = Number.isNaN(parsedFontSize) ? undefined : parsedFontSize;
-    this.setState({ fontSize });
-    this.props.appState.fontSize = fontSize;
-  }
+    /**
+     * Handles a change in the editor font size.
+     */
+    public handleSetFontSize(event: React.FormEvent<HTMLInputElement>): void {
+      const parsedFontSize = parseInt(event.currentTarget.value, 10);
+      const fontSize = Number.isNaN(parsedFontSize)
+        ? undefined
+        : parsedFontSize;
+      this.setState({ fontSize });
+      this.props.appState.fontSize = fontSize;
+    }
 
-  public render() {
-    const { fontFamily, fontSize } = this.state;
-    const fontSettingsInstructions =
-      'Set a font family and size for your editors. Reload or restart for changes to take effect.';
+    public render() {
+      const { fontFamily, fontSize } = this.state;
+      const fontSettingsInstructions =
+        'Set a font family and size for your editors. Reload or restart for changes to take effect.';
 
-    return (
-      <div>
-        <h1>Font Settings</h1>
-        <Callout>
-          <p>{fontSettingsInstructions}</p>
-          <FormGroup label="Font Family" labelFor="font-family">
-            <InputGroup
-              id="font-family"
-              value={fontFamily}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                this.handleSetFontFamily(e)
-              }
-            />
-          </FormGroup>
-          <FormGroup label="Font Size" labelFor="font-size">
-            <InputGroup
-              id="font-size"
-              value={`${fontSize || ''}`}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                this.handleSetFontSize(e)
-              }
-            />
-            <Button
-              onClick={() => window.ElectronFiddle.reloadWindows()}
-              icon="repeat"
-              text="Reload Window"
-            />
-          </FormGroup>
-        </Callout>
-      </div>
-    );
-  }
-}
+      return (
+        <div>
+          <h1>Font Settings</h1>
+          <Callout>
+            <p>{fontSettingsInstructions}</p>
+            <FormGroup label="Font Family" labelFor="font-family">
+              <InputGroup
+                id="font-family"
+                value={fontFamily}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  this.handleSetFontFamily(e)
+                }
+              />
+            </FormGroup>
+            <FormGroup label="Font Size" labelFor="font-size">
+              <InputGroup
+                id="font-size"
+                value={`${fontSize || ''}`}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  this.handleSetFontSize(e)
+                }
+              />
+              <Button
+                onClick={() => window.ElectronFiddle.reloadWindows()}
+                icon="repeat"
+                text="Reload Window"
+              />
+            </FormGroup>
+          </Callout>
+        </div>
+      );
+    }
+  },
+);

--- a/src/renderer/components/sidebar-package-manager.tsx
+++ b/src/renderer/components/sidebar-package-manager.tsx
@@ -19,173 +19,174 @@ interface IProps {
   appState: AppState;
 }
 
-@observer
-export class SidebarPackageManager extends React.Component<IProps, IState> {
-  constructor(props: IProps) {
-    super(props);
-    this.state = {
-      suggestions: [],
-      versionsCache: new Map(),
-    };
-  }
+export const SidebarPackageManager = observer(
+  class SidebarPackageManager extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
+      super(props);
+      this.state = {
+        suggestions: [],
+        versionsCache: new Map(),
+      };
+    }
 
-  public componentDidMount() {
-    autorun(async () => {
-      await this.refreshVersionsCache();
-      this.coerceInvalidVersionNumbers();
-    });
-  }
-
-  public addModuleToFiddle = (item: Hit<NPMSearchResult>) => {
-    const { appState } = this.props;
-    appState.modules.set(item.name, item.version);
-    // copy state so react can re-render
-    this.state.versionsCache.set(item.name, Object.keys(item.versions));
-    const newCache = new Map(this.state.versionsCache);
-    this.setState({ suggestions: [], versionsCache: newCache });
-  };
-
-  public render() {
-    return (
-      <div className="package-tree">
-        <h5>Modules</h5>
-        <Suggest
-          fill={true}
-          inputValueRenderer={() => ''}
-          items={this.state.suggestions}
-          itemRenderer={(item, { modifiers, handleClick }) => (
-            <MenuItem
-              active={modifiers.active}
-              key={item.name}
-              text={
-                <span
-                  className="package-manager-result"
-                  dangerouslySetInnerHTML={{
-                    __html: item._highlightResult?.name?.value ?? '',
-                  }}
-                />
-              }
-              onClick={handleClick}
-            />
-          )}
-          noResults={<em>Search for modules here...</em>}
-          onItemSelect={this.addModuleToFiddle}
-          onQueryChange={pDebounce(async (query) => {
-            if (query !== '') {
-              const { hits } = await npmSearch.search(query);
-              this.setState({
-                suggestions: hits,
-              });
-            } else {
-              this.setState({
-                suggestions: [],
-              });
-            }
-          }, 200)}
-          popoverProps={{ minimal: true, usePortal: false, fill: true }}
-          resetOnClose={false}
-          resetOnSelect={true}
-        />
-        <Tree contents={this.getModuleNodes()} />
-      </div>
-    );
-  }
-
-  /**
-   * Takes the module map and returns an object
-   * conforming to the BlueprintJS tree schema.
-   */
-  private getModuleNodes = (): TreeNodeInfo[] => {
-    const values: TreeNodeInfo[] = [];
-    const { appState } = this.props;
-    for (const [pkg, activeVersion] of appState.modules.entries()) {
-      values.push({
-        id: pkg,
-        label: pkg,
-        secondaryLabel: (
-          <div>
-            <select
-              className="package-tree-version-select"
-              name={pkg}
-              value={activeVersion}
-              onChange={({ target }) =>
-                appState.modules.set(target.name, target.value)
-              }
-            >
-              {this.state.versionsCache.get(pkg)?.map((version) => (
-                <option key={version}>{version}</option>
-              ))}
-            </select>
-
-            <Button
-              minimal
-              icon="remove"
-              onClick={() => appState.modules.delete(pkg)}
-            />
-          </div>
-        ),
+    public componentDidMount() {
+      autorun(async () => {
+        await this.refreshVersionsCache();
+        this.coerceInvalidVersionNumbers();
       });
     }
 
-    return values;
-  };
+    public addModuleToFiddle = (item: Hit<NPMSearchResult>) => {
+      const { appState } = this.props;
+      appState.modules.set(item.name, item.version);
+      // copy state so react can re-render
+      this.state.versionsCache.set(item.name, Object.keys(item.versions));
+      const newCache = new Map(this.state.versionsCache);
+      this.setState({ suggestions: [], versionsCache: newCache });
+    };
 
-  /**
-   * Attempt to fetch the list of all versions for
-   * all installed modules. We need this list of versions
-   * for the version selector.
-   */
-  private refreshVersionsCache = async () => {
-    const { modules } = this.props.appState;
+    public render() {
+      return (
+        <div className="package-tree">
+          <h5>Modules</h5>
+          <Suggest
+            fill={true}
+            inputValueRenderer={() => ''}
+            items={this.state.suggestions}
+            itemRenderer={(item, { modifiers, handleClick }) => (
+              <MenuItem
+                active={modifiers.active}
+                key={item.name}
+                text={
+                  <span
+                    className="package-manager-result"
+                    dangerouslySetInnerHTML={{
+                      __html: item._highlightResult?.name?.value ?? '',
+                    }}
+                  />
+                }
+                onClick={handleClick}
+              />
+            )}
+            noResults={<em>Search for modules here...</em>}
+            onItemSelect={this.addModuleToFiddle}
+            onQueryChange={pDebounce(async (query) => {
+              if (query !== '') {
+                const { hits } = await npmSearch.search(query);
+                this.setState({
+                  suggestions: hits,
+                });
+              } else {
+                this.setState({
+                  suggestions: [],
+                });
+              }
+            }, 200)}
+            popoverProps={{ minimal: true, usePortal: false, fill: true }}
+            resetOnClose={false}
+            resetOnSelect={true}
+          />
+          <Tree contents={this.getModuleNodes()} />
+        </div>
+      );
+    }
 
-    for (const pkg of modules.keys()) {
-      if (!this.state.versionsCache.has(pkg)) {
-        const { hits } = await npmSearch.search(pkg);
-        const firstMatch = hits[0];
-        if (firstMatch === undefined || !firstMatch.versions) {
-          console.warn(
-            `Attempted to fetch version list for ${pkg} from Algolia but failed!`,
-          );
-        } else {
-          this.state.versionsCache.set(
-            firstMatch.name,
-            Object.keys(firstMatch.versions),
-          );
-          // React won't re-render when we're adding
-          // elements to an ES6 Map element. Trigger
-          // the re-render manually.
-          this.forceUpdate();
+    /**
+     * Takes the module map and returns an object
+     * conforming to the BlueprintJS tree schema.
+     */
+    private getModuleNodes = (): TreeNodeInfo[] => {
+      const values: TreeNodeInfo[] = [];
+      const { appState } = this.props;
+      for (const [pkg, activeVersion] of appState.modules.entries()) {
+        values.push({
+          id: pkg,
+          label: pkg,
+          secondaryLabel: (
+            <div>
+              <select
+                className="package-tree-version-select"
+                name={pkg}
+                value={activeVersion}
+                onChange={({ target }) =>
+                  appState.modules.set(target.name, target.value)
+                }
+              >
+                {this.state.versionsCache.get(pkg)?.map((version) => (
+                  <option key={version}>{version}</option>
+                ))}
+              </select>
+
+              <Button
+                minimal
+                icon="remove"
+                onClick={() => appState.modules.delete(pkg)}
+              />
+            </div>
+          ),
+        });
+      }
+
+      return values;
+    };
+
+    /**
+     * Attempt to fetch the list of all versions for
+     * all installed modules. We need this list of versions
+     * for the version selector.
+     */
+    private refreshVersionsCache = async () => {
+      const { modules } = this.props.appState;
+
+      for (const pkg of modules.keys()) {
+        if (!this.state.versionsCache.has(pkg)) {
+          const { hits } = await npmSearch.search(pkg);
+          const firstMatch = hits[0];
+          if (firstMatch === undefined || !firstMatch.versions) {
+            console.warn(
+              `Attempted to fetch version list for ${pkg} from Algolia but failed!`,
+            );
+          } else {
+            this.state.versionsCache.set(
+              firstMatch.name,
+              Object.keys(firstMatch.versions),
+            );
+            // React won't re-render when we're adding
+            // elements to an ES6 Map element. Trigger
+            // the re-render manually.
+            this.forceUpdate();
+          }
         }
       }
-    }
-  };
+    };
 
-  /**
-   * Coerces any invalid semver versions to the latest
-   * version detected in the versionsCache. This is particularly
-   * useful for loading gists created with older versions of
-   * Fiddle that have wildcard (*) versions in their package.json
-   *
-   * This function should only be run after the versions cache
-   * is updated so we have an updated list of all deps and their
-   * versions.
-   */
-  private coerceInvalidVersionNumbers = () => {
-    const { modules } = this.props.appState;
+    /**
+     * Coerces any invalid semver versions to the latest
+     * version detected in the versionsCache. This is particularly
+     * useful for loading gists created with older versions of
+     * Fiddle that have wildcard (*) versions in their package.json
+     *
+     * This function should only be run after the versions cache
+     * is updated so we have an updated list of all deps and their
+     * versions.
+     */
+    private coerceInvalidVersionNumbers = () => {
+      const { modules } = this.props.appState;
 
-    for (const [pkg, version] of modules.entries()) {
-      if (!semver.valid(version)) {
-        const packageVersions = this.state.versionsCache.get(pkg);
+      for (const [pkg, version] of modules.entries()) {
+        if (!semver.valid(version)) {
+          const packageVersions = this.state.versionsCache.get(pkg);
 
-        if (Array.isArray(packageVersions) && packageVersions.length > 0) {
-          const latestVersion = packageVersions[packageVersions.length - 1];
-          modules.set(pkg, latestVersion);
-        } else {
-          console.warn(
-            `Attempted to coerce latest version for package '${pkg}' but failed.`,
-          );
+          if (Array.isArray(packageVersions) && packageVersions.length > 0) {
+            const latestVersion = packageVersions[packageVersions.length - 1];
+            modules.set(pkg, latestVersion);
+          } else {
+            console.warn(
+              `Attempted to coerce latest version for package '${pkg}' but failed.`,
+            );
+          }
         }
       }
-    }
-  };
-}
+    };
+  },
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,6 @@
       "WebWorker"
     ],
     "strict": true,
-    "importHelpers": true,
-    "noEmitHelpers": true,
     "jsx": "react",
     "paths": {
       "src/*": ["./src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,7 +5636,6 @@ __metadata:
     terser-webpack-plugin: "npm:^5.3.3"
     tmp: "npm:0.2.5"
     ts-loader: "npm:^9.4.4"
-    tslib: "npm:^2.6.0"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
     update-electron-app: "npm:^3.0.0"


### PR DESCRIPTION
This looks like more change than it is, but the indentation just changes when dropping `@decorate`. Claude claimed that was the only usage that required `importHelpers: true` (and thus `tslib`). I've validated that things still work as expected after removing `tslib`.