### PR TITLE
fix: handle tmpdir symlinks on macOS

### DIFF
--- a/src/main/fiddle-core.ts
+++ b/src/main/fiddle-core.ts
@@ -38,8 +38,8 @@ const BLOCKED_ENV_KEYS = new Set([
  */
 function isInsideTempDir(dir: unknown): dir is string {
   if (typeof dir !== 'string') return false;
-  const tmpDir = path.resolve(os.tmpdir());
-  const resolved = path.resolve(dir);
+  const tmpDir = fs.realpathSync(os.tmpdir());
+  const resolved = fs.realpathSync(path.resolve(dir));
   return resolved.startsWith(tmpDir + path.sep) || resolved === tmpDir;
 }
 

--- a/src/main/npm.ts
+++ b/src/main/npm.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -72,7 +73,7 @@ export async function addModules(
   { dir, packageManager, useSocketFirewall }: PMOperationOptions,
   ...names: Array<string>
 ): Promise<string> {
-  const tmpDir = os.tmpdir();
+  const tmpDir = fs.realpathSync(os.tmpdir());
   const resolvedDir = path.resolve(dir);
   if (!resolvedDir.startsWith(tmpDir + path.sep) && resolvedDir !== tmpDir) {
     throw new Error(`addModules: dir must be inside the temp directory`);

--- a/tests/main/fiddle-core.spec.ts
+++ b/tests/main/fiddle-core.spec.ts
@@ -49,6 +49,9 @@ describe('fiddle-core', () => {
     vi.mocked(Runner.create).mockResolvedValue(runner as unknown as Runner);
     setupFiddleCore(new ElectronVersionsMock() as unknown as ElectronVersions);
     vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.realpathSync as (p: fs.PathLike) => string).mockImplementation(
+      (p) => p.toString(),
+    );
   });
 
   afterEach(() => {

--- a/tests/main/npm.spec.ts
+++ b/tests/main/npm.spec.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -13,7 +14,7 @@ import { exec, execFile } from '../../src/main/utils/exec';
 import { overridePlatform, resetPlatform } from '../utils';
 vi.mock('../../src/main/utils/exec');
 
-const tmpModuleDir = path.join(os.tmpdir(), 'my-directory');
+const tmpModuleDir = path.join(fs.realpathSync(os.tmpdir()), 'my-directory');
 
 describe('npm', () => {
   describe('getIsPackageManagerInstalled()', () => {


### PR DESCRIPTION
Follow-up to #1926, detecting tmpdir on macOS wasn't working correctly because of symlinks.