### PR TITLE
fix: match system theme for run button

### DIFF
--- a/src/isolated-run-button.ts
+++ b/src/isolated-run-button.ts
@@ -348,6 +348,14 @@ window.addEventListener('message', (event: MessageEvent) => {
   }
 });
 
-void applyThemeByName(initialParams.get('initialTheme'));
+if (isUsingSystemTheme) {
+  applyTheme(
+    window.matchMedia(PREFERS_DARK_MEDIA_QUERY).matches
+      ? defaultDark
+      : defaultLight,
+  );
+} else {
+  void applyThemeByName(initialParams.get('initialTheme'));
+}
 
 render();


### PR DESCRIPTION
Run button is not getting the correct theme on startup when the theme is set to sync with the system theme.