### PR TITLE
build: fix MSIX windows-sign options

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -155,7 +155,8 @@ const config: ForgeConfig = {
       },
       windowsSignOptions: process.env.CERT_FINGERPRINT
         ? {
-            signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
+            signWithParams: `/sha1 ${process.env.CERT_FINGERPRINT}`,
+            hashes: ['sha256'] as any,
           }
         : undefined,
     }),


### PR DESCRIPTION
Latest release attempt hit a failure: https://github.com/electron/fiddle/actions/runs/26997356908/job/79669772465

Looks like `@electron/windows-sign` defaults to injecting `http://timestamp.digicert.com` as the `/tr` arg and adding it in `signWithParams` was causing a duplicate `/tr`. Also making use of the `hashes` parameter (although there's a typing issue here where the enum isn't being exported so can't properly type this).