### PR TITLE
test: re-enable test for preventing new windows

### DIFF
--- a/tests/main/windows.spec.ts
+++ b/tests/main/windows.spec.ts
@@ -88,6 +88,11 @@ describe('windows', () => {
   });
 
   describe('getOrCreateMainWindow()', () => {
+    beforeEach(async () => {
+      const window = await getOrCreateMainWindow();
+      window.emit('closed');
+    });
+
     it('creates a window on first call', async () => {
       expect(browserWindows.length).toBe(0);
       await getOrCreateMainWindow();

--- a/tests/main/windows.spec.ts
+++ b/tests/main/windows.spec.ts
@@ -108,16 +108,18 @@ describe('windows', () => {
       expect(createContextMenu).toHaveBeenCalled();
     });
 
-    // FIXME: new test for setWindowOpenHandler
-    it.skip('prevents new-window"', async () => {
-      const e = {
-        preventDefault: vi.fn(),
-      };
-
+    it('sets a window open handler that denies and opens URL externally', async () => {
       await getOrCreateMainWindow();
-      expect(browserWindows[0]).toBeTruthy();
-      (await getOrCreateMainWindow()).webContents.emit('new-window', e);
-      expect(e.preventDefault).toHaveBeenCalled();
+      const win = browserWindows[0]!;
+      const handler = vi.mocked(win.webContents.setWindowOpenHandler).mock
+        .calls[0][0];
+      const result = handler({
+        url: 'https://example.com',
+      } as Electron.HandlerDetails);
+      expect(result).toEqual({ action: 'deny' });
+      expect(electron.shell.openExternal).toHaveBeenCalledWith(
+        'https://example.com',
+      );
     });
 
     it('prevents will-navigate"', async () => {


### PR DESCRIPTION
Clearing this TODO and re-enabling test coverage of this security feature.