### PR TITLE
build: stop linting external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:js": "eslint \"./**/*.js\"",
     "lint:markdown": "markdownlint-cli2 \"*.md\"",
     "lint:templates": "standard \"static/**/*.js\"",
-    "lint:links": "lint-roller-markdown-links --fetch-external-links \"*.md\"",
+    "lint:links": "lint-roller-markdown-links \"*.md\"",
     "lint:fix": "npm-run-all \"lint:!(fix|links) -- --fix\"",
     "lint": "npm-run-all \"lint:!(fix)\"",
     "make": "electron-forge make",


### PR DESCRIPTION
More sites are adopting anti-bot walls in the current landscape, so this check is no longer serving us well and is actively impeding.