### PR TITLE
fix: correct loadURL usage for createWindow

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -69,11 +69,11 @@ export function createMainWindow(): Electron.BrowserWindow {
   console.log(`Creating main window`);
   let browserWindow: BrowserWindow | null;
   browserWindow = new BrowserWindow(getMainWindowOptions());
-  browserWindow.loadURL(
-    !!process.env.VITEST
-      ? path.join(process.cwd(), './.webpack/renderer/main_window/index.html')
-      : MAIN_WINDOW_WEBPACK_ENTRY,
-  );
+  if (process.env.VITEST) {
+    browserWindow.loadFile('.webpack/renderer/main_window/index.html');
+  } else {
+    browserWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  }
 
   browserWindow.webContents.once('dom-ready', () => {
     if (browserWindow) {


### PR DESCRIPTION
The previous `loadURL` call relied on the fact that `loadURL` does not complain if it gets a raw OS filesystem path as opposed to the options specified [in the documentation](https://www.electronjs.org/docs/latest/api/browser-window#winloadurlurl-options) “The url can be a remote address (e.g. http://) or a path to a local HTML file using the file:// protocol.”