### PR TITLE
fix: improve filename path sanitization

### DIFF
--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -208,9 +208,14 @@ export async function saveFiles(
   filePath: string,
   files: Files,
 ) {
-  console.log(`saveFiddleWithTransforms: Asked to save to ${filePath}`);
+  console.log(`saveFiles: Asked to save to ${filePath}`);
 
   for (const [fileName, content] of files) {
+    if (!isSafeDataName(fileName)) {
+      console.warn(`saveFiles: rejected unsafe filename: ${fileName}`);
+      continue;
+    }
+
     const savePath = path.join(filePath, fileName);
 
     // If the file has content, save it to disk. If there's no

--- a/src/utils/editor-utils.ts
+++ b/src/utils/editor-utils.ts
@@ -45,5 +45,10 @@ export function getSuffix(filename: string) {
 }
 
 export function isSupportedFile(filename: string): filename is EditorId {
+  // Reject any name containing a path separator
+  if (/[/\\]/.test(filename)) {
+    return false;
+  }
+
   return /\.(css|html|cjs|js|mjs|json)$/i.test(filename);
 }

--- a/tests/utils/editor-utils.spec.ts
+++ b/tests/utils/editor-utils.spec.ts
@@ -30,6 +30,13 @@ describe('editor-utils', () => {
         expect(isSupportedFile(id)).toBe(true);
       }
     });
+
+    it('rejects path traversal and absolute paths', () => {
+      expect(isSupportedFile('../../../../tmp/evil.js')).toBe(false);
+      expect(isSupportedFile('/tmp/evil.js')).toBe(false);
+      expect(isSupportedFile('foo/bar.js')).toBe(false);
+      expect(isSupportedFile('..\\..\\evil.js')).toBe(false);
+    });
   });
 
   describe('getSuffix', () => {


### PR DESCRIPTION
#1926 added `isSafeDataName` but only used it in `saveFilesToTemp`, not `saveFiles`.