### PR TITLE
fix: prevent endless checking spinner when local version is missing

### DIFF
--- a/src/isolated-run-button.ts
+++ b/src/isolated-run-button.ts
@@ -132,8 +132,6 @@ function computeMode(): ButtonMode {
       return 'downloading';
     case 'installing':
       return 'unzipping';
-    case 'missing':
-      return 'checking';
     case 'downloaded':
     case 'installed':
     default:


### PR DESCRIPTION
Fixes #1267 

What this PR does:
Removed the explicit 'missing' case from the computeMode switch statement in isolated-run-button.ts. This allows missing local versions to correctly fall back to the default run state instead of getting permanently stuck in an endless "Checking status" spinner.