### PR TITLE
fix: fixups to the new main process GitHub token code

### DIFF
--- a/src/main/github.ts
+++ b/src/main/github.ts
@@ -84,7 +84,7 @@ function getCredentialsPath(): string {
 
 function saveToken(token: string): void {
   const encrypted = safeStorage.encryptString(token);
-  fs.writeFileSync(getCredentialsPath(), encrypted);
+  fs.writeFileSync(getCredentialsPath(), encrypted, { mode: 0o600 });
 }
 
 function loadToken(): string | null {

--- a/src/main/github.ts
+++ b/src/main/github.ts
@@ -186,10 +186,13 @@ async function handleTokenCheckAuth(
     octokit_ = new Octokit({ auth: token });
     const response = await octokit_.users.getAuthenticated();
     return { login: response.data.login };
-  } catch {
-    // Token is expired or revoked — clean up
+  } catch (error: any) {
     octokit_ = null;
-    deleteToken();
+
+    if (error?.status === 401 || error?.status === 403) {
+      deleteToken();
+    }
+
     return { login: null };
   }
 }

--- a/tests/main/github.spec.ts
+++ b/tests/main/github.spec.ts
@@ -133,8 +133,10 @@ describe('github', () => {
         const result = await handleTokenSignIn(MOCK_EVENT, token);
         expect(result).toEqual({ success: true, login: MOCK_LOGIN });
 
-        const writePath = vi.mocked(fs.writeFileSync).mock.calls.at(-1)?.[0];
+        const lastWriteCall = vi.mocked(fs.writeFileSync).mock.calls.at(-1);
+        const writePath = lastWriteCall?.[0];
         expect(writePath).toBe(path.join('/Users/fake-user', CREDENTIALS_FILE));
+        expect(lastWriteCall?.[2]).toEqual({ mode: 0o600 });
       }
 
       expect(fs.writeFileSync).toHaveBeenCalled();

--- a/tests/main/github.spec.ts
+++ b/tests/main/github.spec.ts
@@ -260,14 +260,32 @@ describe('github', () => {
         users: {
           getAuthenticated: vi
             .fn()
-            .mockRejectedValue(new Error('Bad credentials')),
+            .mockRejectedValue(
+              Object.assign(new Error('Bad credentials'), { status: 401 }),
+            ),
         },
       });
 
       const result = await handleTokenCheckAuth(MOCK_EVENT);
       expect(result).toEqual({ login: null });
-      // Should have deleted the invalid token
       expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it('preserves the token for transient auth-check failures', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        Buffer.from(`encrypted:${VALID_GHP_TOKEN}`),
+      );
+      mockOctokitInstance({
+        users: {
+          getAuthenticated: vi.fn().mockRejectedValue(new Error('offline')),
+        },
+      });
+
+      const result = await handleTokenCheckAuth(MOCK_EVENT);
+
+      expect(result).toEqual({ login: null });
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Second in a [series](https://github.com/electron/fiddle/pull/1928) to move GitHub token + gist management into the main process.

This PR has two fixups:

- Previously, we deleted the token when Octokit failed. Now, distinguish between permission errors (delete it) vs network errors (don't delete it)

- Use safer file permissions for the safeStorage info when it's saved to disk.