### PR TITLE
fix: wait for watcher to be ready in getElectronTypes

### DIFF
--- a/src/main/electron-types.ts
+++ b/src/main/electron-types.ts
@@ -1,5 +1,6 @@
-import { readdir } from 'fs/promises';
+import { readdir } from 'node:fs/promises';
 import * as path from 'node:path';
+import { once } from 'node:stream';
 
 import { ElectronVersions } from '@electron/fiddle-core';
 import { BrowserWindow, IpcMainInvokeEvent, app } from 'electron';
@@ -65,7 +66,6 @@ export class ElectronTypes {
     // If it's a local development version, pull Electron types from out directory.
     if (dir) {
       const file = path.join(dir, 'gen/electron/tsc/typings', ELECTRON_DTS);
-      content = this.getTypesFromFile(file);
       try {
         this.unwatch(window);
         this.localPaths.set(window, dir);
@@ -75,12 +75,14 @@ export class ElectronTypes {
           const watcher = watch(file, () =>
             this.notifyElectronTypesChanged(dir, file, version),
           );
+          await once(watcher, 'ready');
           this.watchers.set(dir, watcher);
         }
         window.once('close', () => this.unwatch(window));
       } catch (err) {
         console.debug(`Unable to watch "${file}" for changes: ${err}`);
       }
+      content = this.getTypesFromFile(file);
     }
 
     // If it's a published version, pull from cached file.


### PR DESCRIPTION
Should fix a CI flake that's been popping up: [example](https://github.com/electron/fiddle/actions/runs/27314618025/attempts/1).

Wait for the watcher to actually be ready (can have a slight delay on macOS) and then read and return the content. That should prevent missing any file events during that period when the watcher is setting up and it's actually catching events (which is where the test flake comes from).