### PR TITLE
build(deps): drop tmp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "semver": "^7.3.4",
     "sfw": "^2.0.4",
     "shell-env": "^4.0.3",
-    "tmp": "0.2.5",
     "update-electron-app": "^3.0.0"
   },
   "devDependencies": {
@@ -99,7 +98,6 @@
     "@types/react-dom": "^16.9.11",
     "@types/react-window": "^1.8.8",
     "@types/semver": "^7.3.4",
-    "@types/tmp": "0.2.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vercel/webpack-asset-relocator-loader": "^1.7.2",

--- a/src/main/content.ts
+++ b/src/main/content.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import { STATIC_DIR } from './constants';
 import { ipcMainManager } from './ipc';
 import { readFiddle } from './utils/read-fiddle';
+import { tmpName } from './utils/tmp';
 import { isReleasedMajor } from './versions';
 import { EditorValues } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
@@ -42,8 +43,9 @@ async function prepareTemplate(branch: string): Promise<string> {
 
       // save it to a tempfile
       const buffer = Buffer.from(await response.arrayBuffer());
-      const { tmpNameSync } = await import('tmp');
-      const tempfile = tmpNameSync({ template: 'electron-fiddle-XXXXXX.zip' });
+      const tempfile = await tmpName({
+        template: 'electron-fiddle-XXXXXX.zip',
+      });
       console.log(`Content: ${branch} saving template to "${tempfile}"`);
       await fs.writeFile(tempfile, buffer, { encoding: 'utf8' });
 

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -3,11 +3,11 @@ import * as path from 'node:path';
 
 import { BrowserWindow, IpcMainInvokeEvent, app, dialog } from 'electron';
 import fs from 'fs-extra';
-import * as tmp from 'tmp';
 
 import { ipcMainManager } from './ipc';
 import { getFiles } from './utils/get-files';
 import { readFiddle } from './utils/read-fiddle';
+import * as tmp from './utils/tmp';
 import { Files } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { isSupportedFile } from '../utils/editor-utils';
@@ -200,13 +200,13 @@ export async function saveFilesToTemp(files: Files): Promise<string> {
       continue;
     }
     try {
-      await fs.outputFile(path.join(dir.name, name), content);
+      await fs.outputFile(path.join(dir, name), content);
     } catch (error) {
       throw error;
     }
   }
 
-  return dir.name;
+  return dir;
 }
 
 /**

--- a/src/main/utils/tmp.ts
+++ b/src/main/utils/tmp.ts
@@ -1,0 +1,38 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const TEMPLATE_PATTERN = /XXXXXX/;
+
+let _gracefulCleanup = false;
+const _pathsToCleanup: string[] = [];
+
+export async function tmpName(options: { template: string }): Promise<string> {
+  if (!TEMPLATE_PATTERN.test(options.template)) {
+    throw new Error('Invalid template provided');
+  }
+
+  const tempPath = path
+    .join(await fs.promises.realpath(os.tmpdir()), options.template)
+    .replace(TEMPLATE_PATTERN, crypto.randomBytes(3).toString('hex'));
+  _pathsToCleanup.push(tempPath);
+
+  return tempPath;
+}
+
+export function dirSync(options: { prefix: string }): string {
+  return fs.mkdtempSync(options.prefix);
+}
+
+export function setGracefulCleanup(): void {
+  _gracefulCleanup = true;
+}
+
+process.addListener('exit', () => {
+  if (_gracefulCleanup) {
+    for (const tempPath of _pathsToCleanup) {
+      fs.rmSync(tempPath, { recursive: true, force: true });
+    }
+  }
+});

--- a/tests/main/content.spec.ts
+++ b/tests/main/content.spec.ts
@@ -1,8 +1,8 @@
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { app } from 'electron';
 import fs from 'fs-extra';
-import * as tmp from 'tmp';
 import {
   afterEach,
   beforeAll,
@@ -13,7 +13,7 @@ import {
   vi,
 } from 'vitest';
 
-let fakeUserData: tmp.DirResult | null;
+let fakeUserData: string | null;
 
 import { EditorValues, MAIN_JS } from '../../src/interfaces';
 import { getTemplate, getTestTemplate } from '../../src/main/content';
@@ -65,11 +65,9 @@ describe('content', () => {
       if (name === 'userData') {
         // set it to be a newly-allocated tmpdir
         if (!fakeUserData) {
-          tmp.setGracefulCleanup();
-          fakeUserData = tmp.dirSync({
-            template: 'electron-fiddle-tests--user-data-XXXXXX',
-            unsafeCleanup: true, // remove everything
-          });
+          fakeUserData = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'electron-fiddle-tests--user-data-'),
+          );
         }
       }
 
@@ -79,7 +77,7 @@ describe('content', () => {
 
   afterEach(() => {
     if (fakeUserData) {
-      fakeUserData.removeCallback();
+      fs.rmSync(fakeUserData, { recursive: true, force: true });
       fakeUserData = null;
     }
   });

--- a/tests/main/electron-types.spec.ts
+++ b/tests/main/electron-types.spec.ts
@@ -1,9 +1,9 @@
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { ElectronVersions, ReleaseInfo } from '@electron/fiddle-core';
 import type { BrowserWindow } from 'electron';
 import fs from 'fs-extra';
-import * as tmp from 'tmp';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -27,21 +27,20 @@ describe('ElectronTypes', () => {
   let localFile: string;
   let localVersion: RunnableVersion;
   let remoteVersion: RunnableVersion;
-  let tmpdir: tmp.DirResult;
+  let tmpdir: string;
   let electronTypes: ElectronTypes;
   let nodeTypesData: NodeTypesMock[];
   let electronVersions: ElectronVersionsMock;
   let browserWindow: BrowserWindow;
 
   beforeEach(async () => {
-    tmpdir = tmp.dirSync({
-      template: 'electron-fiddle-typedefs-XXXXXX',
-      unsafeCleanup: true,
-    });
+    tmpdir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'electron-fiddle-typedefs-'),
+    );
 
-    const electronCacheDir = path.join(tmpdir.name, 'electron-cache');
-    const nodeCacheDir = path.join(tmpdir.name, 'node-cache');
-    const localDir = path.join(tmpdir.name, 'local');
+    const electronCacheDir = path.join(tmpdir, 'electron-cache');
+    const nodeCacheDir = path.join(tmpdir, 'node-cache');
+    const localDir = path.join(tmpdir, 'local');
 
     fs.ensureDirSync(nodeCacheDir);
     fs.ensureDirSync(localDir);
@@ -85,7 +84,7 @@ describe('ElectronTypes', () => {
 
   afterEach(async () => {
     electronTypes.unwatch(browserWindow);
-    tmpdir.removeCallback();
+    fs.rmSync(tmpdir, { recursive: true, force: true });
     vi.mocked(fetch).mockReset();
   });
 

--- a/tests/main/files.spec.ts
+++ b/tests/main/files.spec.ts
@@ -4,7 +4,6 @@
 
 import { BrowserWindow, app, dialog } from 'electron';
 import fs from 'fs-extra';
-import * as tmp from 'tmp';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MAIN_JS } from '../../src/interfaces';
@@ -22,6 +21,7 @@ import {
 } from '../../src/main/files';
 import { ipcMainManager } from '../../src/main/ipc';
 import { getFiles } from '../../src/main/utils/get-files';
+import * as tmp from '../../src/main/utils/tmp';
 import { getOrCreateMainWindow } from '../../src/main/windows';
 import { BrowserWindowMock } from '../mocks/browser-window';
 import { createEditorValues } from '../mocks/editor-values';
@@ -29,7 +29,7 @@ import { createEditorValues } from '../mocks/editor-values';
 vi.mock('../../src/main/windows');
 vi.mock('../../src/main/utils/get-files');
 vi.mock('fs-extra');
-vi.mock('tmp');
+vi.mock('../../src/main/utils/tmp');
 
 const mockWindow = new BrowserWindowMock() as unknown as Electron.BrowserWindow;
 
@@ -334,9 +334,7 @@ describe('files', () => {
 
   it('saveFilesToTemp()', async () => {
     const tmpPath = '/tmp/save-to-temp/';
-    vi.spyOn(tmp, 'dirSync').mockReturnValue({
-      name: tmpPath,
-    } as tmp.DirResult);
+    vi.spyOn(tmp, 'dirSync').mockReturnValue(tmpPath);
 
     await expect(
       saveFilesToTemp(
@@ -353,9 +351,7 @@ describe('files', () => {
 
   it('saveFilesToTemp() skips unsafe filenames', async () => {
     const tmpPath = '/tmp/save-to-temp/';
-    vi.spyOn(tmp, 'dirSync').mockReturnValue({
-      name: tmpPath,
-    } as tmp.DirResult);
+    vi.spyOn(tmp, 'dirSync').mockReturnValue(tmpPath);
 
     await saveFilesToTemp(
       new Map([

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,13 +3161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tmp@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@types/tmp@npm:0.2.0"
-  checksum: 10c0/e639b7ed4a219da18407f5c0ec5297e4759d8d3b5b9d54b8a54a7b948ee1477c63dccf71931b742cf5e1a4377456f44b7e8167e1551aa058dda05bc770e1602c
-  languageName: node
-  linkType: hard
-
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
@@ -5543,7 +5536,6 @@ __metadata:
     "@types/react-dom": "npm:^16.9.11"
     "@types/react-window": "npm:^1.8.8"
     "@types/semver": "npm:^7.3.4"
-    "@types/tmp": "npm:0.2.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.0.0"
     "@typescript-eslint/parser": "npm:^6.0.0"
     "@vercel/webpack-asset-relocator-loader": "npm:^1.7.2"
@@ -5597,7 +5589,6 @@ __metadata:
     stylelint: "npm:^15.10.1"
     stylelint-config-standard: "npm:^34.0.0"
     terser-webpack-plugin: "npm:^5.3.3"
-    tmp: "npm:0.2.5"
     ts-loader: "npm:^9.4.4"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
@@ -13254,7 +13245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.5, tmp@npm:^0.2.0":
+"tmp@npm:^0.2.0":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
   checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e


### PR DESCRIPTION
Drops `tmp` and inlines the small API surface that we do use.