### PR TITLE
ci: use macos-latest-large for x64 macOS release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15-intel
+          - macos-latest-large
           - ubuntu-latest
           - windows-latest
         arch:


### PR DESCRIPTION
Latest release job hung, most likely due to OOM which we've run into in the past. Bump to `macos-latest-large` which has more RAM (30GB vs 14GB) but is still Intel macOS.