### PR TITLE
feat: only accept IPC messages from BrowserWindows created by us

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -103,14 +103,28 @@ class IpcMainManager extends EventEmitter {
   ) {
     // there can be only one, so remove previous one first
     ipcMain.removeHandler(channel);
-    ipcMain.handle(channel, listener);
+    ipcMain.handle(
+      channel,
+      (event: Electron.IpcMainInvokeEvent, ...args: any[]) => {
+        // Only accept messages from BrowserWindows created by the app.
+        // This rejects IPC from WebViews, sub-frames, or detached windows.
+        if (!BrowserWindow.fromWebContents(event.sender)) return;
+        return listener(event, ...args);
+      },
+    );
   }
 
   public handleOnce(
     channel: IpcEvents,
     listener: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any,
   ) {
-    ipcMain.handleOnce(channel, listener);
+    ipcMain.handleOnce(
+      channel,
+      (event: Electron.IpcMainInvokeEvent, ...args: any[]) => {
+        if (!BrowserWindow.fromWebContents(event.sender)) return;
+        return listener(event, ...args);
+      },
+    );
   }
 
   public postMessage(

--- a/tests/main/ipc.spec.ts
+++ b/tests/main/ipc.spec.ts
@@ -90,24 +90,72 @@ describe('IpcMainManager', () => {
   });
 
   describe('handle()', () => {
-    it('calls ipcMain.handle', () => {
+    it('registers a handler via ipcMain.handle', () => {
       const noop = () => ({});
       ipcMainManager.handle(IpcEvents.FIDDLE_RUN, noop);
       expect(electron.ipcMain.handle).toHaveBeenCalledWith(
         IpcEvents.FIDDLE_RUN,
-        noop,
+        expect.any(Function),
       );
+    });
+
+    it('rejects senders outside a known BrowserWindow', async () => {
+      vi.mocked(electron.BrowserWindow.fromWebContents).mockReturnValue(
+        null as any,
+      );
+      const mockListener = vi.fn().mockReturnValue('result');
+      ipcMainManager.handle(IpcEvents.FIDDLE_RUN, mockListener);
+
+      // Extract the wrapper that was passed to ipcMain.handle
+      const wrapper = vi.mocked(electron.ipcMain.handle).mock.calls.at(-1)![1];
+      const mockEvent = { sender: {} } as Electron.IpcMainInvokeEvent;
+      const result = await wrapper(mockEvent, 'arg1');
+
+      expect(result).toBeUndefined();
+      expect(mockListener).not.toHaveBeenCalled();
+    });
+
+    it('calls the listener for senders from a known BrowserWindow', async () => {
+      vi.mocked(electron.BrowserWindow.fromWebContents).mockReturnValue(
+        {} as electron.BrowserWindow,
+      );
+      const mockListener = vi.fn().mockReturnValue('result');
+      ipcMainManager.handle(IpcEvents.FIDDLE_RUN, mockListener);
+
+      const wrapper = vi.mocked(electron.ipcMain.handle).mock.calls.at(-1)![1];
+      const mockEvent = { sender: {} } as Electron.IpcMainInvokeEvent;
+      const result = await wrapper(mockEvent, 'arg1');
+
+      expect(result).toBe('result');
+      expect(mockListener).toHaveBeenCalledWith(mockEvent, 'arg1');
     });
   });
 
   describe('handleOnce()', () => {
-    it('calls ipcMain.handleOnce', () => {
+    it('registers a handler via ipcMain.handleOnce', () => {
       const noop = () => ({});
       ipcMainManager.handleOnce(IpcEvents.FIDDLE_RUN, noop);
       expect(electron.ipcMain.handleOnce).toHaveBeenCalledWith(
         IpcEvents.FIDDLE_RUN,
-        noop,
+        expect.any(Function),
       );
+    });
+
+    it('rejects senders outside a known BrowserWindow', async () => {
+      vi.mocked(electron.BrowserWindow.fromWebContents).mockReturnValue(
+        null as any,
+      );
+      const mockListener = vi.fn().mockReturnValue('result');
+      ipcMainManager.handleOnce(IpcEvents.FIDDLE_RUN, mockListener);
+
+      const wrapper = vi
+        .mocked(electron.ipcMain.handleOnce)
+        .mock.calls.at(-1)![1];
+      const mockEvent = { sender: {} } as Electron.IpcMainInvokeEvent;
+      const result = await wrapper(mockEvent, 'arg1');
+
+      expect(result).toBeUndefined();
+      expect(mockListener).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Add a security feature to only accept IPC messages from our own BrowserWindows.