### PR TITLE
feat: use `github.ts` for `fetchGistAndLoad()` and `getGistRevisions()`

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -7,6 +7,8 @@ import {
   FiddleEvent,
   FileTransformOperation,
   Files,
+  GistLoadParams,
+  GistLoadResult,
   IPackageManager,
   InstallState,
   InstallStateEvent,
@@ -104,6 +106,7 @@ declare global {
       ): Promise<void>;
       fetchVersions(): Promise<Version[]>;
       fetchExample(ref: string, path: string): Promise<EditorValues>;
+      gistLoad(params: GistLoadParams): Promise<GistLoadResult>;
       getAvailableThemes(): Promise<Array<LoadedFiddleTheme>>;
       getElectronTypes(ver: RunnableVersion): Promise<string | undefined>;
       getIsPackageManagerInstalled(

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -9,6 +9,7 @@ import {
   Files,
   GistLoadParams,
   GistLoadResult,
+  GistRevision,
   IPackageManager,
   InstallState,
   InstallStateEvent,
@@ -106,6 +107,7 @@ declare global {
       ): Promise<void>;
       fetchVersions(): Promise<Version[]>;
       fetchExample(ref: string, path: string): Promise<EditorValues>;
+      gistListCommits(gistId: string): Promise<GistRevision[]>;
       gistLoad(params: GistLoadParams): Promise<GistLoadResult>;
       getAvailableThemes(): Promise<Array<LoadedFiddleTheme>>;
       getElectronTypes(ver: RunnableVersion): Promise<string | undefined>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -217,6 +217,17 @@ export interface GistRevision {
   };
 }
 
+export interface GistLoadParams {
+  gistId: string;
+  revision?: string;
+}
+
+export interface GistLoadResult {
+  files: Record<string, { filename: string; content: string }>;
+  id: string;
+  revision?: string;
+}
+
 export enum GlobalSetting {
   acceleratorsToBlock = 'acceleratorsToBlock',
   channelsToShow = 'channelsToShow',

--- a/src/main/github.ts
+++ b/src/main/github.ts
@@ -6,7 +6,7 @@ import { IpcMainInvokeEvent, app, safeStorage } from 'electron';
 
 import { getTemplate } from './content';
 import { ipcMainManager } from './ipc';
-import { EditorValues, GistRevision } from '../interfaces';
+import { EditorValues, GistLoadResult, GistRevision } from '../interfaces';
 import { IpcEvents } from '../ipc-events';
 import { isSupportedFile } from '../utils/editor-utils';
 
@@ -284,15 +284,6 @@ async function handleGistDelete(
   return { success: true };
 }
 
-interface GistLoadResult {
-  files: Record<
-    string,
-    { filename: string; content: string; truncated: boolean; rawUrl?: string }
-  >;
-  id: string;
-  revision?: string;
-}
-
 async function handleGistLoad(
   _event: IpcMainInvokeEvent,
   params: unknown,
@@ -328,8 +319,6 @@ async function handleGistLoad(
     files[id] = {
       filename: data.filename ?? id,
       content,
-      truncated: false,
-      rawUrl: data.raw_url ?? undefined,
     };
   }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -110,6 +110,8 @@ export async function setupFiddleGlobal() {
     },
     fetchExample: (ref: string, path: string) =>
       ipcRenderer.invoke(IpcEvents.GITHUB_FETCH_EXAMPLE, { ref, path }),
+    gistListCommits: (gistId: string) =>
+      ipcRenderer.invoke(IpcEvents.GITHUB_GIST_LIST_COMMITS, gistId),
     gistLoad: (params: GistLoadParams) =>
       ipcRenderer.invoke(IpcEvents.GITHUB_GIST_LOAD, params),
     getElectronTypes(ver: RunnableVersion) {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -7,6 +7,7 @@ import {
   FiddleEvent,
   FileTransformOperation,
   Files,
+  GistLoadParams,
   IPackageManager,
   MessageOptions,
   PMOperationOptions,
@@ -109,6 +110,8 @@ export async function setupFiddleGlobal() {
     },
     fetchExample: (ref: string, path: string) =>
       ipcRenderer.invoke(IpcEvents.GITHUB_FETCH_EXAMPLE, { ref, path }),
+    gistLoad: (params: GistLoadParams) =>
+      ipcRenderer.invoke(IpcEvents.GITHUB_GIST_LOAD, params),
     getElectronTypes(ver: RunnableVersion) {
       return ipcRenderer.invoke(IpcEvents.GET_ELECTRON_TYPES, ver);
     },

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -119,18 +119,12 @@ export class RemoteLoader {
     revision?: string,
   ): Promise<boolean> {
     try {
-      const octo = await getOctokit(this.appState);
-      const gist = revision
-        ? await octo.gists.getRevision({ gist_id: gistId, sha: revision })
-        : await octo.gists.get({ gist_id: gistId });
+      const gist = await window.ElectronFiddle.gistLoad({ gistId, revision });
 
       const values: EditorValues = {};
 
-      for (const [id, data] of Object.entries(gist.data.files ?? {})) {
-        if (!data) continue;
-        const content = data.truncated
-          ? await fetch(data.raw_url!).then((r) => r.text())
-          : data.content!;
+      for (const [id, data] of Object.entries(gist.files)) {
+        const { content } = data;
 
         if (id === PACKAGE_NAME) {
           const deps: Record<string, string> = {};
@@ -205,7 +199,7 @@ export class RemoteLoader {
       const result = await this.handleLoadingSuccess(values, gistId);
 
       // Set the active revision - either the specified revision or the latest one
-      const activeRevision = revision || gist.data.history?.[0]?.version;
+      const activeRevision = revision || gist.revision;
       if (activeRevision) {
         this.appState.activeGistRevision = activeRevision;
       }

--- a/src/renderer/remote-loader.ts
+++ b/src/renderer/remote-loader.ts
@@ -3,7 +3,6 @@ import semver from 'semver';
 import { AppState } from './state';
 import { disableDownload } from './utils/disable-download';
 import { isKnownFile, isSupportedFile } from './utils/editor-utils';
-import { getOctokit } from './utils/octokit';
 import { getReleaseChannel } from './versions';
 import {
   EditorValues,
@@ -80,31 +79,7 @@ export class RemoteLoader {
 
   public async getGistRevisions(gistId: string): Promise<GistRevision[]> {
     try {
-      const octo = await getOctokit(this.appState);
-      const { data: revisions } = await octo.gists.listCommits({
-        gist_id: gistId,
-      });
-
-      const oldestRevision = revisions[revisions.length - 1];
-      const nonEmptyRevisions = revisions.filter(
-        (r) =>
-          r === oldestRevision ||
-          (r.change_status.additions ?? 0) > 0 ||
-          (r.change_status.deletions ?? 0) > 0,
-      );
-
-      return nonEmptyRevisions.reverse().map((r, i) => {
-        return {
-          sha: r.version,
-          date: r.committed_at,
-          changes: {
-            total: r.change_status.total ?? 0,
-            additions: r.change_status.additions ?? 0,
-            deletions: r.change_status.deletions ?? 0,
-          },
-          title: i === 0 ? 'Created' : `Revision ${i}`,
-        };
-      });
+      return await window.ElectronFiddle.gistListCommits(gistId);
     } catch (error: any) {
       this.handleLoadingFailed(error);
       return [];

--- a/tests/main/github.spec.ts
+++ b/tests/main/github.spec.ts
@@ -606,7 +606,6 @@ describe('github', () => {
         'https://gist.githubusercontent.com/raw/large.js',
       );
       expect(result.files['large.js'].content).toBe(fullContent);
-      expect(result.files['large.js'].truncated).toBe(false);
 
       fetchSpy.mockRestore();
     });

--- a/tests/main/github.spec.ts
+++ b/tests/main/github.spec.ts
@@ -625,6 +625,71 @@ describe('github', () => {
       expect(result[1].title).toBe('Revision 1');
     });
 
+    it('always keeps the initial revision even with empty change_status', async () => {
+      await handleTokenSignOut(MOCK_EVENT);
+      mockOctokitInstance({
+        gists: {
+          listCommits: vi.fn().mockResolvedValue({
+            data: [
+              {
+                version: 'sha2',
+                committed_at: '2026-02-05T12:00:00Z',
+                change_status: { additions: 5, deletions: 2, total: 7 },
+              },
+              {
+                version: 'sha1',
+                committed_at: '2026-02-01T10:00:00Z',
+                change_status: { additions: 0, deletions: 0, total: 0 },
+              },
+            ],
+          }),
+        },
+      });
+      await handleTokenSignIn(MOCK_EVENT, VALID_GHP_TOKEN);
+
+      const result = await handleGistListCommits(MOCK_EVENT, VALID_GIST_ID);
+
+      // The initial revision should NOT be filtered out.
+      expect(result).toHaveLength(2);
+      expect(result[0].sha).toBe('sha1');
+      expect(result[0].title).toBe('Created');
+    });
+
+    it('filters out empty revisions except the initial one', async () => {
+      await handleTokenSignOut(MOCK_EVENT);
+      mockOctokitInstance({
+        gists: {
+          listCommits: vi.fn().mockResolvedValue({
+            data: [
+              {
+                version: 'sha3',
+                committed_at: '2026-02-10T12:00:00Z',
+                change_status: { additions: 3, deletions: 1, total: 4 },
+              },
+              {
+                version: 'sha2',
+                committed_at: '2026-02-05T12:00:00Z',
+                change_status: { additions: 0, deletions: 0, total: 0 },
+              },
+              {
+                version: 'sha1',
+                committed_at: '2026-02-01T10:00:00Z',
+                change_status: { additions: 0, deletions: 0, total: 0 },
+              },
+            ],
+          }),
+        },
+      });
+      await handleTokenSignIn(MOCK_EVENT, VALID_GHP_TOKEN);
+
+      const result = await handleGistListCommits(MOCK_EVENT, VALID_GIST_ID);
+
+      // sha2 (empty, not initial) is dropped; sha1 (initial) and sha3 are kept.
+      expect(result).toHaveLength(2);
+      expect(result[0].sha).toBe('sha1');
+      expect(result[1].sha).toBe('sha3');
+    });
+
     it('rejects invalid gist IDs', async () => {
       for (const gistId of INVALID_GIST_IDS) {
         await expect(handleGistListCommits(MOCK_EVENT, gistId)).rejects.toThrow(

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -12,6 +12,8 @@ export class ElectronFiddleMock {
   public downloadVersion = vi.fn();
   public fetchExample = vi.fn();
   public fetchVersions = vi.fn();
+  public gistListCommits = vi.fn();
+  public gistLoad = vi.fn();
   public getAvailableThemes = vi.fn();
   public getElectronTypes = vi.fn();
   public getIsPackageManagerInstalled = vi.fn();
@@ -54,5 +56,4 @@ export class ElectronFiddleMock {
   public themePath = '~/.electron-fiddle/themes';
   public uncacheTypes = vi.fn();
   public unwatchElectronTypes = vi.fn();
-  public gistLoad = vi.fn();
 }

--- a/tests/mocks/electron-fiddle.ts
+++ b/tests/mocks/electron-fiddle.ts
@@ -54,4 +54,5 @@ export class ElectronFiddleMock {
   public themePath = '~/.electron-fiddle/themes';
   public uncacheTypes = vi.fn();
   public unwatchElectronTypes = vi.fn();
+  public gistLoad = vi.fn();
 }

--- a/tests/renderer/remote-loader.spec.ts
+++ b/tests/renderer/remote-loader.spec.ts
@@ -1,9 +1,9 @@
-import { Octokit } from '@octokit/rest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   EditorValues,
   ElectronReleaseChannel,
+  GistRevision,
   InstallState,
   MAIN_JS,
   PACKAGE_NAME,
@@ -16,10 +16,7 @@ import {
   isKnownFile,
   isSupportedFile,
 } from '../../src/renderer/utils/editor-utils';
-import { getOctokit } from '../../src/renderer/utils/octokit';
 import { AppMock, StateMock, createEditorValues } from '../mocks/mocks';
-
-vi.mock('../../src/renderer/utils/octokit');
 
 type GistFile = { filename: string; content: string };
 type GistFiles = { [id: string]: GistFile };
@@ -445,100 +442,37 @@ describe('RemoteLoader', () => {
   });
 
   describe('getGistRevisions()', () => {
-    it('returns revisions from the API', async () => {
-      const mockListCommits = vi.fn().mockResolvedValue({
-        data: [
-          {
-            version: 'sha2',
-            committed_at: '2026-02-05T12:00:00Z',
-            change_status: { additions: 5, deletions: 2, total: 7 },
-          },
-          {
-            version: 'sha1',
-            committed_at: '2026-02-01T10:00:00Z',
-            change_status: { additions: 10, deletions: 0, total: 10 },
-          },
-        ],
-      });
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: { listCommits: mockListCommits },
-      } as unknown as Octokit);
+    it('returns revisions from the IPC', async () => {
+      const revisions: GistRevision[] = [
+        {
+          sha: 'sha1',
+          date: '2026-02-01T10:00:00Z',
+          title: 'Created',
+          changes: { additions: 10, deletions: 0, total: 10 },
+        },
+        {
+          sha: 'sha2',
+          date: '2026-02-05T12:00:00Z',
+          title: 'Revision 1',
+          changes: { additions: 5, deletions: 2, total: 7 },
+        },
+      ];
+      vi.mocked(window.ElectronFiddle.gistListCommits).mockResolvedValueOnce(
+        revisions,
+      );
 
-      const revisions = await instance.getGistRevisions('test-gist-id');
+      const result = await instance.getGistRevisions('test-gist-id');
 
-      expect(mockListCommits).toHaveBeenCalledWith({ gist_id: 'test-gist-id' });
-      expect(revisions).toHaveLength(2);
-      expect(revisions[0].sha).toBe('sha1');
-      expect(revisions[0].title).toBe('Created');
-      expect(revisions[1].sha).toBe('sha2');
-      expect(revisions[1].title).toBe('Revision 1');
-    });
-
-    it('always keeps the initial revision even with empty change_status', async () => {
-      const mockListCommits = vi.fn().mockResolvedValue({
-        data: [
-          {
-            version: 'sha2',
-            committed_at: '2026-02-05T12:00:00Z',
-            change_status: { additions: 5, deletions: 2, total: 7 },
-          },
-          {
-            version: 'sha1',
-            committed_at: '2026-02-01T10:00:00Z',
-            change_status: { additions: 0, deletions: 0, total: 0 },
-          },
-        ],
-      });
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: { listCommits: mockListCommits },
-      } as unknown as Octokit);
-
-      const revisions = await instance.getGistRevisions('test-gist-id');
-
-      // Should include both revisions - the initial one should NOT be filtered out
-      expect(revisions).toHaveLength(2);
-      expect(revisions[0].sha).toBe('sha1');
-      expect(revisions[0].title).toBe('Created');
-    });
-
-    it('filters out empty revisions except the initial one', async () => {
-      const mockListCommits = vi.fn().mockResolvedValue({
-        data: [
-          {
-            version: 'sha3',
-            committed_at: '2026-02-10T12:00:00Z',
-            change_status: { additions: 3, deletions: 1, total: 4 },
-          },
-          {
-            version: 'sha2',
-            committed_at: '2026-02-05T12:00:00Z',
-            change_status: { additions: 0, deletions: 0, total: 0 },
-          },
-          {
-            version: 'sha1',
-            committed_at: '2026-02-01T10:00:00Z',
-            change_status: { additions: 0, deletions: 0, total: 0 },
-          },
-        ],
-      });
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: { listCommits: mockListCommits },
-      } as unknown as Octokit);
-
-      const revisions = await instance.getGistRevisions('test-gist-id');
-
-      // Should filter out sha2 (empty, not initial) but keep sha1 (initial) and sha3 (has changes)
-      expect(revisions).toHaveLength(2);
-      expect(revisions[0].sha).toBe('sha1');
-      expect(revisions[1].sha).toBe('sha3');
+      expect(window.ElectronFiddle.gistListCommits).toHaveBeenCalledWith(
+        'test-gist-id',
+      );
+      expect(result).toEqual(revisions);
     });
 
     it('returns empty array on error', async () => {
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: {
-          listCommits: vi.fn().mockRejectedValue(new Error('API error')),
-        },
-      } as unknown as Octokit);
+      vi.mocked(window.ElectronFiddle.gistListCommits).mockRejectedValueOnce(
+        new Error('API error'),
+      );
 
       const revisions = await instance.getGistRevisions('test-gist-id');
 

--- a/tests/renderer/remote-loader.spec.ts
+++ b/tests/renderer/remote-loader.spec.ts
@@ -21,7 +21,7 @@ import { AppMock, StateMock, createEditorValues } from '../mocks/mocks';
 
 vi.mock('../../src/renderer/utils/octokit');
 
-type GistFile = { content: string; truncated?: boolean; raw_url?: string };
+type GistFile = { filename: string; content: string };
 type GistFiles = { [id: string]: GistFile };
 
 describe('RemoteLoader', () => {
@@ -29,7 +29,6 @@ describe('RemoteLoader', () => {
   let app: AppMock;
   let store: StateMock;
   let mockGistFiles: GistFiles;
-  let mockGetGists: { get: () => Promise<{ files: GistFiles }> };
   let editorValues: EditorValues;
 
   beforeEach(() => {
@@ -47,25 +46,31 @@ describe('RemoteLoader', () => {
     mockGistFiles = Object.fromEntries(
       Object.entries(editorValues).map(([id, content]) => [
         id,
-        { content: content as string },
+        { filename: id, content: content as string },
       ]),
     );
-    mockGetGists = {
-      get: vi.fn().mockResolvedValue({ data: { files: mockGistFiles } }),
-    };
+
+    vi.mocked(window.ElectronFiddle.gistLoad).mockImplementation(
+      async ({ gistId }) => ({
+        files: mockGistFiles,
+        id: gistId,
+        revision: 'sha1',
+      }),
+    );
   });
 
   describe('fetchGistAndLoad()', () => {
     it('loads a fiddle', async () => {
       const gistId = 'abcdtestid';
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
       store.gistId = gistId;
 
       const result = await instance.fetchGistAndLoad(gistId);
 
       expect(result).toBe(true);
+      expect(window.ElectronFiddle.gistLoad).toHaveBeenCalledWith({
+        gistId,
+        revision: undefined,
+      });
       expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
     });
 
@@ -75,11 +80,7 @@ describe('RemoteLoader', () => {
         '{"main":"main.js","devDependencies":{"electron":"17.0.0",}}';
 
       store.gistId = gistId;
-      mockGistFiles[PACKAGE_NAME] = { content: badPj };
-
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
+      mockGistFiles[PACKAGE_NAME] = { filename: PACKAGE_NAME, content: badPj };
 
       const result = await instance.fetchGistAndLoad(gistId);
       expect(result).toBe(false);
@@ -98,11 +99,10 @@ describe('RemoteLoader', () => {
       };
 
       store.gistId = gistId;
-      mockGistFiles[PACKAGE_NAME] = { content: JSON.stringify(pj, null, 2) };
-
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
+      mockGistFiles[PACKAGE_NAME] = {
+        filename: PACKAGE_NAME,
+        content: JSON.stringify(pj, null, 2),
+      };
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -114,19 +114,14 @@ describe('RemoteLoader', () => {
       const gistId = 'abcdtestid';
 
       store.showErrorDialog = vi.fn().mockResolvedValueOnce(true);
-      const errorGetGists = {
-        get: vi.fn().mockResolvedValue({
-          data: {
-            files: {
-              'blah.blah': { content: '' },
-              'yes.no': { content: '' },
-            },
-          },
-        }),
-      };
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: errorGetGists,
-      } as unknown as Octokit);
+      vi.mocked(window.ElectronFiddle.gistLoad).mockResolvedValueOnce({
+        files: {
+          'blah.blah': { filename: 'blah.blah', content: '' },
+          'yes.no': { filename: 'yes.no', content: '' },
+        },
+        id: gistId,
+        revision: 'sha1',
+      });
       store.gistId = gistId;
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -148,11 +143,11 @@ describe('RemoteLoader', () => {
       };
 
       store.gistId = gistId;
-      mockGistFiles[PACKAGE_NAME] = { content: JSON.stringify(pj, null, 2) };
+      mockGistFiles[PACKAGE_NAME] = {
+        filename: PACKAGE_NAME,
+        content: JSON.stringify(pj, null, 2),
+      };
 
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
       vi.mocked(window.ElectronFiddle.isReleasedMajor).mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -160,32 +155,6 @@ describe('RemoteLoader', () => {
       expect(result).toBe(true);
       expect(store.modules.size).toEqual(0);
       expect(store.setVersion).toBeCalledWith('17.0.0');
-    });
-
-    it('handles gists with files over 1mb', async () => {
-      const gistId = 'toobig';
-      const filename = 'index.js';
-      const content = 'hello im huge';
-
-      editorValues[filename] = content;
-      mockGistFiles[filename] = {
-        truncated: true,
-        content: 'truncated',
-        raw_url: 'https://gist.githubusercontent.com/IMTOOBIG',
-      };
-
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-        text: () => Promise.resolve(content),
-      } as Response);
-
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
-      instance.confirmAddFile = vi.fn().mockResolvedValue(true);
-
-      const result = await instance.fetchGistAndLoad(gistId);
-      expect(result).toBe(true);
-      expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
     });
 
     it('does not set an invalid Electron version from package.json', async () => {
@@ -198,11 +167,10 @@ describe('RemoteLoader', () => {
       };
 
       store.gistId = gistId;
-      mockGistFiles[PACKAGE_NAME] = { content: JSON.stringify(pj, null, 2) };
-
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
+      mockGistFiles[PACKAGE_NAME] = {
+        filename: PACKAGE_NAME,
+        content: JSON.stringify(pj, null, 2),
+      };
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -230,11 +198,10 @@ describe('RemoteLoader', () => {
       };
 
       store.gistId = gistId;
-      mockGistFiles[PACKAGE_NAME] = { content: JSON.stringify(pj, null, 2) };
-
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
+      mockGistFiles[PACKAGE_NAME] = {
+        filename: PACKAGE_NAME,
+        content: JSON.stringify(pj, null, 2),
+      };
 
       const result = await instance.fetchGistAndLoad(gistId);
 
@@ -256,11 +223,8 @@ describe('RemoteLoader', () => {
       store.gistId = gistId;
 
       editorValues[filename] = content;
-      mockGistFiles[filename] = { content };
+      mockGistFiles[filename] = { filename, content };
 
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
       instance.confirmAddFile = vi.fn().mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -279,11 +243,8 @@ describe('RemoteLoader', () => {
       store.gistId = gistId;
 
       editorValues[filename] = content;
-      mockGistFiles[filename] = { content };
+      mockGistFiles[filename] = { filename, content };
 
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: mockGetGists,
-      } as unknown as Octokit);
       instance.confirmAddFile = vi.fn().mockResolvedValue(true);
 
       const result = await instance.fetchGistAndLoad(gistId);
@@ -292,14 +253,35 @@ describe('RemoteLoader', () => {
       expect(app.replaceFiddle).toBeCalledWith(editorValues, { gistId });
     });
 
+    it('forwards the requested revision to the IPC', async () => {
+      const gistId = 'abcdtestid';
+      const revision = 'sha-revision';
+      store.gistId = gistId;
+
+      const result = await instance.fetchGistAndLoad(gistId, revision);
+
+      expect(result).toBe(true);
+      expect(window.ElectronFiddle.gistLoad).toHaveBeenCalledWith({
+        gistId,
+        revision,
+      });
+      expect(store.activeGistRevision).toBe(revision);
+    });
+
+    it('sets the active revision to the latest version when none is requested', async () => {
+      const gistId = 'abcdtestid';
+      store.gistId = gistId;
+
+      const result = await instance.fetchGistAndLoad(gistId);
+
+      expect(result).toBe(true);
+      expect(store.activeGistRevision).toBe('sha1');
+    });
+
     it('handles an error', async () => {
-      vi.mocked(getOctokit).mockResolvedValue({
-        gists: {
-          get: async () => {
-            throw new Error('Bwap bwap');
-          },
-        },
-      } as unknown as Octokit);
+      vi.mocked(window.ElectronFiddle.gistLoad).mockRejectedValueOnce(
+        new Error('Bwap bwap'),
+      );
 
       const result = await instance.fetchGistAndLoad('abcdtestid');
       expect(result).toBe(false);


### PR DESCRIPTION
Fourth in a [series](https://github.com/electron/fiddle/pull/1928) to move GitHub token + gist management into the main process.

This PR:

- Migrates `fetchGistAndLoad()` in the renderer to use the `GITHUB_GIST_LOAD` IPC
- Migrates `getGistRevisions()` in the renderer to use the `GITHUB_GIST_LIST_COMMITS` IPC
- Update tests accordingly
- Remove some newly-dead code from the old renderer use of octokit. :tada: 