### PR TITLE
refactor: remove some unused GitHub account info

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -235,7 +235,6 @@ export enum GlobalSetting {
   executionFlags = 'executionFlags',
   fontFamily = 'fontFamily',
   fontSize = 'fontSize',
-  gitHubAvatarUrl = 'gitHubAvatarUrl',
   gitHubLogin = 'gitHubLogin',
   gitHubName = 'gitHubName',
   gitHubToken = 'gitHubToken',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -236,7 +236,6 @@ export enum GlobalSetting {
   fontFamily = 'fontFamily',
   fontSize = 'fontSize',
   gitHubLogin = 'gitHubLogin',
-  gitHubName = 'gitHubName',
   gitHubToken = 'gitHubToken',
   hasShownTour = 'hasShownTour',
   isClearingConsoleOnRun = 'isClearingConsoleOnRun',

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -120,7 +120,6 @@ export const TokenDialog = observer(
       // Token is valid and has required scopes.
       this.props.appState.gitHubToken = this.state.tokenInput;
       this.props.appState.gitHubLogin = validation.user.login;
-      this.props.appState.gitHubName = validation.user.name;
 
       this.setState({ verifying: false, error: false });
       this.props.appState.isTokenDialogShowing = false;

--- a/src/renderer/components/dialog-token.tsx
+++ b/src/renderer/components/dialog-token.tsx
@@ -119,7 +119,6 @@ export const TokenDialog = observer(
 
       // Token is valid and has required scopes.
       this.props.appState.gitHubToken = this.state.tokenInput;
-      this.props.appState.gitHubAvatarUrl = validation.user.avatar_url;
       this.props.appState.gitHubLogin = validation.user.login;
       this.props.appState.gitHubName = validation.user.name;
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -58,9 +58,6 @@ export class AppState {
 
   // -- Persisted settings ------------------
   public theme: string | null = localStorage.getItem(GlobalSetting.theme);
-  public gitHubName: string | null = localStorage.getItem(
-    GlobalSetting.gitHubName,
-  );
   public gitHubLogin: string | null = localStorage.getItem(
     GlobalSetting.gitHubLogin,
   );
@@ -225,7 +222,6 @@ export class AppState {
       gistId: observable,
       activeGistRevision: observable,
       gitHubLogin: observable,
-      gitHubName: observable,
       gitHubPublishAsPublic: observable,
       gitHubToken: observable,
       hideChannels: action,
@@ -416,7 +412,6 @@ export class AppState {
           case GlobalSetting.fontFamily:
           case GlobalSetting.fontSize:
           case GlobalSetting.gitHubLogin:
-          case GlobalSetting.gitHubName:
           case GlobalSetting.gitHubToken:
           case GlobalSetting.isClearingConsoleOnRun:
           case GlobalSetting.isEnablingElectronLogging:
@@ -506,7 +501,6 @@ export class AppState {
       ),
     );
     autorun(() => this.save(GlobalSetting.gitHubLogin, this.gitHubLogin));
-    autorun(() => this.save(GlobalSetting.gitHubName, this.gitHubName));
     autorun(() => this.save(GlobalSetting.gitHubToken, this.gitHubToken));
     autorun(() =>
       this.save(
@@ -995,7 +989,6 @@ export class AppState {
   public signOutGitHub(): void {
     this.gitHubLogin = null;
     this.gitHubToken = null;
-    this.gitHubName = null;
   }
 
   public async showGenericDialog(

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -58,9 +58,6 @@ export class AppState {
 
   // -- Persisted settings ------------------
   public theme: string | null = localStorage.getItem(GlobalSetting.theme);
-  public gitHubAvatarUrl: string | null = localStorage.getItem(
-    GlobalSetting.gitHubAvatarUrl,
-  );
   public gitHubName: string | null = localStorage.getItem(
     GlobalSetting.gitHubName,
   );
@@ -227,7 +224,6 @@ export class AppState {
       genericDialogOptions: observable,
       gistId: observable,
       activeGistRevision: observable,
-      gitHubAvatarUrl: observable,
       gitHubLogin: observable,
       gitHubName: observable,
       gitHubPublishAsPublic: observable,
@@ -419,7 +415,6 @@ export class AppState {
           case GlobalSetting.executionFlags:
           case GlobalSetting.fontFamily:
           case GlobalSetting.fontSize:
-          case GlobalSetting.gitHubAvatarUrl:
           case GlobalSetting.gitHubLogin:
           case GlobalSetting.gitHubName:
           case GlobalSetting.gitHubToken:
@@ -509,9 +504,6 @@ export class AppState {
         GlobalSetting.isUsingSocketFirewall,
         this.isUsingSocketFirewall,
       ),
-    );
-    autorun(() =>
-      this.save(GlobalSetting.gitHubAvatarUrl, this.gitHubAvatarUrl),
     );
     autorun(() => this.save(GlobalSetting.gitHubLogin, this.gitHubLogin));
     autorun(() => this.save(GlobalSetting.gitHubName, this.gitHubName));
@@ -1001,7 +993,6 @@ export class AppState {
    * The equivalent of signing out.
    */
   public signOutGitHub(): void {
-    this.gitHubAvatarUrl = null;
     this.gitHubLogin = null;
     this.gitHubToken = null;
     this.gitHubName = null;

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -26,7 +26,6 @@ export class StateMock {
   public genericDialogOptions = {} as GenericDialogOptions;
   public gistId = '';
   public activeGistRevision: string | undefined = undefined;
-  public gitHubAvatarUrl: string | null = null;
   public gitHubLogin: string | null = null;
   public gitHubName: string | null = null;
   public gitHubPublishAsPublic = true;
@@ -127,7 +126,6 @@ export class StateMock {
       genericDialogLastResult: observable,
       genericDialogOptions: observable,
       gistId: observable,
-      gitHubAvatarUrl: observable,
       gitHubLogin: observable,
       gitHubName: observable,
       gitHubPublishAsPublic: observable,

--- a/tests/mocks/state.ts
+++ b/tests/mocks/state.ts
@@ -27,7 +27,6 @@ export class StateMock {
   public gistId = '';
   public activeGistRevision: string | undefined = undefined;
   public gitHubLogin: string | null = null;
-  public gitHubName: string | null = null;
   public gitHubPublishAsPublic = true;
   public gitHubToken: string | null = null;
   public isAddVersionDialogShowing = false;
@@ -127,7 +126,6 @@ export class StateMock {
       genericDialogOptions: observable,
       gistId: observable,
       gitHubLogin: observable,
-      gitHubName: observable,
       gitHubPublishAsPublic: observable,
       gitHubToken: observable,
       isAddVersionDialogShowing: observable,

--- a/tests/renderer/components/dialog-token.spec.tsx
+++ b/tests/renderer/components/dialog-token.spec.tsx
@@ -205,7 +205,6 @@ describe('TokenDialog component', () => {
       expect(store.gitHubToken).toBe(mockValidToken);
       expect(store.gitHubLogin).toBe(mockUser.login);
       expect(store.gitHubName).toBe(mockUser.name);
-      expect(store.gitHubAvatarUrl).toBe(mockUser.avatar_url);
       expect(instance.state.error).toBe(false);
       expect(store.isTokenDialogShowing).toBe(false);
     });

--- a/tests/renderer/components/dialog-token.spec.tsx
+++ b/tests/renderer/components/dialog-token.spec.tsx
@@ -204,7 +204,6 @@ describe('TokenDialog component', () => {
 
       expect(store.gitHubToken).toBe(mockValidToken);
       expect(store.gitHubLogin).toBe(mockUser.login);
-      expect(store.gitHubName).toBe(mockUser.name);
       expect(instance.state.error).toBe(false);
       expect(store.isTokenDialogShowing).toBe(false);
     });

--- a/tests/renderer/state.spec.ts
+++ b/tests/renderer/state.spec.ts
@@ -737,13 +737,11 @@ describe('AppState', () => {
 
   describe('signOutGitHub()', () => {
     it('resets all GitHub information', () => {
-      appState.gitHubAvatarUrl = 'test';
       appState.gitHubLogin = 'test';
       appState.gitHubToken = 'test';
       appState.gitHubName = 'test';
 
       appState.signOutGitHub();
-      expect(appState.gitHubAvatarUrl).toBe(null);
       expect(appState.gitHubLogin).toBe(null);
       expect(appState.gitHubToken).toBe(null);
       expect(appState.gitHubName).toBe(null);

--- a/tests/renderer/state.spec.ts
+++ b/tests/renderer/state.spec.ts
@@ -739,12 +739,10 @@ describe('AppState', () => {
     it('resets all GitHub information', () => {
       appState.gitHubLogin = 'test';
       appState.gitHubToken = 'test';
-      appState.gitHubName = 'test';
 
       appState.signOutGitHub();
       expect(appState.gitHubLogin).toBe(null);
       expect(appState.gitHubToken).toBe(null);
-      expect(appState.gitHubName).toBe(null);
     });
   });
 


### PR DESCRIPTION
Some preliminary cleanup I found while looking at the GitHub token code.

I noticed that the GitHub user's name and avatar were being stored, but not used anywhere. Since we're not using them, this PR removes them.