### PR TITLE
chore: bump namor to v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mobx": "^6.5.0",
     "mobx-react": "^7.3.0",
     "monaco-editor": "^0.22.0",
-    "namor": "^2.0.2",
+    "namor": "^3.0.3",
     "node-watch": "^0.7.3",
     "p-debounce": "^2.0.0",
     "parse-env-string": "^1.0.1",

--- a/src/main/themes.ts
+++ b/src/main/themes.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 
 import { IpcMainInvokeEvent, app, shell } from 'electron';
 import fs from 'fs-extra';
-import * as namor from 'namor';
+import namor from 'namor';
 
 import { ipcMainManager } from './ipc';
 import { IpcEvents } from '../ipc-events';
@@ -56,7 +56,7 @@ export async function createThemeFile(
     Object.entries(theme).filter(([key]) => !['file', 'css'].includes(key)),
   ) as FiddleTheme;
 
-  name = name || namor.generate({ words: 2, numbers: 0 });
+  name = name || namor.generate({ words: 2 });
 
   const file = name.endsWith('.json') ? name : `${name}.json`;
   const themePath = path.join(THEMES_PATH, file);

--- a/src/main/utils/get-project-name.ts
+++ b/src/main/utils/get-project-name.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import * as namor from 'namor';
+import namor from 'namor';
 
 /**
  * Returns a name for this project
@@ -10,5 +10,5 @@ export function getProjectName(localPath?: string): string {
     return path.basename(localPath);
   }
 
-  return namor.generate({ words: 3, numbers: 0 });
+  return namor.generate({ words: 3 });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5568,7 +5568,7 @@ __metadata:
     mobx-react: "npm:^7.3.0"
     monaco-editor: "npm:^0.22.0"
     monaco-editor-webpack-plugin: "npm:^3.0.0"
-    namor: "npm:^2.0.2"
+    namor: "npm:^3.0.3"
     node-watch: "npm:^0.7.3"
     npm-run-all2: "npm:^7.0.1"
     p-debounce: "npm:^2.0.0"
@@ -10058,12 +10058,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namor@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "namor@npm:2.0.2"
+"namor@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "namor@npm:3.0.3"
   dependencies:
     crypto-extra: "npm:1.0.1"
-  checksum: 10c0/bc4cc6a7c585adc316297de3a8fd1a47b64108efc2c3fe69c1b0b06c5410f913c46284bca220f45c4d3b7515ec5abf290509cf8a9409f1be17d97a1f6253a075
+  checksum: 10c0/fce90feb0f21422ec7ea4a3c1b888a72cbce9f2fe6660f9d16f7e0cb19ac44c623b5f23a9b5d4aec218c894b9501d5f25bc726ea557e56557584c3a858bf28e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump our [namor](https://www.npmjs.com/package/namor) dependency from `v2.0.2` (Nov 15 2019) to `v3.0.3` (Oct 2, 2025).

This doesn't affect the package dependency count, but it's still a nice cheap win: namor removed a lot of features we didn't use and now has a package size of [6.9 kB](https://bundlephobia.com/package/namor@3.0.3) vs [47.4 kB](https://bundlephobia.com/package/namor@2.0.2).