### PR TITLE
test: run tests under ELECTRON_AS_NODE

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "package": "electron-forge package",
     "publish": "electron-forge publish",
     "start": "tsx ./tools/clean-webpack.ts && electron-forge start --",
-    "test": "vitest run",
-    "test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=./reports/report.xml",
-    "test:report": "vitest run --reporter=json --outputFile=report.json | true",
+    "test": "tsx ./tools/vitest.ts run",
+    "test:ci": "tsx ./tools/vitest.ts run --coverage --reporter=default --reporter=junit --outputFile=./reports/report.xml",
+    "test:report": "tsx ./tools/vitest.ts run --reporter=json --outputFile=report.json | true",
     "tsc": "tsc --noEmit -p .",
     "electron-releases": "tsx ./tools/fetch-releases.ts",
     "postinstall": "husky && npm run electron-releases"

--- a/tools/vitest.ts
+++ b/tools/vitest.ts
@@ -1,0 +1,22 @@
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+
+// When required from Node.js (rather than Electron's main process), the
+// `electron` module resolves to the path of the Electron executable.
+const electron = require('electron') as unknown as string;
+const vitestPkg = require.resolve('vitest/package.json');
+const vitestCli = path.join(path.dirname(vitestPkg), 'vitest.mjs');
+
+const child = spawn(electron, [vitestCli, ...process.argv.slice(2)], {
+  cwd: path.join(__dirname, '..'),
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});


### PR DESCRIPTION
In the future we should look at moving tests to run inside Electron itself to ensure we catch issues, but for now let's use `ELECTRON_RUN_AS_NODE` so we are at least sure we're using the same Node.js version as our `electron` package.